### PR TITLE
fix(spec): reconcile recordset-computed-columns idea-sync drift

### DIFF
--- a/spec/ideas/README.md
+++ b/spec/ideas/README.md
@@ -13,7 +13,7 @@ The Idea format follows [SpecScore](https://specscore.md/idea-specification).
 | [dalgo-dialect-aware-sql-emission](dalgo-dialect-aware-sql-emission.md) | Draft | 2026-05-15 | alex | — |
 | [dalgo-schema-modification](dalgo-schema-modification.md) | Approved | 2026-05-12 | alex | — |
 | [recordops](recordops.md) | Approved | 2026-05-15 | alex | — |
-| [recordset-computed-columns](recordset-computed-columns.md) | Implementing | 2026-06-02 | alex | recordset-computed-columns |
+| [recordset-computed-columns](recordset-computed-columns.md) | Specified | 2026-06-02 | alex | recordset-computed-columns |
 | [transaction-message](transaction-message.md) | Approved | 2026-06-02 | alex | — |
 
 ## Open Questions

--- a/spec/ideas/recordset-computed-columns.md
+++ b/spec/ideas/recordset-computed-columns.md
@@ -1,6 +1,6 @@
 # Idea: Computed Columns in recordset (neutral evaluator)
 
-**Status:** Implementing
+**Status:** Specified
 **Date:** 2026-06-02
 **Owner:** alex
 **Promotes To:** recordset-computed-columns


### PR DESCRIPTION
Fixes a **pre-existing** `idea-sync-lint-strict` violation on `main` (unrelated to any feature work): the `recordset-computed-columns` idea's `**Status:**` disagreed with its referencing feature's lifecycle stage.

Applied `specscore spec lint --fix`, which reconciled the idea status `Implementing → Specified` and synced the ideas index row. **No feature content changed** — purely managed-state reconciliation. `specscore spec lint` is now clean (0 violations).

Isolated into its own branch/PR so it can merge independently of in-flight feature work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
