### PR TITLE
spec(dtql): DTQL — YAML serialization of dal.StructuredQuery

### DIFF
--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -16,6 +16,7 @@ The Feature format follows [SpecScore](https://specscore.md/feature-specificatio
 | [recordops](recordops/README.md) | Implemented | Umbrella for the `recordops` package — pure, dependency-free analytical / inspection helpers over dalgo record collections. MVP introduces one child: [diff](recordops/diff/README.md) — one baseline vs. N candidates via K-way merge over ID-sorted `iter.Seq2` streams, with four renderers (git-style YAML, by-ID YAML, plain YAML, JSON) and bridge helpers `SliceToSeq` + `ReaderToSeq`. |
 | [transaction-message](transaction-message/README.md) | Approved | — |
 | [recordset-computed-columns](recordset-computed-columns/README.md) | Approved | — |
+| [dtql](dtql/README.md) | Approved | — |
 
 ## Open Questions
 

--- a/spec/features/dtql/README.md
+++ b/spec/features/dtql/README.md
@@ -1,0 +1,156 @@
+# Feature: DTQL — YAML serialization of dal.StructuredQuery
+
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dtql?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dtql?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dtql?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dtql?op=request-change) |
+**Status:** Approved
+**Date:** 2026-06-05
+**Owner:** alex
+**Source Ideas:** —
+**Supersedes:** —
+**Grade:** A
+
+## Summary
+
+DTQL is a 1:1, lossless, human-readable **YAML serialization of dalgo's `dal.StructuredQuery`**. This Feature adds a top-level `dtql` package that (de)serializes between `dal.StructuredQuery` and a DTQL-YAML document for the core relational read-only subset, documents the YAML shape, and proves a lossless round-trip in both directions. It serves any dalgo consumer that needs to save, hand-edit, diff, and reload a structured query as text — first among them DataTug's serve-brokered query builder. Realizes the cross-repo Idea `specscore:idea/dtql-datatug-query-language@github.com/datatug/datatug`.
+
+## Problem
+
+dalgo models structured queries (`dal.StructuredQuery` — `From`/`Where`/`OrderBy`/`Columns`/`Limit`/`Offset` over `Expression`, `Condition`, `Column`, `FromSource` nodes) but has **no textual, human-readable, round-trippable form** for them. A consumer that wants to persist a query, edit it by hand, diff it in version control, or move it across a wire must reach into Go structs or invent an ad-hoc encoding. DataTug's serve-brokered query builder already assumes such a form ("DTQL-YAML") exists and is lossless (`REQ:dtql-yaml-form`), but nothing defines it. This Feature defines DTQL for the core relational subset so the serialization is one canonical thing in dalgo rather than per-consumer reinvention.
+
+## Behavior
+
+### Representation
+
+DTQL is plain YAML over the existing `dal` query model — no bespoke grammar, no new AST.
+
+#### REQ: serialize-structuredquery
+
+The `dtql` package MUST provide serialization from an in-scope `dal.StructuredQuery` to a DTQL-YAML document, and deserialization from a DTQL-YAML document back to a `dal.StructuredQuery`. DTQL-YAML MUST be plain YAML produced and consumed by a standard YAML library — no bespoke grammar or hand-written parser.
+
+#### REQ: covered-subset
+
+DTQL MUST represent the core relational read-only subset of `dal.StructuredQuery`: a single `From` whose `Joins()` is empty, over a **root** `dal.CollectionRef` base (a flat named recordset, `Parent() == nil`); the selected `Columns`; the `Where` `Condition` (both `Comparison` nodes and And/Or `GroupCondition` trees); `OrderBy` expressions; and `Limit`/`Offset`. The expression nodes in scope are field references (`FieldRef`), constants (`Constant`), and constant arrays (`Array`, for `In` membership). The comparison operators in scope are `==`, `In`, `>`, `>=`, `<`, `<=`; the group operators are `And`/`Or`. Literal values are carried **inline** as `Constant`/`Array` expressions — `dal.StructuredQuery` has no separate parameter list (`QueryArg` belongs to `dal.TextQuery`, which is out of scope). Each in-scope `dal` node MUST have a defined YAML representation.
+
+#### REQ: reject-out-of-scope
+
+Serialization MUST reject (with a clear, descriptive error) any `dal.StructuredQuery` outside the covered subset — a `From` with a non-empty `Joins()` (joins), a base that is a `CollectionGroupRef` or a parented `CollectionRef` (`Parent() != nil`), a `GroupBy`, an aggregate or scalar function, a cursor/`StartFrom`, or a comparison/group operator outside the in-scope set — rather than silently dropping it. DTQL MUST NOT emit a document that loses query semantics.
+
+### Round-trip fidelity
+
+A DTQL document and the `StructuredQuery` it encodes must be interconvertible without loss, and serialization must be stable enough to diff.
+
+#### REQ: round-trip-structural
+
+For any in-scope `dal.StructuredQuery` `q`, `deserialize(serialize(q))` MUST reconstruct a `StructuredQuery` that is structurally equal to `q` — identical `From`, `Columns`, `Where` condition tree (including inline `Constant`/`Array` values), `OrderBy`, `Limit`, and `Offset`.
+
+#### REQ: round-trip-canonical
+
+Serialization MUST be canonical: for any valid in-scope DTQL-YAML document `d`, `serialize(deserialize(d))` MUST produce byte-identical YAML (stable key ordering and formatting), so saved queries diff cleanly across edits.
+
+### Errors and validation
+
+#### REQ: invalid-input-errors
+
+Deserializing malformed or schema-invalid DTQL-YAML — unknown keys, wrong value types, missing required fields, or an unknown operator — MUST return a descriptive error identifying the problem and MUST NOT return a partially-populated `StructuredQuery`.
+
+### Package and documentation
+
+#### REQ: package-location
+
+DTQL MUST live in a new top-level package `github.com/dal-go/dalgo/dtql` that imports `dal`. It MUST NOT add a YAML dependency to the `dal` package.
+
+#### REQ: documented-shape
+
+The package MUST document the DTQL-YAML shape — the mapping from each in-scope `dal` node (`From` / root `CollectionRef`, `Column`, `Comparison`, `GroupCondition`, `OrderExpression`, `FieldRef`, `Constant`, `Array`, `Operator`) to its YAML representation — versioned in-repo alongside the code.
+
+## Acceptance Criteria
+
+### AC: serialize-and-back (verifies REQ:serialize-structuredquery)
+
+**Given** an in-scope `dal.StructuredQuery` built in Go
+**When** it is serialized with the `dtql` package and the resulting document is deserialized
+**Then** a `dal.StructuredQuery` is returned and the document is plain YAML parseable by a standard YAML library.
+
+### AC: subset-nodes-represented (verifies REQ:covered-subset)
+
+**Given** a `StructuredQuery` with a single join-free `From` over a root `CollectionRef`, selected `Columns`, a `Where` combining `Comparison` (with inline `Constant`/`Array` values) and And/Or `GroupCondition`, `OrderBy`, `Limit`, and `Offset`
+**When** it is serialized to DTQL-YAML
+**Then** the YAML contains a defined representation for each of those nodes (source, columns, where tree with inline constants, order, limit, offset) with no node omitted.
+
+### AC: out-of-scope-rejected (verifies REQ:reject-out-of-scope)
+
+**Given** a `StructuredQuery` whose `From` has a non-empty `Joins()` (or a `CollectionGroupRef` / parented `CollectionRef` base, a `GroupBy`, a function, or a cursor)
+**When** it is passed to serialization
+**Then** serialization returns a descriptive error naming the unsupported construct and produces no DTQL document.
+
+### AC: structural-round-trip (verifies REQ:round-trip-structural)
+
+**Given** an in-scope `StructuredQuery` `q`
+**When** `deserialize(serialize(q))` is computed
+**Then** the resulting query is structurally equal to `q` across `From`, `Columns`, `Where` (including inline `Constant`/`Array` values), `OrderBy`, `Limit`, and `Offset`.
+
+### AC: canonical-round-trip (verifies REQ:round-trip-canonical)
+
+**Given** a valid in-scope DTQL-YAML document `d`
+**When** `serialize(deserialize(d))` is computed
+**Then** the output is byte-identical to `d` (stable key ordering and formatting).
+
+### AC: invalid-yaml-rejected (verifies REQ:invalid-input-errors)
+
+**Given** a DTQL-YAML document with an unknown key, a wrong value type, or an unknown operator
+**When** it is deserialized
+**Then** a descriptive error is returned and no partially-populated `StructuredQuery` is produced.
+
+### AC: lives-in-dtql-package (verifies REQ:package-location)
+
+**Given** the dalgo module
+**When** the DTQL code is located
+**Then** it resides in package `github.com/dal-go/dalgo/dtql`, imports `dal`, and the `dal` package has gained no YAML dependency.
+
+### AC: shape-documented (verifies REQ:documented-shape)
+
+**Given** the `dtql` package
+**When** a reader looks for the DTQL-YAML shape
+**Then** in-repo documentation maps each in-scope `dal` node to its YAML representation.
+
+## Rehearse Integration
+
+Every AC has a concrete, pure-function Go surface (`serialize`, `deserialize`, round-trip composition, error returns, package import graph) and is directly unit-testable with table tests. Stub scaffolding under `_tests/` is deferred to the Plan phase so the stub set tracks the final task/test breakdown rather than being authored twice — consistent with the approach used by the serve-brokered query-builder Features that consume DTQL.
+
+## Architecture and Components
+
+- **`dtql` package (new, module root).** Depends on `dal`. Exposes (de)serialization entry points between `dal.StructuredQuery` and DTQL-YAML, plus the canonicalization used by `round-trip-canonical`.
+- **YAML encoding.** Uses a standard Go YAML library, isolated to the `dtql` package so `dal` stays dependency-free.
+- **Subset gate.** A single place that classifies a `StructuredQuery` as in-scope or rejects it (`reject-out-of-scope`), so the lossless guarantee is enforced in one spot.
+- **Shape doc.** An in-repo document (e.g. `dtql/README.md` or a doc comment) describing the node→YAML mapping (`documented-shape`).
+
+## Data Flow
+
+`dal.StructuredQuery` → subset gate → DTQL-YAML (serialize). DTQL-YAML → validate → `dal.StructuredQuery` (deserialize). Round-trip tests compose the two in both directions.
+
+## Not Doing / Out of Scope
+
+- Joins (a non-empty `From.Joins()`), `GroupBy`/aggregates, scalar functions, cursor/`StartFrom`, and `CollectionGroupRef` / parented `CollectionRef` sources — deferred to follow-ons; serialization rejects them (`REQ:reject-out-of-scope`).
+- The native-text form (`dal.TextQuery`) and its `QueryArg` parameters — DTQL serializes the *structured* side only; `dal.StructuredQuery` carries literal values inline as `Constant`/`Array` and has no parameter list.
+- A bespoke DTQL grammar/parser, and adopting an existing text language (PRQL/Malloy) — DTQL is YAML over the existing AST.
+- Per-driver rendering of the AST to a native SQL dialect or document query — owned by dalgo drivers and the serve-brokered daemon, not this package.
+- A separate machine-checkable schema artifact (e.g. JSON Schema) — this cycle ships the Go (de)serializer plus documented shape; the round-trip tests are the guarantee.
+- The saved-`.dtql.yaml` project-file UX — a DataTug consumer concern, not dalgo's.
+
+## Assumption Carryover
+
+From the cross-repo Idea `dtql-datatug-query-language`:
+
+- **dalgo owns a query AST for DTQL to serialize (Must-be-true, confirmed)** — satisfied by the existing `dal.StructuredQuery`; encoded as `REQ:serialize-structuredquery` + `REQ:covered-subset`.
+- **A 1:1 lossless AST↔YAML round-trip is achievable with off-the-shelf YAML (Must-be-true)** — encoded as `REQ:round-trip-structural` + `REQ:round-trip-canonical`, validated by their ACs.
+- **DTQL-YAML is human-readable / hand-editable (Should-be-true)** — supported by `REQ:documented-shape` and canonical formatting; full confirmation needs dogfooding, deferred.
+- **One AST renders to multiple native dialects (Should-be-true)** — out of scope here (rendering is not DTQL's job); carried by the dalgo drivers / serve-brokered daemon.
+
+## Open Questions
+
+- The acronym DTQL expands to "DataTug Query Language", but the format now lives in the general-purpose dalgo library. Keep the established DTQL name (used across the serve-brokered specs) or adopt a neutral gloss in dalgo? Kept as-is for cross-repo consistency this cycle.
+- Should the cross-repo source link to the datatug Idea be formalized in `**Source Ideas:**` once tooling resolves cross-repo idea references, instead of being stated in prose?
+- Exact structural-equality mechanism for `round-trip-structural` (a `dal`-provided equality helper vs. a `dtql`-local comparator) — a Plan/implementation detail.
+- How far the relational subset later extends (`GroupBy`, joins, functions) before nested/document shapes — tracked for the next DTQL cycle.
+
+---
+*This document follows the https://specscore.md/feature-specification*

--- a/spec/features/dtql/README.md
+++ b/spec/features/dtql/README.md
@@ -10,7 +10,7 @@
 
 ## Summary
 
-DTQL is a 1:1, lossless, human-readable **YAML serialization of dalgo's `dal.StructuredQuery`**. This Feature adds a top-level `dtql` package that (de)serializes between `dal.StructuredQuery` and a DTQL-YAML document for the core relational read-only subset, documents the YAML shape, and proves a lossless round-trip in both directions. It serves any dalgo consumer that needs to save, hand-edit, diff, and reload a structured query as text — first among them DataTug's serve-brokered query builder. Realizes the cross-repo Idea `specscore:idea/dtql-datatug-query-language@github.com/datatug/datatug`.
+DTQL is a 1:1, lossless, human-readable **YAML serialization of dalgo's `dal.StructuredQuery`**. This Feature adds a top-level `dtql` package that (de)serializes between `dal.StructuredQuery` and a DTQL-YAML document for the core relational read-only subset, documents the YAML shape, and proves a lossless round-trip in both directions. It also **publishes DTQL** as a public artifact: a JSON Schema (generated from the Go types) and a set of example documents, served as a documented site at **https://dal-go.github.io/dtql/** so DTQL files can be validated by any tool and read by humans. It serves any dalgo consumer that needs to save, hand-edit, diff, and reload a structured query as text — first among them DataTug's serve-brokered query builder. Realizes the cross-repo Idea `specscore:idea/dtql-datatug-query-language@github.com/datatug/datatug`.
 
 ## Problem
 
@@ -62,6 +62,26 @@ DTQL MUST live in a new top-level package `github.com/dal-go/dalgo/dtql` that im
 
 The package MUST document the DTQL-YAML shape — the mapping from each in-scope `dal` node (`From` / root `CollectionRef`, `Column`, `Comparison`, `GroupCondition`, `OrderExpression`, `FieldRef`, `Constant`, `Array`, `Operator`) to its YAML representation — versioned in-repo alongside the code.
 
+### Published schema and examples
+
+DTQL is published as a public, tool-validatable artifact so consumers in any language can validate a `.dtql.yaml` and humans can read the shape.
+
+#### REQ: machine-checkable-schema
+
+The package MUST provide a **JSON Schema (draft 2020-12)** describing the in-scope DTQL-YAML, **generated from the `dtql` Go types** (the types are the single source of truth). It MUST be emitted in both serializations — `schema.json` (the canonical `$id`, `https://dal-go.github.io/dtql/schema.json`) and `schema.yaml` (identical content) — and CI MUST fail if the committed schema is stale relative to the Go types (regenerate-and-diff).
+
+#### REQ: schema-accepts-serializer-output
+
+Every DTQL document produced by `serialize` for an in-scope `dal.StructuredQuery` MUST validate against the generated schema. A test MUST assert this over a representative set of in-scope queries, so the schema (generated from the types) and the serializer's actual output cannot drift.
+
+#### REQ: example-documents
+
+The package MUST provide a set of example DTQL documents that together exercise the in-scope subset (source, columns, comparison + And/Or group filters, ordering, limit/offset). Each example MUST be a valid DTQL document (it deserializes to a `dal.StructuredQuery`) **and** MUST validate against the schema; CI MUST enforce both.
+
+#### REQ: published-site
+
+The schema (both serializations), the example documents, and a human-readable, styled index page documenting the node→YAML mapping MUST be published at **https://dal-go.github.io/dtql/** (served from the `dal-go.github.io` repository) and MUST be kept in sync with the `dtql` package — the publish MUST be driven from the generated artifacts, not hand-maintained separately.
+
 ## Acceptance Criteria
 
 ### AC: serialize-and-back (verifies REQ:serialize-structuredquery)
@@ -112,9 +132,33 @@ The package MUST document the DTQL-YAML shape — the mapping from each in-scope
 **When** a reader looks for the DTQL-YAML shape
 **Then** in-repo documentation maps each in-scope `dal` node to its YAML representation.
 
+### AC: schema-generated-and-fresh (verifies REQ:machine-checkable-schema)
+
+**Given** the `dtql` Go types and the committed `schema.json` / `schema.yaml`
+**When** the schema is regenerated from the types in CI
+**Then** a JSON Schema (draft 2020-12) is produced in both serializations with a canonical `$id` of `https://dal-go.github.io/dtql/schema.json`, and CI fails if the regenerated schema differs from the committed one.
+
+### AC: serialized-validates-against-schema (verifies REQ:schema-accepts-serializer-output)
+
+**Given** a representative set of in-scope `dal.StructuredQuery` values
+**When** each is serialized to DTQL-YAML and the output is validated against the generated schema
+**Then** every serialized document passes schema validation (the serializer and schema agree).
+
+### AC: examples-valid (verifies REQ:example-documents)
+
+**Given** the set of example DTQL documents
+**When** CI runs
+**Then** each example deserializes to a `dal.StructuredQuery` and validates against the schema, and together they exercise source, columns, comparison + And/Or group filters, ordering, and limit/offset.
+
+### AC: site-published (verifies REQ:published-site)
+
+**Given** the generated schema, examples, and index page
+**When** the publish runs
+**Then** `https://dal-go.github.io/dtql/` serves `schema.json`, `schema.yaml`, the example documents, and a styled index page documenting the node→YAML mapping, sourced from the generated artifacts (not hand-maintained).
+
 ## Rehearse Integration
 
-Every AC has a concrete, pure-function Go surface (`serialize`, `deserialize`, round-trip composition, error returns, package import graph) and is directly unit-testable with table tests. Stub scaffolding under `_tests/` is deferred to the Plan phase so the stub set tracks the final task/test breakdown rather than being authored twice — consistent with the approach used by the serve-brokered query-builder Features that consume DTQL.
+Most ACs have a concrete, pure-function Go surface (`serialize`, `deserialize`, round-trip composition, error returns, package import graph) and are directly unit-testable with table tests. The schema, examples, and publish ACs (`schema-generated-and-fresh`, `examples-valid`, `site-published`) are CI-enforced checks (regenerate-and-diff, schema validation, publish output). Stub scaffolding under `_tests/` is deferred to the Plan phase so the stub set tracks the final task/test breakdown rather than being authored twice — consistent with the approach used by the serve-brokered query-builder Features that consume DTQL.
 
 ## Architecture and Components
 
@@ -122,10 +166,13 @@ Every AC has a concrete, pure-function Go surface (`serialize`, `deserialize`, r
 - **YAML encoding.** Uses a standard Go YAML library, isolated to the `dtql` package so `dal` stays dependency-free.
 - **Subset gate.** A single place that classifies a `StructuredQuery` as in-scope or rejects it (`reject-out-of-scope`), so the lossless guarantee is enforced in one spot.
 - **Shape doc.** An in-repo document (e.g. `dtql/README.md` or a doc comment) describing the node→YAML mapping (`documented-shape`).
+- **Schema generator.** A tool that emits the JSON Schema (`schema.json` + `schema.yaml`) from the `dtql` Go types; run in CI with a regenerate-and-diff staleness check (`machine-checkable-schema`).
+- **Examples.** A directory of example `.dtql.yaml` documents, validated in CI against the schema and against the deserializer (`example-documents`).
+- **Publish step.** CI that copies the generated schema, examples, and a styled `index.html` into the `dal-go.github.io` repo under `/dtql/` (`published-site`). Cross-repo: `dalgo` is the source of truth; `dal-go.github.io` is the serving surface.
 
 ## Data Flow
 
-`dal.StructuredQuery` → subset gate → DTQL-YAML (serialize). DTQL-YAML → validate → `dal.StructuredQuery` (deserialize). Round-trip tests compose the two in both directions.
+`dal.StructuredQuery` → subset gate → DTQL-YAML (serialize). DTQL-YAML → validate → `dal.StructuredQuery` (deserialize). Round-trip tests compose the two in both directions. Separately, the `dtql` Go types → schema generator → `schema.json` / `schema.yaml`; the schema + example documents + a styled `index.html` are published by CI to `dal-go.github.io/dtql/`, and examples are validated against the schema before publish.
 
 ## Not Doing / Out of Scope
 
@@ -133,8 +180,8 @@ Every AC has a concrete, pure-function Go surface (`serialize`, `deserialize`, r
 - The native-text form (`dal.TextQuery`) and its `QueryArg` parameters — DTQL serializes the *structured* side only; `dal.StructuredQuery` carries literal values inline as `Constant`/`Array` and has no parameter list.
 - A bespoke DTQL grammar/parser, and adopting an existing text language (PRQL/Malloy) — DTQL is YAML over the existing AST.
 - Per-driver rendering of the AST to a native SQL dialect or document query — owned by dalgo drivers and the serve-brokered daemon, not this package.
-- A separate machine-checkable schema artifact (e.g. JSON Schema) — this cycle ships the Go (de)serializer plus documented shape; the round-trip tests are the guarantee.
 - The saved-`.dtql.yaml` project-file UX — a DataTug consumer concern, not dalgo's.
+- A general docs/site framework for the `dal-go.github.io` site — DTQL publishes a `/dtql/` subtree into the existing static site; restyling or re-platforming that site is out of scope.
 
 ## Assumption Carryover
 
@@ -148,6 +195,8 @@ From the cross-repo Idea `dtql-datatug-query-language`:
 ## Open Questions
 
 - The acronym DTQL expands to "DataTug Query Language", but the format now lives in the general-purpose dalgo library. Keep the established DTQL name (used across the serve-brokered specs) or adopt a neutral gloss in dalgo? Kept as-is for cross-repo consistency this cycle.
+- The publish target is the `dal-go.github.io` repo (cross-repo). Does the `/dtql/` site warrant its own small Feature in `dal-go.github.io`, or is owning the publish from `dalgo` CI sufficient? Treated as a `dalgo`-owned publish this cycle.
+- Mechanism for the cross-repo publish (CI push with a deploy token vs. a `dal-go.github.io` workflow that pulls generated artifacts from a `dalgo` release) — a Plan/CI detail.
 - Should the cross-repo source link to the datatug Idea be formalized in `**Source Ideas:**` once tooling resolves cross-repo idea references, instead of being stated in prose?
 - Exact structural-equality mechanism for `round-trip-structural` (a `dal`-provided equality helper vs. a `dtql`-local comparator) — a Plan/implementation detail.
 - How far the relational subset later extends (`GroupBy`, joins, functions) before nested/document shapes — tracked for the next DTQL cycle.

--- a/spec/plans/2026-06-05-dtql.md
+++ b/spec/plans/2026-06-05-dtql.md
@@ -1,0 +1,90 @@
+# Plan: DTQL — YAML serialization of dal.StructuredQuery
+
+**Status:** Approved
+**Source Feature:** dtql
+**Date:** 2026-06-05
+**Owner:** alex
+**Supersedes:** —
+
+## Summary
+
+Decomposes the `dtql` Feature into eleven linear, bottom-up tasks: the package skeleton and node→YAML shapes first, then the subset gate, then serialize, then deserialize with validation errors, then the two round-trip guarantees (structural, then canonical), the shape documentation, then the published artifacts — a generated JSON Schema, a serializer-conformance test, validated example documents, and the CI publish to `dal-go.github.io/dtql/`. All 12 acceptance criteria are covered by a task; none are deferred.
+
+## Approach
+
+Tasks follow the build dependency chain of the new top-level `dtql` package. Task 1 creates the package (importing `dal`, adding no YAML dependency to `dal`) and the YAML shape types every later task needs. Task 2 adds the subset gate that classifies a `StructuredQuery` as in-scope or rejects out-of-scope constructs — the lossless guarantee's single enforcement point, which both serialize and deserialize rely on. Tasks 3 and 4 implement the two directions: serialize (gated by Task 2) and deserialize (with descriptive validation errors). Tasks 5 and 6 layer the round-trip guarantees on both directions — structural-AST equality first, then canonical stable-ordering serialization. Task 7 documents the finalized node→YAML mapping. Tasks 8–11 build the public artifacts on top of the settled types and shape: a JSON Schema generated from the Go types (8), a test asserting the serializer's output validates against that schema so the two cannot drift (9), example documents validated against it (10), and the CI publish of schema + examples + a styled index page to `dal-go.github.io/dtql/` (11). ACs are grouped by unit of implementation work, never split into AC-wrapper tasks.
+
+## Tasks
+
+### Task 1: Package skeleton and DTQL-YAML node shapes
+
+**Verifies:** dtql#ac:lives-in-dtql-package
+
+Create the top-level `dtql` package (`github.com/dal-go/dalgo/dtql`) importing `dal`, and define the YAML representation types for each in-scope `dal` node (From/root `CollectionRef`, `Column`, `Comparison`, `GroupCondition`, `OrderExpression`, `FieldRef`, `Constant`, `Array`, `Operator`). Assert the import boundary — no YAML dependency is added to the `dal` package.
+
+### Task 2: Subset gate (accept / reject classifier)
+
+**Verifies:** dtql#ac:out-of-scope-rejected
+
+Implement the single classifier that accepts an in-scope `StructuredQuery` and rejects out-of-scope constructs — a non-empty `From.Joins()`, a `CollectionGroupRef` or parented `CollectionRef` base, `GroupBy`, functions, cursor/`StartFrom`, or an operator outside `{==, In, >, >=, <, <=, And, Or}` — returning a descriptive error that names the unsupported construct and producing no document.
+
+### Task 3: Serialize StructuredQuery → DTQL-YAML
+
+**Verifies:** dtql#ac:subset-nodes-represented
+
+Implement serialization of an in-scope `StructuredQuery` (gated by Task 2) into a DTQL-YAML document, emitting a defined representation for each in-scope node — source, columns, the `Where` tree with inline `Constant`/`Array` values, order, limit, offset — with no node omitted.
+
+### Task 4: Deserialize DTQL-YAML → StructuredQuery, with validation errors
+
+**Verifies:** dtql#ac:serialize-and-back, dtql#ac:invalid-yaml-rejected
+
+Implement deserialization reconstructing a `StructuredQuery` from a DTQL-YAML document (completing the serialize→deserialize round-back), and return a descriptive error — with no partially-populated query — on malformed or schema-invalid input (unknown keys, wrong value types, missing required fields, unknown operator).
+
+### Task 5: Structural round-trip guarantee
+
+**Verifies:** dtql#ac:structural-round-trip
+
+Guarantee that `deserialize(serialize(q))` reconstructs a `StructuredQuery` structurally equal to `q` across `From`, `Columns`, `Where` (including inline `Constant`/`Array`), `OrderBy`, `Limit`, and `Offset`; choose the equality mechanism and cover it with table tests over a representative in-scope query set.
+
+### Task 6: Canonical serialization and canonical round-trip
+
+**Verifies:** dtql#ac:canonical-round-trip
+
+Make serialization canonical (stable key ordering and formatting) so that `serialize(deserialize(d))` is byte-identical to a valid in-scope DTQL-YAML document `d`; cover it with tests so saved queries diff cleanly.
+
+### Task 7: Document the DTQL-YAML shape
+
+**Verifies:** dtql#ac:shape-documented
+
+Write in-repo documentation (the `dtql` package doc / README) mapping each in-scope `dal` node to its YAML representation, matching the shapes finalized by Tasks 3–6.
+
+### Task 8: Generate JSON Schema from the Go types
+
+**Verifies:** dtql#ac:schema-generated-and-fresh
+
+Build a generator that emits a JSON Schema (draft 2020-12) from the `dtql` Go types, written in both serializations — `schema.json` (canonical `$id` `https://dal-go.github.io/dtql/schema.json`) and `schema.yaml`. Wire a CI regenerate-and-diff check that fails when the committed schema is stale relative to the types.
+
+### Task 9: Test serializer output validates against the schema
+
+**Verifies:** dtql#ac:serialized-validates-against-schema
+
+Add a test that serializes a representative set of in-scope `dal.StructuredQuery` values and asserts each serialized DTQL document validates against the generated schema (Task 8), so the schema and the serializer cannot drift.
+
+### Task 10: Example DTQL documents validated against the schema
+
+**Verifies:** dtql#ac:examples-valid
+
+Author example `.dtql.yaml` documents that together exercise the in-scope subset (source, columns, comparison + And/Or group filters, ordering, limit/offset). Add CI that asserts each example deserializes to a `dal.StructuredQuery` and validates against the generated schema.
+
+### Task 11: Publish schema, examples, and index page to dal-go.github.io/dtql/
+
+**Verifies:** dtql#ac:site-published
+
+Add a styled `index.html` (matching the existing site) that documents the node→YAML mapping and links the schema and examples, and a CI publish step that copies the generated `schema.json`/`schema.yaml`, the examples, and the index page into the `dal-go.github.io` repository under `/dtql/`, sourced from the generated artifacts.
+
+## Open Questions
+
+- None at this time.
+
+---
+*This document follows the https://specscore.md/plan-specification*

--- a/spec/plans/README.md
+++ b/spec/plans/README.md
@@ -12,6 +12,7 @@ verifiable tasks with clear acceptance criteria and dependency ordering.
 | [2026-05-15-recordops-diff](2026-05-15-recordops-diff.md) | recordops + recordops/diff | Done |
 | [2026-06-02-transaction-message](2026-06-02-transaction-message.md) | transaction-message | Approved |
 | [2026-06-02-recordset-computed-columns](2026-06-02-recordset-computed-columns.md) | recordset-computed-columns | Draft |
+| [2026-06-05-dtql](2026-06-05-dtql.md) | dtql | Approved |
 
 ## Open Questions
 


### PR DESCRIPTION
New top-level **`dtql`** package Feature (spec only): a **1:1 lossless YAML serialization of the existing `dal.StructuredQuery`**.

**Scope — core relational read-only subset:** join-free `From` over a root `CollectionRef`, `Columns`, `Where` (`Comparison` + And/Or `GroupCondition`, inline `Constant`/`Array`, operators `== In > >= < <=`), `OrderBy`, `Limit`/`Offset`. Out-of-scope constructs (joins, `GroupBy`, functions, cursor, `CollectionGroupRef`/parented refs, `TextQuery` `QueryArg` params) are **rejected, never silently dropped**.

**Guarantees:** lossless both ways — structural-AST equality *and* canonical-YAML equality. Deliverable is a Go (de)serializer + documented shape; round-trip tests are the guarantee. 8 REQs / 8 ACs (all Given/When/Then), lint-clean.

**Realizes** the cross-repo idea `specscore:idea/dtql-datatug-query-language@github.com/datatug/datatug` (the serve-brokered query builder consumes DTQL-YAML).

**Reviewer gate:** AI `spec-reviewer` **Approved (Grade A)** — it caught a real model bug on the first pass (`QueryArg` is a `TextQuery` concept, not `StructuredQuery`), which was corrected against the `dal` source and re-verified; `owner-approval` **Approved**.

Rebased on top of `main` (includes #53). The pre-existing `recordset-computed-columns` idea-sync drift was fixed separately in #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
