### PR TITLE
feat(dal): transaction message (replaces TxWithName)

### DIFF
--- a/.specscore/reviewers/spec.md
+++ b/.specscore/reviewers/spec.md
@@ -1,0 +1,21 @@
+# Spec Reviewer
+
+You are a rigorous SpecScore Feature reviewer. You are given a Feature `README.md`. Review it and return a verdict. Be a skeptic, not a cheerleader — your job is to catch problems before they reach a plan.
+
+## What to check
+
+1. **Requirement enforceability** — every `#### REQ:` states one enforceable rule (MUST/SHOULD/MAY), not a vague intention.
+2. **AC coverage & form** — every REQ has at least one acceptance criterion, each in strict `Given / When / Then` form with an *observable* `Then`.
+3. **Internal consistency** — Architecture, Behavior, and ACs agree; no requirement contradicts another; Not-Doing items aren't secretly required elsewhere.
+4. **Scope** — the Feature is implementable as a single plan and does not smuggle multiple independent subsystems.
+5. **Ambiguity** — no requirement can be read two ways; terms are precise.
+6. **Traceability** — assumptions carried from the source Idea are addressed, not silently dropped.
+
+## Verdict format
+
+Return exactly one of:
+
+- `Approved` — followed by a one-line rationale. Use only when you found no Blocker.
+- `Issues Found` — followed by a numbered list. Mark each finding `Blocker` (must fix before approval) or `Advisory` (optional). Quote the section/REQ/AC each finding refers to.
+
+Be specific and terse. Do not restate the Feature back. Do not invent problems to seem thorough — if it is sound, approve it.

--- a/dal/transaction.go
+++ b/dal/transaction.go
@@ -78,6 +78,8 @@ type ReadwriteTransactionCoordinator interface {
 // Transaction defines an instance of DALgo transaction
 type Transaction interface {
 	// Options indicates parameters that were requested at time of transaction creation.
+	// The message field is mutable during execution via TransactionOptions.SetMessage();
+	// implementations should return options by shared reference so the update is observed.
 	Options() TransactionOptions
 }
 
@@ -121,9 +123,15 @@ func GetNonTransactionalContext(ctx context.Context) context.Context {
 // TransactionOptions holds transaction settings
 type TransactionOptions interface {
 
-	// Name describes what will be done in transaction.
-	// This is useful for mocking transaction in tests
-	Name() string
+	// Message returns an optional human-readable message describing the transaction.
+	// Backends may surface it (e.g. dalgo2ingitdb uses it as a git commit message)
+	// or include it in logs. It returns an empty string when no message was set.
+	Message() string
+
+	// SetMessage sets (replaces) the transaction message. It can be used at
+	// transaction start via TxWithMessage, or during transaction execution.
+	// It is available on both readonly and read-write transactions.
+	SetMessage(message string)
 
 	// IsolationLevel indicates requested isolation level
 	IsolationLevel() TxIsolationLevel
@@ -144,7 +152,7 @@ type TransactionOptions interface {
 type TransactionOption func(options *txOptions)
 
 type txOptions struct {
-	name           string
+	message        string
 	isolationLevel TxIsolationLevel
 	isReadonly     bool
 	isCrossGroup   bool
@@ -154,8 +162,12 @@ type txOptions struct {
 
 var _ TransactionOptions = (*txOptions)(nil)
 
-func (v txOptions) Name() string {
-	return v.name
+func (v txOptions) Message() string {
+	return v.message
+}
+
+func (v *txOptions) SetMessage(message string) {
+	v.message = message
 }
 
 // IsReadonly indicates a readonly transaction was requested
@@ -188,7 +200,7 @@ func NewTransactionOptions(opts ...TransactionOption) TransactionOptions {
 	for _, opt := range opts {
 		opt(&options)
 	}
-	return options
+	return &options
 }
 
 // TxWithIsolationLevel requests transaction with required isolation level
@@ -207,10 +219,12 @@ func TxWithIsolationLevel(isolationLevel TxIsolationLevel) TransactionOption {
 	}
 }
 
-// TxWithName specifies number of attempts to execute a transaction
-func TxWithName(name string) TransactionOption {
+// TxWithMessage sets a human-readable message on the transaction.
+// The message can be read back via TransactionOptions.Message() and replaced
+// during transaction execution via TransactionOptions.SetMessage().
+func TxWithMessage(message string) TransactionOption {
 	return func(options *txOptions) {
-		options.name = name
+		options.message = message
 	}
 }
 

--- a/dal/transaction_test.go
+++ b/dal/transaction_test.go
@@ -89,12 +89,10 @@ func TestNewTransactionOptions(t *testing.T) {
 }
 
 type mockTx struct {
-	name    string
 	options TransactionOptions
 }
 
 func (t mockTx) Options() TransactionOptions { return t.options }
-func (t mockTx) Name() string                { return t.name }
 
 func TestGetTransaction(t *testing.T) {
 	tx := mockTx{options: NewTransactionOptions()}
@@ -243,28 +241,35 @@ func TestTxOptions(t *testing.T) {
 	}
 }
 
-func TestTxWithName(t *testing.T) {
-	t.Run("empty", func(t *testing.T) {
-		to := new(txOptions)
-		o := TxWithName("")
-		o(to)
-		assert.Equal(t, "", to.Name())
+func TestTxWithMessage(t *testing.T) {
+	t.Run("empty_by_default", func(t *testing.T) {
+		opts := NewTransactionOptions()
+		assert.Equal(t, "", opts.Message())
 	})
-	t.Run("non_empty", func(t *testing.T) {
-		to := new(txOptions)
-		o := TxWithName("my-tx")
-		o(to)
-		assert.Equal(t, "my-tx", to.Name())
+	t.Run("option_sets_message", func(t *testing.T) {
+		opts := NewTransactionOptions(TxWithMessage("commit subject"))
+		assert.Equal(t, "commit subject", opts.Message())
 	})
-	t.Run("twice_overwrite", func(t *testing.T) {
-		to := new(txOptions)
-		TxWithName("first")(to)
-		TxWithName("second")(to)
-		assert.Equal(t, "second", to.Name())
+	t.Run("setmessage_overwrites", func(t *testing.T) {
+		opts := NewTransactionOptions(TxWithMessage("first"))
+		opts.SetMessage("second")
+		assert.Equal(t, "second", opts.Message())
 	})
-	t.Run("with_NewTransactionOptions", func(t *testing.T) {
-		opts := NewTransactionOptions(TxWithName("builder-tx"))
-		name := opts.(txOptions).Name()
-		assert.Equal(t, "builder-tx", name)
+}
+
+// TestTxMessageSharedReferenceRoundTrip verifies that a runtime SetMessage is
+// observable via a separately obtained Options() — i.e. Options() returns the
+// shared reference, not a copy — on both read-write and readonly transactions.
+func TestTxMessageSharedReferenceRoundTrip(t *testing.T) {
+	t.Run("read_write", func(t *testing.T) {
+		tx := mockTx{options: NewTransactionOptions(TxWithMessage("init"))}
+		tx.Options().SetMessage("final")
+		assert.Equal(t, "final", tx.Options().Message())
+	})
+	t.Run("readonly", func(t *testing.T) {
+		tx := mockTx{options: NewTransactionOptions(TxWithReadonly())}
+		assert.True(t, tx.Options().IsReadonly())
+		tx.Options().SetMessage("read by module X")
+		assert.Equal(t, "read by module X", tx.Options().Message())
 	})
 }

--- a/end2end/end2end_test.go
+++ b/end2end/end2end_test.go
@@ -122,7 +122,7 @@ func TestEndToEnd(t *testing.T) {
 		txOptions := dal.NewTransactionOptions(options...)
 		//tx.EXPECT().Options().Return(txOptions)
 
-		txName := txOptions.Name()
+		txName := txOptions.Message()
 		//t.Log("RW tx:", txName)
 		switch txName {
 		case "SELECT * FROM Cities: no_limit":
@@ -179,7 +179,7 @@ func TestEndToEnd(t *testing.T) {
 		txOptions := dal.NewTransactionOptions(options...)
 		//tx.EXPECT().Options().Return(txOptions)
 
-		txName := txOptions.Name()
+		txName := txOptions.Message()
 		//t.Log("RO tx:", txName)
 		switch txName {
 		case "SELECT ID FROM Cities; limit=0":

--- a/end2end/test_multi.go
+++ b/end2end/test_multi.go
@@ -14,7 +14,7 @@ import (
 func deleteAllRecords(ctx context.Context, t *testing.T, db dal.DB, keys []*dal.Key) {
 	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
 		return tx.DeleteMulti(ctx, keys)
-	}, dal.TxWithName("deleteAllRecords"))
+	}, dal.TxWithMessage("deleteAllRecords"))
 	require.NoErrorf(t, err, "DeleteMulti(ctx, keys) for %v records", len(keys))
 }
 
@@ -73,7 +73,7 @@ func getMulti2existing2missingRecords(t *testing.T, db dal.DB, k1r1Key, k1r2Key 
 	ctx := context.Background()
 	require.NoError(t, db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
 		return tx.GetMulti(ctx, records)
-	}, dal.TxWithName("getMulti2existing2missingRecords")))
+	}, dal.TxWithMessage("getMulti2existing2missingRecords")))
 	recordsMustExist(t, records[:2])
 	recordsMustNotExist(t, records[2:])
 	require.Equal(t, "k1r1str", data[0].StringProp)
@@ -95,7 +95,7 @@ func get3NonExistingRecords(t *testing.T, db dal.DB) {
 
 	require.NoError(t, db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
 		return tx.GetMulti(ctx, records)
-	}, dal.TxWithName("get3NonExistingRecords")))
+	}, dal.TxWithMessage("get3NonExistingRecords")))
 	recordsMustNotExist(t, records)
 
 }
@@ -113,7 +113,7 @@ func setMulti(t *testing.T, db dal.DB, k1r1Key, k1r2Key, k2r1Key *dal.Key) {
 	ctx := context.Background()
 	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
 		return tx.SetMulti(ctx, records)
-	}, dal.TxWithName("setMulti"))
+	}, dal.TxWithMessage("setMulti"))
 	require.NoError(t, err)
 }
 
@@ -127,7 +127,7 @@ func cleanupDelete(t *testing.T, db dal.DB, allKeys []*dal.Key) {
 	}
 	require.NoError(t, db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
 		return tx.GetMulti(ctx, records)
-	}, dal.TxWithName("verify_cleanupDelete")))
+	}, dal.TxWithMessage("verify_cleanupDelete")))
 	recordsMustNotExist(t, records)
 }
 
@@ -150,7 +150,7 @@ func update2records(t *testing.T, db dal.DB, k1r1Key, k1r2Key, k2r1Key *dal.Key)
 	ctx := context.Background()
 	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
 		return tx.UpdateMulti(ctx, []*dal.Key{k1r1Key, k1r2Key}, updates)
-	}, dal.TxWithName("update2records"))
+	}, dal.TxWithMessage("update2records"))
 	if errors.Is(err, dal.ErrNotSupported) {
 		t.Log(err)
 		return
@@ -159,7 +159,7 @@ func update2records(t *testing.T, db dal.DB, k1r1Key, k1r2Key, k2r1Key *dal.Key)
 	records := newRecords()
 	require.NoError(t, db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
 		return tx.GetMulti(ctx, records)
-	}, dal.TxWithName("getMultiNewRecords")))
+	}, dal.TxWithMessage("getMultiNewRecords")))
 	recordsMustExist(t, records)
 	asserRecord := func(i int, expected string) {
 		require.Equal(t, expected, records[i].Data().(*TestData).StringProp, "record #%d key: %v", i+1, records[i].Key())
@@ -209,7 +209,7 @@ func getMulti3existingRecords(t *testing.T, allKeys []*dal.Key, db dal.DB) {
 		ctx := context.Background()
 		require.NoError(t, db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
 			return tx.GetMulti(ctx, records)
-		}, dal.TxWithName("using_records_with_data")))
+		}, dal.TxWithMessage("using_records_with_data")))
 		recordsMustExist(t, records)
 		assetProps(t)
 	})

--- a/end2end/test_query.go
+++ b/end2end/test_query.go
@@ -21,7 +21,7 @@ func selectAllCities(ctx context.Context, db dal.DB) (records []dal.Record, err 
 	err = db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
 		records, err = dal.ExecuteQueryAndReadAllToRecords(ctx, q, tx)
 		return err
-	}, dal.TxWithName("selectAllCities"))
+	}, dal.TxWithMessage("selectAllCities"))
 	return
 }
 
@@ -58,7 +58,7 @@ func queryOperationsTest(ctx context.Context, t *testing.T, db dal.DB, eventuall
 				expectedIDs := models.SortedCityIDs
 				assert.Equal(t, expectedIDs, ids)
 				return nil
-			}, dal.TxWithName("SELECT ID FROM Cities; limit=0"))
+			}, dal.TxWithMessage("SELECT ID FROM Cities; limit=0"))
 			assert.Nil(t, err)
 		})
 		t.Run("limit=3", func(t *testing.T) {
@@ -78,7 +78,7 @@ func queryOperationsTest(ctx context.Context, t *testing.T, db dal.DB, eventuall
 				sort.Strings(ids)
 				assert.Equal(t, expectedIDs, ids)
 				return nil
-			}, dal.TxWithName("SELECT ID FROM Cities; limit=3"))
+			}, dal.TxWithMessage("SELECT ID FROM Cities; limit=3"))
 			assert.Nil(t, err)
 		})
 	})
@@ -91,7 +91,7 @@ func queryOperationsTest(ctx context.Context, t *testing.T, db dal.DB, eventuall
 				require.NoError(t, err)
 				assert.Equal(t, len(models.Cities), len(records))
 				return nil
-			}, dal.TxWithName("SELECT * FROM Cities: no_limit"))
+			}, dal.TxWithMessage("SELECT * FROM Cities: no_limit"))
 			assert.Nil(t, err)
 		})
 		t.Run("limit=3", func(t *testing.T) {
@@ -101,7 +101,7 @@ func queryOperationsTest(ctx context.Context, t *testing.T, db dal.DB, eventuall
 				require.NoError(t, err)
 				assert.Equal(t, q.Limit(), len(records))
 				return nil
-			}, dal.TxWithName("SELECT * FROM Cities: limit=3"))
+			}, dal.TxWithMessage("SELECT * FROM Cities: limit=3"))
 			assert.Nil(t, err)
 		})
 	})
@@ -128,7 +128,7 @@ func queryOperationsTest(ctx context.Context, t *testing.T, db dal.DB, eventuall
 				}
 				assert.Equal(t, expectedIDs, ids)
 				return nil
-			}, dal.TxWithName("SELECT ID FROM Cities ORDER BY Population; limit=3"))
+			}, dal.TxWithMessage("SELECT ID FROM Cities ORDER BY Population; limit=3"))
 			assert.Nil(t, err)
 		})
 		t.Run("descending", func(t *testing.T) {
@@ -152,7 +152,7 @@ func queryOperationsTest(ctx context.Context, t *testing.T, db dal.DB, eventuall
 				}
 				assert.Equal(t, expectedIDs, ids)
 				return nil
-			}, dal.TxWithName("SELECT ID FROM Cities ORDER BY Population DESCENDING; limit=3"))
+			}, dal.TxWithMessage("SELECT ID FROM Cities ORDER BY Population DESCENDING; limit=3"))
 			assert.Nil(t, err)
 
 		})
@@ -177,7 +177,7 @@ func queryOperationsTest(ctx context.Context, t *testing.T, db dal.DB, eventuall
 				}
 				assert.Equal(t, expectedIDs, ids)
 				return nil
-			}, dal.TxWithName("SELECT ID FROM Cities WHERE Country = 'IN'"))
+			}, dal.TxWithMessage("SELECT ID FROM Cities WHERE Country = 'IN'"))
 			assert.Nil(t, err)
 
 		})
@@ -206,7 +206,7 @@ func deleteAllCities(ctx context.Context, db dal.DB) (err error) {
 			return nil
 		}
 		return tx.DeleteMulti(ctx, keys)
-	}, dal.TxWithName("deleteAllCities"))
+	}, dal.TxWithMessage("deleteAllCities"))
 	if err != nil {
 		return fmt.Errorf("failed to delete all cities: %w", err)
 	}
@@ -226,5 +226,5 @@ func setupDataForQueryTests(ctx context.Context, db dal.DB) (err error) {
 			)
 		}
 		return tx.SetMulti(ctx, records)
-	}, dal.TxWithName("setupDataForQueryTests"))
+	}, dal.TxWithMessage("setupDataForQueryTests"))
 }

--- a/end2end/test_single.go
+++ b/end2end/test_single.go
@@ -45,7 +45,7 @@ func singleDeleteTest(t *testing.T, db dal.DB, key *dal.Key) {
 	ctx := context.Background()
 	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
 		return tx.Delete(ctx, key)
-	}, dal.TxWithName("singleDeleteTest"))
+	}, dal.TxWithMessage("singleDeleteTest"))
 	require.NoError(t, err)
 }
 
@@ -77,6 +77,6 @@ func singleCreateWithPredefinedIDTest(ctx context.Context, t *testing.T, db dal.
 	record := dal.NewRecordWithData(key, &data)
 	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
 		return tx.Insert(ctx, record)
-	}, dal.TxWithName("singleCreateWithPredefinedIDTest"))
+	}, dal.TxWithMessage("singleCreateWithPredefinedIDTest"))
 	require.NoError(t, err)
 }

--- a/spec/README.md
+++ b/spec/README.md
@@ -4,6 +4,6 @@ This directory contains the specification for [DALgo](https://github.com/dal-go/
 
 The specification format follows [SpecScore](https://specscore.md).
 
-## Outstanding Questions
+## Open Questions
 
 None at this time.

--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -14,8 +14,9 @@ The Feature format follows [SpecScore](https://specscore.md/feature-specificatio
 | [dbschema](dbschema/README.md) | Implemented | Umbrella for the schema-description vocabulary AND the read-side (introspection) capability (new top-level `dbschema` package). Tier-1 types (`FieldDef`, `CollectionDef`, `IndexDef`, `Type`, `Precision`, `DefaultExpr`), `SchemaReader` capability interface + helpers, and the shared `NotSupportedError` typed error. Designed for three-tier composition: Tier-2 engine extensions in driver repos; Tier-3 app wrappers in consumers (datatug-cli, etc.). |
 | [ddl](ddl/README.md) | Implemented | Umbrella for the schema-modification execution surface (new top-level `ddl` package). 3-method `SchemaModifier` capability interface (`CreateCollection`, `DropCollection`, `AlterCollection`); composable `AlterOp` model with six constructors (`AddField`, `DropField`, `ModifyField`, `RenameField`, `AddIndex`, `DropIndex`) — all accept `Option` for opt-in idempotency; `TransactionalDDL` capability for atomicity advertisement; `PartialSuccessError` for non-transactional partial failures. Imports `dbschema` for types AND for the shared `NotSupportedError`. |
 | [recordops](recordops/README.md) | Implemented | Umbrella for the `recordops` package — pure, dependency-free analytical / inspection helpers over dalgo record collections. MVP introduces one child: [diff](recordops/diff/README.md) — one baseline vs. N candidates via K-way merge over ID-sorted `iter.Seq2` streams, with four renderers (git-style YAML, by-ID YAML, plain YAML, JSON) and bridge helpers `SliceToSeq` + `ReaderToSeq`. |
+| [transaction-message](transaction-message/README.md) | Approved | — |
 
-## Outstanding Questions
+## Open Questions
 
 None at this time.
 

--- a/spec/features/concurrency-capability/README.md
+++ b/spec/features/concurrency-capability/README.md
@@ -1,6 +1,6 @@
 # Feature: Concurrency Capability
 
-> [View in SpecStudio](https://specstudio.synchestra.io/project/features?id=dalgo@dal-go@github.com&path=spec%2Ffeatures%2Fconcurrency-capability) — graph, discussions, approvals
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/concurrency-capability?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/concurrency-capability?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/concurrency-capability?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/concurrency-capability?op=request-change) |
 
 **Status:** Implemented
 **Source Idea:** [`concurrency-capability`](../../ideas/concurrency-capability.md)
@@ -220,7 +220,7 @@ From the source Idea:
 | Might-be-true: second capability arrives soon | Deferred; no shared registry built ahead of need. |
 | Might-be-true: read/write asymmetry becomes a real ask | Deferred; documented in godoc per REQ `godoc`. |
 
-## Outstanding Questions
+## Open Questions
 
 None at this time.
 

--- a/spec/features/dbschema/README.md
+++ b/spec/features/dbschema/README.md
@@ -1,6 +1,6 @@
 # Feature: Schema Description Vocabulary & Read Capability (`dbschema`)
 
-> [View in SpecStudio](https://specstudio.synchestra.io/project/features?id=dalgo@dal-go@github.com&path=spec%2Ffeatures%2Fdbschema) — graph, discussions, approvals
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema?op=request-change) |
 
 **Status:** Implemented
 **Source Idea:** [`dalgo-schema-modification`](../../ideas/dalgo-schema-modification.md)
@@ -96,7 +96,7 @@ From the source Idea (now scope-expanded to cover reader + writer + three-tier c
 | Schema-info types have multiple consumers (DDL, browsers, query builders) | Validated; supports the engine-neutral Tier 1 + reader interface design. |
 | Existing datatug schemer is battle-tested and worth upstream-ing | Validated by code review of `pkg/datatug-core/schemer/` and `pkg/schemers/*`. |
 
-## Outstanding Questions
+## Open Questions
 
 - **Whether `ListCollections` should accept a richer scope object** than `parent *dal.Key` (e.g. catalog+schema pair for SQL). Tier-1 keeps it minimal; Tier-2 SQL extensions MAY add richer methods. Plan time decides if the Tier-1 surface needs adjustment.
 - **Whether `Referrer.Fields` is sufficient** or whether reciprocal foreign-key metadata (cascade actions, deferred-vs-immediate) needs Tier-1 representation. Defer to plan time.

--- a/spec/features/dbschema/collection-def/README.md
+++ b/spec/features/dbschema/collection-def/README.md
@@ -1,6 +1,6 @@
 # Feature: dbschema CollectionDef
 
-> [View in SpecStudio](https://specstudio.synchestra.io/project/features?id=dalgo@dal-go@github.com&path=spec%2Ffeatures%2Fdbschema%2Fcollection-def) — graph, discussions, approvals
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/collection-def?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/collection-def?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/collection-def?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/collection-def?op=request-change) |
 
 **Status:** Implemented
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
@@ -62,7 +62,7 @@ The package does NOT validate that `PrimaryKey` or `Indexes` reference fields ac
 | `dbschema/collection_def.go` | `CollectionDef` struct + godoc. |
 | `dbschema/collection_def_test.go` | Tests covering the ACs above. |
 
-## Outstanding Questions
+## Open Questions
 
 None at this time.
 

--- a/spec/features/dbschema/default-expr/README.md
+++ b/spec/features/dbschema/default-expr/README.md
@@ -1,6 +1,6 @@
 # Feature: dbschema DefaultExpr (Sealed Interface)
 
-> [View in SpecStudio](https://specstudio.synchestra.io/project/features?id=dalgo@dal-go@github.com&path=spec%2Ffeatures%2Fdbschema%2Fdefault-expr) — graph, discussions, approvals
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/default-expr?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/default-expr?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/default-expr?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/default-expr?op=request-change) |
 
 **Status:** Implemented
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
@@ -69,7 +69,7 @@ The package MUST export `type DefaultCurrentTimestamp struct{}` that satisfies `
 | `dbschema/default_expr.go` | `DefaultExpr` sealed interface, `DefaultLiteral`, `DefaultCurrentTimestamp`. |
 | `dbschema/default_expr_test.go` | Tests covering the ACs above. |
 
-## Outstanding Questions
+## Open Questions
 
 - **Cross-engine "current timestamp" precision.** SQLite returns timestamps at second resolution by default; PostgreSQL at microsecond; some inGitDB layouts may store ISO-8601 strings. The Feature does not pin precision — drivers translate as their engine allows. Worth a godoc paragraph.
 

--- a/spec/features/dbschema/errors/README.md
+++ b/spec/features/dbschema/errors/README.md
@@ -1,6 +1,6 @@
 # Feature: dbschema NotSupportedError
 
-> [View in SpecStudio](https://specstudio.synchestra.io/project/features?id=dalgo@dal-go@github.com&path=spec%2Ffeatures%2Fdbschema%2Ferrors) — graph, discussions, approvals
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/errors?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/errors?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/errors?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/errors?op=request-change) |
 
 **Status:** Implemented
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
@@ -82,7 +82,7 @@ The `ddl` package MUST import and reuse `dbschema.NotSupportedError` (not define
 | `dbschema/errors.go` | `NotSupportedError` struct + `Error()` + `Unwrap()` + godoc. |
 | `dbschema/errors_test.go` | Tests covering the ACs above. |
 
-## Outstanding Questions
+## Open Questions
 
 None at this time.
 

--- a/spec/features/dbschema/field-def/README.md
+++ b/spec/features/dbschema/field-def/README.md
@@ -1,6 +1,6 @@
 # Feature: dbschema FieldDef
 
-> [View in SpecStudio](https://specstudio.synchestra.io/project/features?id=dalgo@dal-go@github.com&path=spec%2Ffeatures%2Fdbschema%2Ffield-def) — graph, discussions, approvals
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/field-def?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/field-def?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/field-def?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/field-def?op=request-change) |
 
 **Status:** Implemented
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
@@ -73,7 +73,7 @@ The godoc on `FieldDef.AutoIncrement` MUST note that drivers MAY restrict this a
 | `dbschema/field_def.go` | `FieldDef` struct + godoc. |
 | `dbschema/field_def_test.go` | Tests covering the ACs above. |
 
-## Outstanding Questions
+## Open Questions
 
 None at this time.
 

--- a/spec/features/dbschema/index-def/README.md
+++ b/spec/features/dbschema/index-def/README.md
@@ -1,6 +1,6 @@
 # Feature: dbschema IndexDef
 
-> [View in SpecStudio](https://specstudio.synchestra.io/project/features?id=dalgo@dal-go@github.com&path=spec%2Ffeatures%2Fdbschema%2Findex-def) — graph, discussions, approvals
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/index-def?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/index-def?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/index-def?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/index-def?op=request-change) |
 
 **Status:** Implemented
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
@@ -52,7 +52,7 @@ type IndexDef struct {
 | `dbschema/index_def.go` | `IndexDef` struct + godoc. |
 | `dbschema/index_def_test.go` | Tests covering the ACs above. |
 
-## Outstanding Questions
+## Open Questions
 
 None at this time.
 

--- a/spec/features/dbschema/schema-reader/README.md
+++ b/spec/features/dbschema/schema-reader/README.md
@@ -1,6 +1,6 @@
 # Feature: dbschema SchemaReader (Introspection Capability)
 
-> [View in SpecStudio](https://specstudio.synchestra.io/project/features?id=dalgo@dal-go@github.com&path=spec%2Ffeatures%2Fdbschema%2Fschema-reader) — graph, discussions, approvals
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/schema-reader?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/schema-reader?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/schema-reader?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/schema-reader?op=request-change) |
 
 **Status:** Implemented
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
@@ -151,7 +151,7 @@ Per-engine introspection logic that today lives in `datatug-cli/pkg/schemers/sql
 
 Each driver's reader implements `dbschema.SchemaReader` (Tier 1) and MAY return engine-specific extension types via additional reader methods (Tier 2).
 
-## Outstanding Questions
+## Open Questions
 
 - **`ConstraintDef` shape.** The Tier-1 struct is minimal — three fields. At Feature-spec time it's unclear whether all required constraint metadata is captured. Likely needs refinement once the SQL Tier-2 extension is drafted. Defer.
 - **`ListCollections` parent-key semantics.** SQL catalog/schema vs Firestore parent document — both fit the `parent *dal.Key` shape but with different semantics. The interface is generic; godoc must spell out each backend's interpretation.

--- a/spec/features/dbschema/types/README.md
+++ b/spec/features/dbschema/types/README.md
@@ -1,6 +1,6 @@
 # Feature: dbschema Types (`Type`, `Precision`)
 
-> [View in SpecStudio](https://specstudio.synchestra.io/project/features?id=dalgo@dal-go@github.com&path=spec%2Ffeatures%2Fdbschema%2Ftypes) — graph, discussions, approvals
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/types?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/types?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/types?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/types?op=request-change) |
 
 **Status:** Implemented
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
@@ -61,7 +61,7 @@ The package MUST export `type Precision struct { Total, Scale int }`. `Total` is
 | `dbschema/type.go` | `Type` enum constants, `String()` method, `Precision` struct. |
 | `dbschema/type_test.go` | Tests covering the ACs above. |
 
-## Outstanding Questions
+## Open Questions
 
 None at this time.
 

--- a/spec/features/ddl/README.md
+++ b/spec/features/ddl/README.md
@@ -1,6 +1,6 @@
 # Feature: Schema Modification (DDL) Execution Surface (`ddl`)
 
-> [View in SpecStudio](https://specstudio.synchestra.io/project/features?id=dalgo@dal-go@github.com&path=spec%2Ffeatures%2Fddl) — graph, discussions, approvals
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl?op=request-change) |
 
 **Status:** Implemented
 **Source Idea:** [`dalgo-schema-modification`](../../ideas/dalgo-schema-modification.md)
@@ -186,7 +186,7 @@ External `dal.DB` implementations do NOT need to update; DDL support is
 opt-in per driver.
 ```
 
-## Outstanding Questions
+## Open Questions
 
 - **Backend identification source.** Resolved at Feature-spec time: helpers populate `Backend` from `db.Adapter().Name()` if `db.Adapter()` returns a non-nil `dal.Adapter`; otherwise leave `Backend` empty. See [`operations/`](operations/README.md) `REQ:not-supported-on-non-implementer` AC-2 and AC-3 for the contract.
 - **Option misuse handling.** If a caller passes `IfNotExists()` to `DropCollection` (or `IfExists()` to `CreateCollection`), drivers MUST silently ignore the mismatched option per [`options/`](options/README.md) REQ. Plan decides whether to add a test-level lint warning.

--- a/spec/features/ddl/alter-ops/README.md
+++ b/spec/features/ddl/alter-ops/README.md
@@ -1,6 +1,6 @@
 # Feature: ddl AlterOp (Composable Alteration Operations)
 
-> [View in SpecStudio](https://specstudio.synchestra.io/project/features?id=dalgo@dal-go@github.com&path=spec%2Ffeatures%2Fddl%2Falter-ops) — graph, discussions, approvals
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/alter-ops?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/alter-ops?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/alter-ops?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/alter-ops?op=request-change) |
 
 **Status:** Implemented
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
@@ -156,7 +156,7 @@ Drops an existing index by name. Drivers translate to engine-specific `DROP INDE
 | `ddl/alter_op_test.go` | Tests covering the ACs above. |
 | `ddl/testdata/external_sealing/` | A standalone Go package used by AC-3 to verify sealing via subprocess `go build`. |
 
-## Outstanding Questions
+## Open Questions
 
 - **Granular per-attribute ops** (`ChangeFieldType`, `SetFieldDefault`, `DropFieldDefault`) — explicitly deferred per Q20 lock. If real consumers want them, they're additive (new constructor functions; interface unchanged).
 - **Per-`AlterOp` idempotency mismatched options.** `IfNotExists()` on `DropField`/`DropIndex` and `IfExists()` on `AddField`/`AddIndex` are semantically meaningless. Drivers MUST silently ignore them per the REQs above. On `ModifyField`/`RenameField`, BOTH `IfNotExists()` and `IfExists()` are no-ops by the same rule.

--- a/spec/features/ddl/applier/README.md
+++ b/spec/features/ddl/applier/README.md
@@ -1,6 +1,6 @@
 # Feature: ddl Applier (Visitor for AlterOp Dispatch)
 
-> [View in SpecStudio](https://specstudio.synchestra.io/project/features?id=dalgo@dal-go@github.com&path=spec%2Ffeatures%2Fddl%2Fapplier) — graph, discussions, approvals
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/applier?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/applier?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/applier?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/applier?op=request-change) |
 
 **Status:** Implemented
 **Source Idea:** —
@@ -223,7 +223,7 @@ No source Idea exists. The implicit assumptions this Feature commits to:
 | Should-be-true | The visitor pattern is the right shape for this dispatch problem (vs. a generic `Apply(op AlterOp) error` method that type-switches internally) | Carried; the visitor pattern's appeal is that the driver writes one method per op and the compiler checks all six are present. The generic `Apply` alternative pushes type assertion into the driver, which is exactly what we're solving. |
 | Might-be-true | Future AlterOp additions (if any) will continue to follow this pattern | Deferred; if proven wrong, the Applier interface can be replaced (it's not sealed externally — but in practice drivers implement it, which is the surface that matters). |
 
-## Outstanding Questions
+## Open Questions
 
 - **`ctx context.Context` as first parameter vs. struct-stored.** The Feature pins `ctx` as the FIRST parameter of every `Apply*` method (and of `ApplyTo`). Rationale: idiomatic for a published interface other packages will implement; matches stdlib patterns (e.g. `database/sql.DB.QueryContext`); makes test stubs trivial; aligns with Go vet's `contextcheck`. The alternative — storing `ctx` on the driver's adapter struct and having Apply methods take no ctx — is a recognized pattern for short-lived adapters (the `sqliteAlterApplier` sketch in `dalgo2sqlite/spec/plans/2026-05-13-dbschema-ddl-coverage.md` uses it). When the dalgo2sqlite plan executes Tasks 20–21, its `sqliteAlterApplier` struct MUST be updated to match this spec's contract (ctx-in-signature). The plan's pre-flight sketch is illustrative and predates this spec; reconciliation is a plan-time concern.
 - **Variadic `...Option` vs resolved `Options` in `Apply*` method signatures.** The Feature pins the resolved-`Options` form. Rationale: each concrete op already calls `ResolveOptions(opts...)` once at construction and stores the result, so the driver sees the resolved view. Open question: should the dispatch instead pass `[]Option` (raw) so the Applier can re-extract or wrap? Plan-time decision: stick with resolved `Options` value unless a real consumer needs the raw form.

--- a/spec/features/ddl/errors/README.md
+++ b/spec/features/ddl/errors/README.md
@@ -1,6 +1,6 @@
 # Feature: ddl PartialSuccessError
 
-> [View in SpecStudio](https://specstudio.synchestra.io/project/features?id=dalgo@dal-go@github.com&path=spec%2Ffeatures%2Fddl%2Ferrors) — graph, discussions, approvals
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/errors?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/errors?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/errors?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/errors?op=request-change) |
 
 **Status:** Implemented
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
@@ -84,7 +84,7 @@ Drivers that DO guarantee transactional DDL (`SupportsTransactionalDDL` returns 
 | `ddl/errors.go` | `PartialSuccessError` struct + `Error()` + `Unwrap()` + godoc. |
 | `ddl/errors_test.go` | Tests covering the ACs above. |
 
-## Outstanding Questions
+## Open Questions
 
 - **Multiple failures.** If a non-transactional driver attempts every op regardless of earlier failures, multiple ops may fail. The MVP shape only records the FIRST failure (`FirstFailed`) and folds the rest into the driver-specific `Cause`. Refining to a `Failures []FailureRecord` slice is a follow-up if a real driver needs to surface multi-failure detail.
 - **Relationship to `dal.ErrNotSupported`.** If the underlying `Cause` is `dal.ErrNotSupported` (e.g. SQLite can't drop a column), `errors.Is(err, dal.ErrNotSupported)` returns `true` via `Unwrap`. Consumers can therefore use a coarse not-supported check across all DDL paths.

--- a/spec/features/ddl/operations/README.md
+++ b/spec/features/ddl/operations/README.md
@@ -1,6 +1,6 @@
 # Feature: ddl Top-Level Operations
 
-> [View in SpecStudio](https://specstudio.synchestra.io/project/features?id=dalgo@dal-go@github.com&path=spec%2Ffeatures%2Fddl%2Foperations) — graph, discussions, approvals
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/operations?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/operations?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/operations?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/operations?op=request-change) |
 
 **Status:** Implemented
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
@@ -90,7 +90,7 @@ When `db.(ddl.SchemaModifier)` fails (the concrete type does NOT implement `Sche
 | `ddl/operations.go` | The three top-level helper functions + godoc. |
 | `ddl/operations_test.go` | Tests with two stub `dal.DB` types (one satisfies `SchemaModifier`, one does not). |
 
-## Outstanding Questions
+## Open Questions
 
 None at this time.
 

--- a/spec/features/ddl/options/README.md
+++ b/spec/features/ddl/options/README.md
@@ -1,6 +1,6 @@
 # Feature: ddl Options (`IfNotExists`, `IfExists`)
 
-> [View in SpecStudio](https://specstudio.synchestra.io/project/features?id=dalgo@dal-go@github.com&path=spec%2Ffeatures%2Fddl%2Foptions) — graph, discussions, approvals
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/options?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/options?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/options?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/options?op=request-change) |
 
 **Status:** Implemented
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
@@ -87,7 +87,7 @@ Drivers MUST silently ignore the mismatched option rather than error — the mea
 | `ddl/options.go` | `Option`, `Options`, `IfNotExists`, `IfExists` + godoc. |
 | `ddl/options_test.go` | Tests covering the ACs above. |
 
-## Outstanding Questions
+## Open Questions
 
 None at this time.
 

--- a/spec/features/ddl/schema-modifier/README.md
+++ b/spec/features/ddl/schema-modifier/README.md
@@ -1,6 +1,6 @@
 # Feature: ddl SchemaModifier Interface
 
-> [View in SpecStudio](https://specstudio.synchestra.io/project/features?id=dalgo@dal-go@github.com&path=spec%2Ffeatures%2Fddl%2Fschema-modifier) — graph, discussions, approvals
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/schema-modifier?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/schema-modifier?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/schema-modifier?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/schema-modifier?op=request-change) |
 
 **Status:** Implemented
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
@@ -71,7 +71,7 @@ The interface has exactly three methods with the signatures above. Drivers imple
 | `ddl/modifier.go` | `SchemaModifier` interface declaration + godoc. |
 | `ddl/modifier_test.go` | Compile-time-style tests verifying the interface shape. |
 
-## Outstanding Questions
+## Open Questions
 
 None at this time.
 

--- a/spec/features/ddl/transactional-ddl/README.md
+++ b/spec/features/ddl/transactional-ddl/README.md
@@ -1,6 +1,6 @@
 # Feature: ddl TransactionalDDL Capability
 
-> [View in SpecStudio](https://specstudio.synchestra.io/project/features?id=dalgo@dal-go@github.com&path=spec%2Ffeatures%2Fddl%2Ftransactional-ddl) — graph, discussions, approvals
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/transactional-ddl?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/transactional-ddl?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/transactional-ddl?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/transactional-ddl?op=request-change) |
 
 **Status:** Implemented
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
@@ -86,7 +86,7 @@ The helper performs `db.(ddl.TransactionalDDL)`; on success it returns the resul
 | `ddl/transactional.go` | `TransactionalDDL` interface + `SupportsTransactionalDDL(db)` helper + godoc. |
 | `ddl/transactional_test.go` | Tests covering the ACs above. |
 
-## Outstanding Questions
+## Open Questions
 
 - **Granularity.** This capability is binary: a driver either does or doesn't guarantee transactional DDL across batches. Real engines have nuance (PostgreSQL is transactional for most DDL but not all; MySQL is NOT transactional for DDL even though it has transactions). The MVP picks the simpler shape and trusts drivers to return `false` when they cannot uphold the contract for ALL batched ops. Refining to "transactional for SOME ops but not others" is a follow-up if a real driver needs it.
 

--- a/spec/features/recordops/README.md
+++ b/spec/features/recordops/README.md
@@ -1,6 +1,6 @@
 # Feature: `recordops` package
 
-> [View in SpecStudio](https://specstudio.synchestra.io/project/features?id=dalgo@dal-go@github.com&path=spec%2Ffeatures%2Frecordops) — graph, discussions, approvals
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops?op=request-change) |
 
 **Status:** Implemented
 **Source Idea:** [`recordops`](../../ideas/recordops.md)
@@ -47,7 +47,7 @@ These tenets bind every child Feature added under `recordops/`:
 - **Re-exporting helpers at the dalgo root.** Consumers import `github.com/dal-go/dalgo/recordops` explicitly.
 - **Columnar `recordset.Recordset` support.** Distinct shape; if/when a consumer needs it, a sibling package (e.g., `recordsetops`) is the right answer — not retrofitting `recordops`.
 
-## Outstanding Questions
+## Open Questions
 
 None at this time.
 

--- a/spec/features/recordops/diff/README.md
+++ b/spec/features/recordops/diff/README.md
@@ -1,6 +1,6 @@
 # Feature: `recordops` — Diff
 
-> [View in SpecStudio](https://specstudio.synchestra.io/project/features?id=dalgo@dal-go@github.com&path=spec%2Ffeatures%2Frecordops%2Fdiff) — graph, discussions, approvals
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops/diff?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops/diff?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops/diff?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops/diff?op=request-change) |
 
 **Status:** Implemented
 **Source Idea:** [`recordops`](../../../ideas/recordops.md)
@@ -724,7 +724,7 @@ From the source Idea:
 | Might-be-true: `WithOnlyChangedFields()` will become the more common consumer choice. | Carried as the default-include design tenet; the option is in scope (REQ `options`). |
 | Might-be-true: `iter.Seq2`-based error propagation is ergonomic. | Carried via REQ `input-streams` AC-4 + the renderers' stream-error tests. |
 
-## Outstanding Questions
+## Open Questions
 
 None at this time.
 

--- a/spec/features/transaction-message/README.md
+++ b/spec/features/transaction-message/README.md
@@ -1,0 +1,141 @@
+# Feature: Transaction Message
+
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/transaction-message?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/transaction-message?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/transaction-message?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/transaction-message?op=request-change) |
+
+**Status:** Approved
+**Date:** 2026-06-02
+**Owner:** alex
+**Source Idea:** [`transaction-message`](../../ideas/transaction-message.md)
+**Supersedes:** —
+
+## Summary
+
+Carry a single human-readable message on a DALgo transaction. It can be seeded when the transaction starts (via a functional option) and/or set while the transaction runs (via the transaction's options), and is read back through the existing `Options()` surface. Backends consume it for their own purposes — `dalgo2ingitdb` as a git commit message, any backend as a log/observability annotation — on both readonly and read-write transactions.
+
+## Problem
+
+`dalgo2ingitdb` maps a read-write transaction onto a git commit but has no portable way to obtain a human-authored message for that commit. More broadly, any backend benefits from a human-readable annotation on a transaction for logs (e.g. which module is reading or updating a table), so the need is not write-only. DALgo today offers only `TxWithName` / `Options().Name()`, documented as a short identifier "useful for mocking transaction in tests": it conflates a test/debug label with a user-facing message, and "name" implies brevity. This Feature replaces `name` with a `message` surface that reads naturally for both commit messages and log annotations.
+
+## Behavior
+
+### Seeding the message at start
+
+#### REQ: tx-with-message-option
+
+The `dal` package MUST provide a functional option `TxWithMessage(message string) TransactionOption` that sets the transaction message on the options used to start a transaction. Passing it to `RunReadonlyTransaction`, `RunReadwriteTransaction`, or `NewTransactionOptions` MUST make that message readable via `Message()`.
+
+### Reading and writing the message
+
+#### REQ: options-message-reader
+
+`TransactionOptions` MUST expose `Message() string`, returning the current message, or the empty string when no message has been set.
+
+#### REQ: options-message-setter
+
+`TransactionOptions` MUST expose `SetMessage(message string)`, which replaces the current message. After it is called, `Message()` MUST return the value last written, regardless of whether the prior value came from `TxWithMessage` at start or an earlier `SetMessage`. Semantics are set/replace — the caller composes the full string itself; there is no append.
+
+#### REQ: message-survives-options-roundtrip
+
+The `TransactionOptions` value produced by `NewTransactionOptions` MUST be backed by shared (reference) state: after `SetMessage(x)` on it, `Message()` MUST return `x`, and any holder of that same value — e.g. a transaction whose `Options()` returns it by reference rather than copying — MUST observe `x`. This is what lets a backend read the final message via `tx.Options().Message()` after the worker returns. Wiring each concrete adapter's `Options()` to return this shared value is downstream adoption (see Architecture & Components), not part of this Feature.
+
+### Availability across transaction kinds
+
+#### REQ: message-on-readonly-and-readwrite
+
+The message surface (`Message()` and `SetMessage()`) MUST be available on both readonly and read-write transactions, since `Options()` is defined on the base `Transaction` interface. Setting a message on a readonly transaction MUST be permitted (it is meaningful for logging/observability) and MUST NOT error.
+
+### Removal of the legacy name surface
+
+#### REQ: remove-tx-name
+
+The `dal` package MUST remove `TxWithName` and `TransactionOptions.Name()`. Because `Name()` is declared on the `TransactionOptions` interface, the compiler enforces that **every** in-tree reference is migrated to the message surface or removed; a clean build is the completeness check. Known reference sites, non-exhaustively: the `end2end` `TxWithName(...)` call sites and the `txOptions.Name()` readers in `end2end/end2end_test.go`; and `TestTxWithName`, `mockTx.Name()`, and the `txOptions.Name()` assertions in `dal/transaction_test.go`. This is a deliberate breaking change against dalgo v0.44.1 (pre-1.0). No adapter code requires changes for the removal, because no adapter reads `Name()`.
+
+## Acceptance Criteria
+
+### AC: option-sets-message (verifies REQ: tx-with-message-option)
+
+**Given** options built with `dal.NewTransactionOptions(dal.TxWithMessage("commit subject"))`
+**When** `Message()` is called on the resulting `TransactionOptions`
+**Then** it returns `"commit subject"`.
+
+### AC: message-empty-by-default (verifies REQ: options-message-reader)
+
+**Given** options built with `dal.NewTransactionOptions()` and no message option
+**When** `Message()` is called
+**Then** it returns `""`.
+
+### AC: setmessage-overwrites (verifies REQ: options-message-setter)
+
+**Given** options seeded with `dal.TxWithMessage("first")`
+**When** `SetMessage("second")` is called on those options
+**Then** `Message()` returns `"second"`.
+
+### AC: runtime-message-visible-after-worker (verifies REQ: message-survives-options-roundtrip)
+
+**Given** a transaction whose `Options()` returns by reference the shared `TransactionOptions` it was created with, seeded via `dal.TxWithMessage("init")`
+**When** `tx.Options().SetMessage("final")` is called and the worker returns
+**Then** a separately obtained `tx.Options().Message()` returns `"final"`, proving `Options()` returns the shared reference rather than a copy.
+
+### AC: message-settable-on-readonly (verifies REQ: message-on-readonly-and-readwrite)
+
+**Given** a readonly transaction
+**When** `tx.Options().SetMessage("read by module X")` is called
+**Then** the call does not error and `tx.Options().Message()` returns `"read by module X"`.
+
+### AC: name-surface-removed (verifies REQ: remove-tx-name)
+
+**Given** a Go program importing `github.com/dal-go/dalgo/dal`
+**When** it references `dal.TxWithName` or calls `Name()` on a `dal.TransactionOptions`
+**Then** the program fails to compile because neither symbol exists.
+
+## Architecture & Components
+
+**In scope — the `dal` package only:**
+
+- **`dal.TransactionOption` / `TxWithMessage`** — a new functional option alongside the existing `TxWithReadonly`, `TxWithIsolationLevel`, etc. Sets `txOptions.message`.
+- **`dal.TransactionOptions` interface** — gains `Message() string` and `SetMessage(string)`; loses `Name()`. `txOptions` (the single implementer in `dal/`) backs both. For `SetMessage` to persist, `txOptions`'s mutating method uses a pointer receiver and `NewTransactionOptions` returns `*txOptions`, so the value is shared by reference rather than copied.
+
+**Downstream adoption — informational, NOT part of this Feature:**
+
+- For a backend to actually surface the message, its `Transaction.Options()` must return the shared options reference. Today `dalgo2memory.session.Options()` and `dalgo2fs.transaction.Options()` both return `nil`, and external `dalgo2ingitdb` returns `r.opts` by value — each adopts on its own schedule. Removing `Name()` does not force changes in any of them (none read `Name()`); they continue to compile against the new interface. No new interface and no type assertion are introduced at any call site.
+
+## Error Handling & Failure Modes
+
+There are no error paths: `Message()`, `SetMessage()`, and `TxWithMessage` cannot fail. An empty message is the valid "unset" state. Setting a message on a readonly transaction is allowed and simply has no commit effect on backends that only persist messages on write.
+
+## Rehearse Integration
+
+Every AC has a pure-Go surface (functional option, interface methods, compile check) and is verified by standard Go tests, not separate Rehearse scenario files:
+
+- `option-sets-message`, `message-empty-by-default`, `setmessage-overwrites` → table tests in `dal/transaction_test.go` (replacing `TestTxWithName` with `TestTxWithMessage`).
+- `runtime-message-visible-after-worker`, `message-settable-on-readonly` → in-package tests in `dal/transaction_test.go` using a mock transaction whose `Options()` returns the shared `*txOptions`, exercising the round-trip on both readonly and read-write kinds.
+- `name-surface-removed` → enforced by the compiler across the tree (the migration of `end2end` call sites and `dal/transaction_test.go`); a negative compile test is not added.
+
+Separate `_tests/*.md` Rehearse stubs are intentionally skipped as redundant with these Go tests. The user may request stubs to override this.
+
+## Not Doing / Out of Scope
+
+Carried from the source Idea:
+
+- **Append / `AddMessage` accumulation** — set/replace only; the caller composes the full string. Can be added later without breaking set/replace.
+- **Wiring the message into a real git commit (`dalgo2ingitdb`) or into any backend's logs** — downstream consumer work; this Feature only lands the portable surface.
+- **A separate runtime-only interface or type-assertion pattern** — unnecessary once the message lives on the single-implementer `Options` interface.
+- **Per-write or per-record message attribution** — transaction-level message only.
+- **Structured message metadata (author, trailers, etc.)** — single string; the caller encodes any structure it needs.
+- **Deprecated aliases for `TxWithName` / `Name()`** — removed outright.
+- **Adapter `Options()` adoption** — wiring `dalgo2memory`, `dalgo2fs`, `mocks`, or `dalgo2ingitdb` to carry and return the shared message is downstream adoption, not part of this Feature (see Architecture & Components).
+
+## Assumption Carryover
+
+From the source Idea `transaction-message`:
+
+- **Validated by this Feature's ACs:** a single transaction-level string serves both consumers; a transaction can expose its options by shared reference so a runtime `SetMessage` is visible after the worker returns.
+- **Confirmed with the owner:** `name` and `message` are the same concept (no consumer needs both); exposing `SetMessage` on readonly transactions is useful (logging), not merely harmless.
+- **Deferred (Might-be-true):** append / multi-line composition (`AddMessage`) — revisited only when a consumer needs to build a message across multiple writes.
+
+## Open Questions
+
+None at this time.
+
+---
+*This document follows the https://specscore.md/feature-specification*

--- a/spec/ideas/README.md
+++ b/spec/ideas/README.md
@@ -13,8 +13,9 @@ The Idea format follows [SpecScore](https://specscore.md/idea-specification).
 | [dalgo-dialect-aware-sql-emission](dalgo-dialect-aware-sql-emission.md) | Draft | 2026-05-15 | alex | — |
 | [dalgo-schema-modification](dalgo-schema-modification.md) | Approved | 2026-05-12 | alex | — |
 | [recordops](recordops.md) | Approved | 2026-05-15 | alex | — |
+| [transaction-message](transaction-message.md) | Approved | 2026-06-02 | alex | — |
 
-## Outstanding Questions
+## Open Questions
 
 None at this time.
 

--- a/spec/ideas/concurrency-capability.md
+++ b/spec/ideas/concurrency-capability.md
@@ -60,7 +60,7 @@ Land `dal.ConcurrencyAware` plus its two embeddable helper structs (`NoConcurren
 - **Downstream consumer (informational; Synchestra manages `promotes_to`):**
   - [`datatug/datatug-cli` Idea `cross-engine-db-copy`](https://github.com/datatug/datatug-cli/blob/main/spec/ideas/cross-engine-db-copy.md) — `--parallel-streams` defaults to `runtime.NumCPU() - 1` but caps to 1 when either side returns `false` from `ConcurrencyAware.SupportsConcurrentConnections()`. This is the consumer driving the Idea.
 
-## Outstanding Questions
+## Open Questions
 
 All four original questions were resolved when this Idea was promoted to the Feature spec at [`spec/features/concurrency-capability/`](../features/concurrency-capability/README.md):
 

--- a/spec/ideas/dal-records-reader-iter-seq.md
+++ b/spec/ideas/dal-records-reader-iter-seq.md
@@ -51,7 +51,7 @@ Scope: deciding the migration shape (sibling method vs. wholesale replacement vs
 - **Existing Features affected:** none
 - **Dependencies:** none
 
-## Outstanding Questions
+## Open Questions
 
 None at this time.
 

--- a/spec/ideas/dalgo-dialect-aware-sql-emission.md
+++ b/spec/ideas/dalgo-dialect-aware-sql-emission.md
@@ -127,7 +127,7 @@ datatug-cli's `dalgo2sql/sqlite_emit.go` shim is removed; datatug-cli's `replace
   - None upstream. This is the leaf Idea — sibling work cascades downstream from it.
   - **Downstream consumers waiting on this:** `dal-go/dalgo2sql`'s `emitSQL` shim removal; `datatug/datatug-cli`'s LIMIT-N test infrastructure consolidation; future PostgreSQL DALgo driver.
 
-## Outstanding Questions
+## Open Questions
 
 - **Dialect propagation mechanism: constructor option vs auto-detect from SQL driver name vs both.** The plan picks "constructor option, defaults to ANSI". An alternative is to auto-detect from the `database/sql` driver name passed to `dalgo2sql.NewDatabase` (e.g. `"sqlite3"` → `dialect.SQLite`, `"postgres"` → `dialect.Postgres`, `"sqlserver"` → `dialect.TSQL`). Auto-detect is friendlier but introduces a string-keyed map at the dalgo2sql boundary that could go stale. Plan-time decision: probably "explicit option, but provide `dalgo2sql.AutoDialect(driverName)` as a convenience that returns the right Dialect for known names".
 - **Where does `Dialect` live?** Option A: `dal-go/dalgo/dal/dialect/` (in core, ships with every dalgo install — recommended). Option B: `dal-go/dalgo-dialects` (separate module, drivers depend on the dialects they need). Plan picks A for ergonomic reasons (one import, no version skew across modules); B is the answer if dalgo core wants to stay zero-dependency.

--- a/spec/ideas/dalgo-schema-modification.md
+++ b/spec/ideas/dalgo-schema-modification.md
@@ -106,7 +106,7 @@ A focused PR on dal-go/dalgo adding the DDL surface (table create/drop, primary 
   - None upstream. This is the foundational change.
 - **Downstream consumer:** [`datatug/datatug-cli` Idea `cross-engine-db-copy`](https://github.com/datatug/datatug-cli/blob/main/spec/ideas/cross-engine-db-copy.md) is the driving consumer and the one that validates the surface. (Synchestra will manage `promotes_to`; do not edit manually.)
 
-## Outstanding Questions
+## Open Questions
 
 
 ---

--- a/spec/ideas/recordops.md
+++ b/spec/ideas/recordops.md
@@ -95,7 +95,7 @@ No CLI, no schema-aware diffing, no `DiffMap` entrypoint, no patch application.
 - **Existing Features affected:** none.
 - **Dependencies:** [[dal-records-reader-iter-seq]] (informational only — recordops works without it via the bridge).
 
-## Outstanding Questions
+## Open Questions
 
 None at this time.
 

--- a/spec/ideas/transaction-message.md
+++ b/spec/ideas/transaction-message.md
@@ -1,0 +1,68 @@
+# Idea: Transaction Message
+
+**Status:** Approved
+**Date:** 2026-06-02
+**Owner:** alex
+**Promotes To:** —
+**Supersedes:** —
+**Related Ideas:** —
+
+## Problem Statement
+
+How might we let a DALgo transaction carry a human-readable message — set when the transaction starts and/or refined while it runs — so backends can surface it (dalgo2ingitdb as a git commit message, and any backend in its logs)?
+
+## Context
+
+dalgo2ingitdb (ingitdb-cli) maps a DALgo read-write transaction onto a git commit but has no portable way to obtain a human-authored message for that commit. More broadly, any backend benefits from a human-readable annotation on a transaction for logs and observability — e.g. surfacing which module is reading or updating a table — so the need is not write-only. DALgo today exposes only `TxWithName` / `Options().Name()`, documented as a short identifier "useful for mocking transaction in tests": it conflates a test/debug label with a user-facing message and the word "name" implies brevity. dalgo is v0.44.1 (pre-1.0). The only readers of `TxWithName` are ~22 end2end test helpers inside dalgo itself, and nothing reads `Options().Name()`; `dalgo2ingitdb` uses neither — so replacing `name` with `message` is contained.
+
+## Recommended Direction
+
+Treat the message as a single human-readable annotation carried by the transaction's **options**, readable and writable through the existing `Options()` surface, and available on both readonly and read-write transactions.
+
+Concretely: (1) add `TxWithMessage(string) TransactionOption` to seed the message when a transaction starts; (2) add `Message() string` (reader) and `SetMessage(string)` (writer) to the `TransactionOptions` interface — reading is always `tx.Options().Message()`, writing is either the init option or `tx.Options().SetMessage(...)` during execution, against one backing field, so there is no second accessor and no fallback; (3) **remove** `TxWithName` and `Name()` outright — "message" subsumes "name" and doesn't imply brevity. The message is **set/replace only**: the caller composes the full string (including any multi-line body) itself.
+
+Why this lives on `Options` rather than on a new transaction method or optional interface: `TransactionOptions` has a single implementer (`txOptions` in `dal/`), so adding two methods is non-breaking for every adapter — they pass `txOptions` through. It needs no new optional interface and no type assertion at the call site. And because `Options()` is on the base `Transaction` interface, the message is uniformly available to **both readonly and read-write** transactions — which is wanted, since readonly callers use it for logging and observability (e.g. attributing a read to a module).
+
+One implementation requirement follows: a transaction must expose its options by **shared reference** (not a value copy) so a runtime `SetMessage` persists and the backend reads the final value at commit or log time. `dalgo2ingitdb` currently returns its options by value (`return r.opts`); that becomes a reference.
+
+## Alternatives Considered
+
+- **Put `SetMessage`/`GetMessage` on `ReadwriteTransaction`, or on a new optional `dal.TransactionWithMessage` interface.** Rejected — the first breaks every adapter (`dalgo2fs`, `dalgo2memory`, `mocks`, `dalgo2ingitdb`) by adding a required method; the second forces a `tx.(dal.TransactionWithMessage)` type assertion at every call site. Both also scope the message to writes, but readonly transactions want it too for logging.
+- **Keep `Name` and add a separate `Message` alongside it.** Rejected — two fields for the same concept. A short label and a message are the same string used for two purposes; the owner's call is that `message` subsumes `name`.
+- **Keep `TxWithName`/`Name()` as deprecated aliases for one release.** Rejected — pre-1.0 with only in-tree callers; a clean hard break is simpler, and the one external consumer (`dalgo2ingitdb`) is updated as part of adopting the feature anyway.
+- **Append/accumulate semantics (`AddMessage`).** Rejected for MVP — the caller composes the full string; append can be added later without breaking set/replace.
+
+## MVP Scope
+
+In dal-go/dalgo only: add the `TxWithMessage` option; add `Message()` and `SetMessage(string)` to `TransactionOptions`, backed by a renamed `txOptions.message` field exposed by shared reference so `SetMessage` sticks; remove `TxWithName` and `Name()`; migrate the ~22 end2end call sites and replace `TestTxWithName` with `TestTxWithMessage`. Ensure in-tree adapters (`dalgo2fs`, `dalgo2memory`) and `mocks` return options by shared reference so a runtime `SetMessage` is observable via `Options().Message()`. Unit tests: the option seeds the message; `Message()` reads it back; `SetMessage` overwrites and is visible via `Options().Message()` on **both** a readonly and a read-write transaction. Timebox: a single focused dalgo change — wiring the message into a real git commit (`dalgo2ingitdb`) and into backend logs are downstream follow-ups, not in this MVP.
+
+## Not Doing (and Why)
+
+- AddMessage / append accumulation — caller composes the full string; revisit only if multi-write composition becomes a real ask
+- Wiring the message into a real git commit in dalgo2ingitdb, or into any backend's logs — downstream consumer work; this Idea only lands the portable surface
+- A separate runtime-only interface or type-assertion pattern — unnecessary once the message lives on the single-implementer Options interface
+- Per-write or per-record message attribution — transaction-level message only
+- Structured message metadata (author, trailers, etc.) — single string; the caller encodes any structure it needs
+
+## Key Assumptions to Validate
+
+| Tier | Assumption | How to validate |
+|------|------------|-----------------|
+| Must-be-true | A single transaction-level string serves both consumers: a git commit message (dalgo2ingitdb) and a log/observability annotation (any backend, including readonly). | Trace the ingitdb commit path and a representative log path; confirm one string fits both without structured fields. |
+| Must-be-true | A transaction can expose its options by shared reference so a runtime `SetMessage` is visible at commit/log time. | Confirm dalgo2ingitdb and in-tree adapters can return options by pointer; verify `Options().Message()` reflects a prior `SetMessage`. |
+| Should-be-true | "name" and "message" are the same concept; no consumer needs both. | grep confirms zero readers of `Options().Name()` outside its definition; reconfirm before deleting. |
+| Should-be-true | Exposing `SetMessage` on readonly transactions is useful (logging), not merely harmless. | Confirmed by the owner: readonly callers annotate reads (e.g. module attribution) for logs. |
+| Might-be-true | Append / multi-line composition (`AddMessage`) will eventually be wanted. | Defer until a consumer needs to build a message across multiple writes. |
+
+## SpecScore Integration
+
+- **New Features this would create:** `spec/features/transaction-message/` — the `TxWithMessage` option, `TransactionOptions.Message()` / `SetMessage()`, removal of `TxWithName`/`Name()`, the shared-reference `Options()` requirement, and godoc covering the read/write surface, mutability, and the readonly-logging use.
+- **Existing Features affected:** none — no existing dalgo Feature references transaction `Name`. Sibling Ideas (`concurrency-capability`, `dalgo-schema-modification`) are orthogonal.
+- **Dependencies:** none upstream — additive methods on `Options` plus a contained removal. Downstream consumers (informational; lifecycle tooling manages `Promotes To`): `ingitdb-cli/pkg/dalgo2ingitdb` (git commit message) and any backend wanting transaction annotations in its logs.
+
+## Open Questions
+
+None at this time. Prior questions are resolved with the owner: hard removal of `TxWithName`/`Name()` (no aliases); the message lives on `TransactionOptions` as `Message()` / `SetMessage()`, available to both readonly and read-write transactions.
+
+---
+*This document follows the https://specscore.md/idea-specification*

--- a/spec/plans/2026-06-02-transaction-message.md
+++ b/spec/plans/2026-06-02-transaction-message.md
@@ -1,0 +1,42 @@
+# Plan: Transaction Message
+
+**Status:** Approved
+**Source Feature:** transaction-message
+**Date:** 2026-06-02
+**Owner:** alex
+**Supersedes:** —
+
+## Summary
+
+Decomposes the `transaction-message` Feature into three linear tasks: land the additive `message` surface on `dal` transaction options, perform the coupled breaking removal of the legacy `Name` surface with its call-site migration, then add the shared-reference round-trip tests across readonly and read-write transactions. All six acceptance criteria are covered; none are deferred.
+
+## Approach
+
+Order is forced by the compiler. Task 1 is purely additive (option, interface methods, shared-reference `NewTransactionOptions`) and unblocks everything. Task 2 is the only breaking change and must land as one unit — removing `Name()` and migrating every reference together, since the tree will not build otherwise — and it depends on Task 1 because the migration targets (`TxWithMessage`, `Message()`) must already exist. Task 3 adds the behaviour tests that exercise the shared-reference guarantee on both transaction kinds and depends on Task 1's `*txOptions` return. Each task is one focused work session.
+
+## Tasks
+
+### Task 1: Add the message surface to dal transaction options
+
+**Verifies:** transaction-message#ac:option-sets-message, transaction-message#ac:message-empty-by-default, transaction-message#ac:setmessage-overwrites
+
+Add a `message` field to `txOptions`; add `TxWithMessage(message string) TransactionOption`; add `Message() string` (reader) and a pointer-receiver `SetMessage(message string)` to both the `TransactionOptions` interface and `txOptions`; change `NewTransactionOptions` to return `*txOptions` so the value is shared by reference rather than copied. Because the concrete return type changes, update any surviving value-type assertions on the options (e.g. `opts.(txOptions)`) to `*txOptions`. Add table tests in `dal/transaction_test.go` covering the seeded option, the empty-string default, and `SetMessage` overwrite.
+
+### Task 2: Remove TxWithName / Name() and migrate all references
+
+**Verifies:** transaction-message#ac:name-surface-removed
+
+Delete `TxWithName` and `TransactionOptions.Name()` (interface declaration and `txOptions` implementation). Migrate every in-tree reference so the tree builds cleanly: the `end2end` `TxWithName(...)` call sites become `TxWithMessage(...)`, and the `txOptions.Name()` readers at `end2end/end2end_test.go:125` and `:182` become `Message()` — **preserving the exact seeded strings**, because the surrounding `switch txName` blocks dispatch on those literal values, so the rename stays green only if the strings are unchanged. In `dal/transaction_test.go`, rename `TestTxWithName` → `TestTxWithMessage` and update/remove its `txOptions.Name()` assertions; the standalone `mockTx.Name()` test-double method is not part of the removed interface surface — remove it as incidental dead-code cleanup, not as a build requirement. A clean `go build ./... && go test ./...` is the completeness check. Depends on Task 1, whose `TxWithMessage`/`Message()` are the migration targets.
+
+### Task 3: Verify shared-reference round-trip on readonly and read-write transactions
+
+**Verifies:** transaction-message#ac:runtime-message-visible-after-worker, transaction-message#ac:message-settable-on-readonly
+
+In `dal/transaction_test.go`, give the mock transaction an `Options()` that returns the shared `*txOptions` it was constructed with. Add tests that seed the message via `TxWithMessage("init")`, call `tx.Options().SetMessage("final")`, and assert a separately obtained `tx.Options().Message()` returns `"final"` — proving `Options()` returns the shared reference, not a copy — exercised on both a read-write and a readonly transaction, and asserting that setting a message on a readonly transaction does not error. Depends on Task 1's shared-reference `NewTransactionOptions`.
+
+## Outstanding Questions
+
+None at this time.
+
+---
+*This document follows the https://specscore.md/plan-specification*

--- a/spec/plans/README.md
+++ b/spec/plans/README.md
@@ -10,8 +10,9 @@ verifiable tasks with clear acceptance criteria and dependency ordering.
 | [2026-05-12-concurrency-capability](2026-05-12-concurrency-capability.md) | concurrency-capability | Done |
 | [2026-05-13-dbschema-ddl](2026-05-13-dbschema-ddl.md) | dbschema + ddl | Done |
 | [2026-05-15-recordops-diff](2026-05-15-recordops-diff.md) | recordops + recordops/diff | Done |
+| [2026-06-02-transaction-message](2026-06-02-transaction-message.md) | transaction-message | Approved |
 
-## Outstanding Questions
+## Open Questions
 
 None at this time.
 

--- a/specscore.yaml
+++ b/specscore.yaml
@@ -2,3 +2,12 @@
 
 project:
   title: DALgo
+
+gates:
+  specify:
+    reviewers:
+      - type: ai
+        name: spec-reviewer
+        prompt: .specscore/reviewers/spec.md
+      - type: human
+        name: owner-approval


### PR DESCRIPTION
## What

Adds a human-readable **message** to a DALgo transaction, replacing the old `TxWithName` / `Options().Name()` surface. The message can be seeded at transaction start or set/updated during execution, and is read back via the existing `Options()` surface — on both readonly and read-write transactions.

Driven by `dalgo2ingitdb`, which needs a commit message for the git commit a read-write transaction maps to. The message is equally useful as a log/observability annotation (e.g. which module is reading/updating a table), which is why it's available on readonly transactions too.

## API

```go
// seed at start
db.RunReadwriteTransaction(ctx, worker, dal.TxWithMessage("Fix typo in user 42"))

// read back (e.g. at commit/log time)
msg := tx.Options().Message()

// set/replace during execution (RO or RW)
tx.Options().SetMessage("final message")
```

- `TxWithMessage(string) TransactionOption`
- `TransactionOptions.Message() string` — single reader
- `TransactionOptions.SetMessage(string)` — set/replace (caller composes the full string)
- `NewTransactionOptions` now returns `*txOptions` (shared reference) so a runtime `SetMessage` is observed by the backend after the worker returns.

## ⚠️ Breaking change

`TxWithName` and `TransactionOptions.Name()` are **removed** (no deprecated aliases). Acceptable for pre-1.0 (v0.44.1). No adapter code changes were needed — no adapter read `Name()`. In-tree callers (`end2end`, `dal/transaction_test.go`) migrated to `TxWithMessage`/`Message()`, preserving the seeded strings the `end2end` switch dispatch depends on.

## Scope

This PR lands the portable `dal` surface only. Wiring the message into an actual git commit (`dalgo2ingitdb`) and into backend logs is downstream adoption, tracked separately.

## Spec artifacts

Built via the SpecScore flow (ideate → specify → plan), all Approved:
- Idea: `spec/ideas/transaction-message.md`
- Feature: `spec/features/transaction-message/README.md` (6 REQs, 6 Given/When/Then ACs)
- Plan: `spec/plans/2026-06-02-transaction-message.md` (3 tasks, full AC coverage)

## Verification

- All 6 ACs covered by passing tests
- Full module test suite green
- `dal` coverage **100%** (pre-push hook)
- `go vet` clean

## Commits

- `chore(spec)`: normalize Studio toolbar + Open Questions headings (lint-required, unrelated siblings)
- `chore(specscore)`: add specify reviewer gate config
- `docs(spec)`: add idea + feature + plan
- `feat(dal)`: implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)