### PR TITLE
feat(record): add DataToMap/MapToData with db>json tag precedence

### DIFF
--- a/record/data_map.go
+++ b/record/data_map.go
@@ -1,0 +1,135 @@
+package record
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"reflect"
+	"strings"
+)
+
+// DataToMap converts record data into a map[string]any keyed by field name.
+//
+// A map[string]any is returned unchanged. Any other value (typically a struct
+// or a pointer to a struct) is converted via encoding/json, after which the
+// top-level keys are remapped so a field's `db` tag takes precedence over its
+// `json` tag. This lets file/document adapters that lack a native serializer
+// (unlike the Firestore SDK or scany for SQL) reuse one consistent mapping.
+//
+// Tag precedence for a field key is: `db` tag, then `json` tag, then field name.
+// `json:"-"` fields are omitted and `,omitempty` is honoured (both via the
+// json round-trip). Nested struct fields are serialized by encoding/json and
+// therefore follow their `json` tags.
+func DataToMap(data any) (map[string]any, error) {
+	if data == nil {
+		return nil, nil
+	}
+	if m, ok := data.(map[string]any); ok {
+		return m, nil
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("record: marshal data of type %T: %w", data, err)
+	}
+	m := map[string]any{}
+	if err = json.Unmarshal(b, &m); err != nil {
+		return nil, fmt.Errorf("record: convert data of type %T to map: %w", data, err)
+	}
+	for _, r := range fieldTagRenames(reflect.TypeOf(data)) {
+		if r.from == r.to {
+			continue
+		}
+		if v, ok := m[r.from]; ok {
+			m[r.to] = v
+			delete(m, r.from)
+		}
+	}
+	return m, nil
+}
+
+// MapToData populates target from src. If target is a map[string]any, src is
+// copied into it. Otherwise target must be a pointer (typically to a struct):
+// the `db`-keyed entries in src are remapped back to `json` keys and applied via
+// encoding/json, so values, nested structs and type coercion are handled by the
+// standard library. Tag precedence matches DataToMap: `db`, then `json`, then
+// field name.
+func MapToData(target any, src map[string]any) error {
+	if m, ok := target.(map[string]any); ok {
+		maps.Copy(m, src)
+		return nil
+	}
+	remapped := maps.Clone(src)
+	if remapped == nil {
+		remapped = map[string]any{}
+	}
+	for _, r := range fieldTagRenames(reflect.TypeOf(target)) {
+		if r.from == r.to {
+			continue
+		}
+		if v, ok := remapped[r.to]; ok {
+			remapped[r.from] = v
+			delete(remapped, r.to)
+		}
+	}
+	b, err := json.Marshal(remapped)
+	if err != nil {
+		return fmt.Errorf("record: marshal data map: %w", err)
+	}
+	if err = json.Unmarshal(b, target); err != nil {
+		return fmt.Errorf("record: unmarshal data into %T: %w", target, err)
+	}
+	return nil
+}
+
+// tagRename records that the json key `from` should be exposed as the db key `to`.
+type tagRename struct{ from, to string }
+
+// fieldTagRenames walks the struct fields of t (dereferencing pointers) and
+// returns the renames needed to make a field's `db` tag take precedence over its
+// `json` tag. Anonymous (embedded) struct fields are recursed into so their
+// fields participate too.
+func fieldTagRenames(t reflect.Type) []tagRename {
+	for t != nil && (t.Kind() == reflect.Pointer || t.Kind() == reflect.Interface) {
+		t = t.Elem()
+	}
+	if t == nil || t.Kind() != reflect.Struct {
+		return nil
+	}
+	var renames []tagRename
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.Anonymous {
+			renames = append(renames, fieldTagRenames(f.Type)...)
+			continue
+		}
+		if f.PkgPath != "" { // unexported
+			continue
+		}
+		jsonKey := tagName(f.Tag.Get("json"), f.Name)
+		if jsonKey == "" { // json:"-"
+			continue
+		}
+		dbKey := tagName(f.Tag.Get("db"), "")
+		if dbKey == "" || dbKey == jsonKey {
+			continue
+		}
+		renames = append(renames, tagRename{from: jsonKey, to: dbKey})
+	}
+	return renames
+}
+
+// tagName extracts the name portion of a struct tag value (the part before the
+// first comma). A tag of "-" yields "" (skip). An empty tag yields fallback.
+func tagName(tag, fallback string) string {
+	if tag == "" {
+		return fallback
+	}
+	name, _, _ := strings.Cut(tag, ",")
+	if name == "-" {
+		return ""
+	}
+	if name == "" {
+		return fallback
+	}
+	return name
+}

--- a/record/data_map.go
+++ b/record/data_map.go
@@ -36,9 +36,6 @@ func DataToMap(data any) (map[string]any, error) {
 		return nil, fmt.Errorf("record: convert data of type %T to map: %w", data, err)
 	}
 	for _, r := range fieldTagRenames(reflect.TypeOf(data)) {
-		if r.from == r.to {
-			continue
-		}
 		if v, ok := m[r.from]; ok {
 			m[r.to] = v
 			delete(m, r.from)
@@ -63,9 +60,6 @@ func MapToData(target any, src map[string]any) error {
 		remapped = map[string]any{}
 	}
 	for _, r := range fieldTagRenames(reflect.TypeOf(target)) {
-		if r.from == r.to {
-			continue
-		}
 		if v, ok := remapped[r.to]; ok {
 			remapped[r.from] = v
 			delete(remapped, r.to)

--- a/record/data_map_test.go
+++ b/record/data_map_test.go
@@ -1,0 +1,87 @@
+package record
+
+import (
+	"reflect"
+	"testing"
+)
+
+type dataMapTestData struct {
+	StringProp  string `json:"StringProp,omitempty" db:"StringProp"`
+	IntegerProp int    `json:"IntegerProp" db:"IntegerProp"`
+}
+
+type dataMapTagged struct {
+	Name    string `json:"name" db:"full_name"`
+	Age     int    `json:"age"`
+	Ignored string `json:"-"`
+	hidden  string //nolint:unused
+}
+
+func TestDataToMap(t *testing.T) {
+	t.Run("map_passthrough", func(t *testing.T) {
+		in := map[string]any{"a": 1}
+		got, err := DataToMap(in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(got, in) {
+			t.Errorf("got %v, want %v", got, in)
+		}
+	})
+
+	t.Run("struct_json_tags", func(t *testing.T) {
+		got, err := DataToMap(&dataMapTestData{StringProp: "str1", IntegerProp: 1})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got["StringProp"] != "str1" {
+			t.Errorf("StringProp: got %v", got["StringProp"])
+		}
+		if got["IntegerProp"].(float64) != 1 {
+			t.Errorf("IntegerProp: got %v", got["IntegerProp"])
+		}
+	})
+
+	t.Run("db_tag_takes_precedence", func(t *testing.T) {
+		got, err := DataToMap(dataMapTagged{Name: "Alice", Age: 30, Ignored: "x"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got["full_name"] != "Alice" {
+			t.Errorf("expected key 'full_name'=Alice, got map %v", got)
+		}
+		if _, ok := got["name"]; ok {
+			t.Errorf("json key 'name' should have been renamed to db key 'full_name': %v", got)
+		}
+		if _, ok := got["Ignored"]; ok {
+			t.Error("json:\"-\" field must be omitted")
+		}
+	})
+}
+
+func TestMapToData_RoundTrip(t *testing.T) {
+	t.Run("struct", func(t *testing.T) {
+		src := dataMapTagged{Name: "Bob", Age: 25}
+		m, err := DataToMap(src)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got dataMapTagged
+		if err := MapToData(&got, m); err != nil {
+			t.Fatal(err)
+		}
+		if got.Name != "Bob" || got.Age != 25 {
+			t.Errorf("round-trip mismatch: got %+v, want %+v", got, src)
+		}
+	})
+
+	t.Run("map_target", func(t *testing.T) {
+		target := map[string]any{}
+		if err := MapToData(target, map[string]any{"k": "v"}); err != nil {
+			t.Fatal(err)
+		}
+		if target["k"] != "v" {
+			t.Errorf("got %v", target)
+		}
+	})
+}

--- a/record/data_map_test.go
+++ b/record/data_map_test.go
@@ -85,3 +85,81 @@ func TestMapToData_RoundTrip(t *testing.T) {
 		}
 	})
 }
+
+type embeddedInnerForMap struct {
+	Inner string `json:"inner" db:"inner_col"`
+}
+
+type embeddedOuterForMap struct {
+	embeddedInnerForMap
+	Outer string `json:"outer"`
+}
+
+type commaJSONTag struct {
+	Name string `json:",omitempty"` // empty name → key falls back to field name
+}
+
+func TestDataToMap_NilMarshalAndShape(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		m, err := DataToMap(nil)
+		if err != nil || m != nil {
+			t.Fatalf("DataToMap(nil) = %v, %v; want nil, nil", m, err)
+		}
+	})
+	t.Run("marshal_error", func(t *testing.T) {
+		if _, err := DataToMap(make(chan int)); err == nil {
+			t.Fatal("want marshal error for a chan value")
+		}
+	})
+	t.Run("not_a_json_object", func(t *testing.T) {
+		if _, err := DataToMap([]int{1, 2}); err == nil {
+			t.Fatal("want error converting a non-object to map[string]any")
+		}
+	})
+}
+
+func TestMapToData_Errors(t *testing.T) {
+	t.Run("nil_src", func(t *testing.T) {
+		var got embeddedOuterForMap
+		if err := MapToData(&got, nil); err != nil {
+			t.Fatalf("MapToData(&struct, nil) = %v; want nil", err)
+		}
+	})
+	t.Run("marshal_error", func(t *testing.T) {
+		err := MapToData(&struct{ X int }{}, map[string]any{"x": make(chan int)})
+		if err == nil {
+			t.Fatal("want marshal error for a chan value in src")
+		}
+	})
+	t.Run("unmarshal_error_non_struct_target", func(t *testing.T) {
+		// *int is not a struct: fieldTagRenames returns nil and unmarshalling a
+		// JSON object into *int fails.
+		if err := MapToData(new(int), map[string]any{"x": 1}); err == nil {
+			t.Fatal("want unmarshal error for object into *int")
+		}
+	})
+}
+
+func TestDataToMap_EmbeddedAndCommaTag(t *testing.T) {
+	t.Run("anonymous_embedded_db_tag", func(t *testing.T) {
+		m, err := DataToMap(embeddedOuterForMap{embeddedInnerForMap{Inner: "i"}, "o"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if m["inner_col"] != "i" {
+			t.Errorf("embedded field db tag not applied: %v", m)
+		}
+		if m["outer"] != "o" {
+			t.Errorf("outer: %v", m)
+		}
+	})
+	t.Run("comma_only_json_tag_falls_back_to_field_name", func(t *testing.T) {
+		m, err := DataToMap(commaJSONTag{Name: "n"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if m["Name"] != "n" {
+			t.Errorf("comma-only json tag should fall back to field name: %v", m)
+		}
+	})
+}


### PR DESCRIPTION
## What

Adds two reusable helpers to the `record` package:

- `DataToMap(data any) (map[string]any, error)`
- `MapToData(target any, src map[string]any) error`

They convert record data between a `map[string]any` and an arbitrary struct (or `*struct`), with key precedence **`db` tag → `json` tag → field name**. Values, nesting, `omitempty` and type coercion are delegated to `encoding/json`; reflection is used only to remap the top-level `db` keys.

## Why

Adapters whose backend has a native struct serializer don't need this — `dalgo2firestore` hands `record.Data()` straight to the Firestore SDK (`firestore:` tags), and `dalgo2sql` uses `scany` (`db:` tags). But **file/document adapters have no native serializer**: e.g. `dalgo2ingitdb` stores records as YAML/JSON files and previously only accepted `map[string]any`, so passing a struct (as `dalgo-end2end-tests` does with `*TestData`) panicked.

This gives those adapters one consistent struct↔map mapping that honours the same `db`-then-`json` convention the rest of the ecosystem already uses, instead of each reinventing it.

## Tests

`record/data_map_test.go` covers map passthrough, json-tag mapping, `db`-tag precedence, `json:"-"` omission, and struct round-trips. `go test ./record/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)