### PR TITLE
chore: add pre-push hook enforcing 100% test coverage

### DIFF
--- a/.git-hooks/pre-push
+++ b/.git-hooks/pre-push
@@ -1,0 +1,20 @@
+#!/bin/sh
+# To setup git hooks run:
+#   > git config core.hooksPath .git-hooks || echo 'Not in a git repo'
+echo "Running .git-hooks/pre-push..."
+
+# Enforce 100% test coverage, matching CI (min_test_coverage_percent: 100).
+cover_file=$(mktemp)
+trap 'rm -f "$cover_file"' EXIT
+
+if ! go test -covermode=atomic -coverprofile="$cover_file" ./...; then
+  echo "pre-push: tests failed"
+  exit 1
+fi
+
+total=$(go tool cover -func="$cover_file" | awk '/^total:/ {print $3}')
+echo "Total coverage: $total"
+if [ "$total" != "100.0%" ]; then
+  echo "Coverage $total is below required 100%"
+  exit 1
+fi


### PR DESCRIPTION
Adds a `.git-hooks/pre-push` script that runs the module test suite with coverage and fails the push if total coverage is below 100% — mirroring the CI gate (`min_test_coverage_percent: 100`) so regressions are caught locally instead of after a failed CI run.

Follows the existing `.git-hooks` convention used across the org's repos. Enable with:

```
git config core.hooksPath .git-hooks
```

Output on success ends with `Total coverage: 100.0%`; on a regression it prints `Coverage <x>% is below required 100%` and exits non-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)