### PR TITLE
feat: source-qualified, multi-key ORDER BY resolution in dalgo2memory

### DIFF
--- a/dalgo2memory/database.go
+++ b/dalgo2memory/database.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"sort"
 	"sync"
 
 	"github.com/dal-go/dalgo/dal"
@@ -261,10 +260,18 @@ func (s session) ExecuteQueryToRecordsReader(_ context.Context, query dal.Query)
 	if len(q.From().Joins()) > 0 {
 		return s.executeJoinQuery(q)
 	}
-	collectionName := q.From().Base().Name()
+	base := q.From().Base()
+	collectionName := base.Name()
 	collection := s.db.collections[collectionName]
 	if len(collection) == 0 {
 		return dal.NewRecordsReader([]dal.Record{}), nil
+	}
+	known := map[string]bool{"": true, base.Name(): true}
+	if a := base.Alias(); a != "" {
+		known[a] = true
+	}
+	if err := validateOrderSources(q.OrderBy(), known); err != nil {
+		return nil, err
 	}
 	rows := make([]memoryRow, 0, len(collection))
 	for id, b := range collection {
@@ -277,7 +284,15 @@ func (s session) ExecuteQueryToRecordsReader(_ context.Context, query dal.Query)
 		}
 		rows = append(rows, memoryRow{id: id, data: data, raw: b})
 	}
-	sortRows(rows, q.OrderBy())
+	orderBySources(rows, q.OrderBy(),
+		func(r memoryRow) map[string]map[string]any {
+			src := map[string]map[string]any{"": r.data, base.Name(): r.data}
+			if a := base.Alias(); a != "" {
+				src[a] = r.data
+			}
+			return src
+		},
+		func(r memoryRow) string { return r.id })
 	if limit := q.Limit(); limit > 0 && limit < len(rows) {
 		rows = rows[:limit]
 	}
@@ -368,24 +383,6 @@ func matchesWhere(data map[string]any, condition dal.Condition) bool {
 		return false
 	}
 	return data[field.Name()] == constant.Value
-}
-
-func sortRows(rows []memoryRow, orderBy []dal.OrderExpression) {
-	if len(orderBy) == 0 {
-		sort.Slice(rows, func(i, j int) bool { return rows[i].id < rows[j].id })
-		return
-	}
-	sort.Slice(rows, func(i, j int) bool {
-		field, ok := orderBy[0].Expression().(dal.FieldRef)
-		if !ok {
-			return rows[i].id < rows[j].id
-		}
-		cmp := compare(rows[i].data[field.Name()], rows[j].data[field.Name()])
-		if orderBy[0].Descending() {
-			return cmp > 0
-		}
-		return cmp < 0
-	})
 }
 
 func compare(a, b any) int {

--- a/dalgo2memory/database_test.go
+++ b/dalgo2memory/database_test.go
@@ -209,10 +209,6 @@ func TestQueryHelperBranches(t *testing.T) {
 		Right:    dal.Field("Other"),
 	}))
 
-	rows := []memoryRow{{id: "b", data: map[string]any{"Name": "b"}}, {id: "a", data: map[string]any{"Name": "a"}}}
-	sortRows(rows, []dal.OrderExpression{dal.Ascending(dal.Constant{Value: "not field"})})
-	require.Equal(t, "a", rows[0].id)
-
 	require.Equal(t, -1, compare("a", "b"))
 	require.Equal(t, 1, compare("b", "a"))
 	require.Equal(t, 0, compare("a", "a"))

--- a/dalgo2memory/join.go
+++ b/dalgo2memory/join.go
@@ -41,6 +41,10 @@ func (s session) executeJoinQuery(q dal.StructuredQuery) (dal.RecordsReader, err
 	joinKey := sourceKey(join)
 	known := map[string]bool{"": true, baseKey: true, joinKey: true}
 
+	if err := validateOrderSources(q.OrderBy(), known); err != nil {
+		return nil, err
+	}
+
 	baseRows, err := s.loadRows(base.Name())
 	if err != nil {
 		return nil, err
@@ -108,6 +112,23 @@ func sourceKey(rs dal.RecordsetSource) string {
 		return a
 	}
 	return rs.Name()
+}
+
+// validateOrderSources rejects an ORDER BY FieldRef whose non-empty Source()
+// names no recordset in the query, before sorting (the sort callback cannot
+// return an error). A non-FieldRef key is not an error here — it is skipped
+// during the sort.
+func validateOrderSources(orderBy []dal.OrderExpression, known map[string]bool) error {
+	for _, oe := range orderBy {
+		f, ok := oe.Expression().(dal.FieldRef)
+		if !ok {
+			continue
+		}
+		if src := f.Source(); src != "" && !known[src] {
+			return fmt.Errorf("dalgo2memory: ORDER BY field %q references unknown source %q", f.Name(), src)
+		}
+	}
+	return nil
 }
 
 // orderJoinedRows stably sorts rows by the ORDER BY expressions in declared

--- a/dalgo2memory/join.go
+++ b/dalgo2memory/join.go
@@ -83,7 +83,7 @@ func (s session) executeJoinQuery(q dal.StructuredQuery) (dal.RecordsReader, err
 		}
 	}
 
-	sort.SliceStable(filtered, func(i, j int) bool { return filtered[i].baseID < filtered[j].baseID })
+	orderJoinedRows(filtered, q.OrderBy())
 
 	if limit := q.Limit(); limit > 0 && limit < len(filtered) {
 		filtered = filtered[:limit]
@@ -108,6 +108,30 @@ func sourceKey(rs dal.RecordsetSource) string {
 		return a
 	}
 	return rs.Name()
+}
+
+// orderJoinedRows stably sorts rows by the ORDER BY expressions in declared
+// order, resolving each FieldRef key against its source (empty Source() -> the
+// base, carried under the "" key of each row's sources map; non-empty -> the
+// recordset whose Alias()/Name() it matches). Each key honors its Descending()
+// flag; a non-FieldRef key is skipped; ties fall back to the base record id.
+func orderJoinedRows(rows []joinedRow, orderBy []dal.OrderExpression) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		for _, oe := range orderBy {
+			f, ok := oe.Expression().(dal.FieldRef)
+			if !ok {
+				continue
+			}
+			c := compare(rows[i].sources[f.Source()][f.Name()], rows[j].sources[f.Source()][f.Name()])
+			if oe.Descending() {
+				c = -c
+			}
+			if c != 0 {
+				return c < 0
+			}
+		}
+		return rows[i].baseID < rows[j].baseID
+	})
 }
 
 func (s session) loadRows(collectionName string) ([]memoryRow, error) {

--- a/dalgo2memory/join.go
+++ b/dalgo2memory/join.go
@@ -131,19 +131,20 @@ func validateOrderSources(orderBy []dal.OrderExpression, known map[string]bool) 
 	return nil
 }
 
-// orderJoinedRows stably sorts rows by the ORDER BY expressions in declared
-// order, resolving each FieldRef key against its source (empty Source() -> the
-// base, carried under the "" key of each row's sources map; non-empty -> the
-// recordset whose Alias()/Name() it matches). Each key honors its Descending()
-// flag; a non-FieldRef key is skipped; ties fall back to the base record id.
-func orderJoinedRows(rows []joinedRow, orderBy []dal.OrderExpression) {
+// orderBySources is the shared ORDER BY comparator for both the single-source
+// and join paths. It stably sorts rows by the ORDER BY expressions in declared
+// order, resolving each FieldRef key against sourcesOf(row) (empty Source() ->
+// the "" entry; non-empty -> the matching source), honoring Descending() per
+// key, skipping non-FieldRef keys, with idOf(row) as the final tiebreak.
+func orderBySources[T any](rows []T, orderBy []dal.OrderExpression, sourcesOf func(T) map[string]map[string]any, idOf func(T) string) {
 	sort.SliceStable(rows, func(i, j int) bool {
+		si, sj := sourcesOf(rows[i]), sourcesOf(rows[j])
 		for _, oe := range orderBy {
 			f, ok := oe.Expression().(dal.FieldRef)
 			if !ok {
 				continue
 			}
-			c := compare(rows[i].sources[f.Source()][f.Name()], rows[j].sources[f.Source()][f.Name()])
+			c := compare(si[f.Source()][f.Name()], sj[f.Source()][f.Name()])
 			if oe.Descending() {
 				c = -c
 			}
@@ -151,8 +152,15 @@ func orderJoinedRows(rows []joinedRow, orderBy []dal.OrderExpression) {
 				return c < 0
 			}
 		}
-		return rows[i].baseID < rows[j].baseID
+		return idOf(rows[i]) < idOf(rows[j])
 	})
+}
+
+// orderJoinedRows orders join result rows via the shared comparator.
+func orderJoinedRows(rows []joinedRow, orderBy []dal.OrderExpression) {
+	orderBySources(rows, orderBy,
+		func(r joinedRow) map[string]map[string]any { return r.sources },
+		func(r joinedRow) string { return r.baseID })
 }
 
 func (s session) loadRows(collectionName string) ([]memoryRow, error) {

--- a/dalgo2memory/join_test.go
+++ b/dalgo2memory/join_test.go
@@ -245,3 +245,80 @@ func TestExecuteJoin_EdgeCases(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+// seedForOrdering loads three matched rows with distinct amounts/status; users
+// carry a colliding "status" field ("zuser") to exercise qualified resolution.
+func seedForOrdering(t *testing.T) (*database, context.Context) {
+	t.Helper()
+	db := NewDB().(*database)
+	ctx := context.Background()
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("users", "1"), &map[string]any{"id": 1, "status": "zuser"})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("users", "2"), &map[string]any{"id": 2, "status": "zuser"})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("orders", "oa"), &map[string]any{"userId": 1, "amount": 30, "status": "c"})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("orders", "ob"), &map[string]any{"userId": 1, "amount": 10, "status": "a"})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("orders", "oc"), &map[string]any{"userId": 2, "amount": 20, "status": "b"})))
+	return db, ctx
+}
+
+func amountSeq(rows []map[string]any) []float64 {
+	out := make([]float64, len(rows))
+	for i, r := range rows {
+		out[i] = r["amount"].(float64)
+	}
+	return out
+}
+
+func idSeq(rows []map[string]any) []float64 {
+	out := make([]float64, len(rows))
+	for i, r := range rows {
+		out[i] = r["id"].(float64)
+	}
+	return out
+}
+
+func innerJoinQuery(order ...dal.OrderExpression) dal.Query {
+	join := dal.NewJoinedSource(ordersAlias(), dal.JoinInner, onUserEqOrder())
+	return dal.From(usersAlias()).Join(join).NewQuery().OrderBy(order...).SelectIntoRecord(intoMapRecord())
+}
+
+// Task 1: source-qualified, multi-key ordering with base-id tiebreak.
+func TestExecuteJoin_OrderBy(t *testing.T) {
+	t.Run("by qualified numeric key ascending", func(t *testing.T) {
+		db, ctx := seedForOrdering(t)
+		got := runJoinQuery(t, db, ctx, innerJoinQuery(dal.Ascending(dal.NewFieldRef("o", "amount"))))
+		require.Equal(t, []float64{10, 20, 30}, amountSeq(got))
+	})
+
+	t.Run("by qualified colliding key uses the order's source", func(t *testing.T) {
+		db, ctx := seedForOrdering(t)
+		got := runJoinQuery(t, db, ctx, innerJoinQuery(dal.Ascending(dal.NewFieldRef("o", "status"))))
+		// o.status a,b,c -> amounts 10,20,30; status values are the order's, not "zuser".
+		require.Equal(t, []float64{10, 20, 30}, amountSeq(got))
+		for _, r := range got {
+			require.NotEqual(t, "zuser", r["status"])
+		}
+	})
+
+	t.Run("multiple keys: u.id asc then o.amount desc", func(t *testing.T) {
+		db, ctx := seedForOrdering(t)
+		got := runJoinQuery(t, db, ctx, innerJoinQuery(
+			dal.Ascending(dal.NewFieldRef("u", "id")),
+			dal.Descending(dal.NewFieldRef("o", "amount")),
+		))
+		require.Equal(t, []float64{1, 1, 2}, idSeq(got))
+		require.Equal(t, []float64{30, 10, 20}, amountSeq(got))
+	})
+
+	t.Run("no ORDER BY falls back to base-id order", func(t *testing.T) {
+		db, ctx := seedForOrdering(t)
+		got := runJoinQuery(t, db, ctx, innerJoinQuery())
+		require.Equal(t, []float64{1, 1, 2}, idSeq(got))
+	})
+
+	t.Run("all keys equal falls back to base-id order", func(t *testing.T) {
+		db, ctx := seedForOrdering(t)
+		// u.status is "zuser" for every row -> all equal -> base-id tiebreak.
+		got := runJoinQuery(t, db, ctx, innerJoinQuery(dal.Ascending(dal.NewFieldRef("u", "status"))))
+		require.Equal(t, []float64{1, 1, 2}, idSeq(got))
+	})
+}

--- a/dalgo2memory/join_test.go
+++ b/dalgo2memory/join_test.go
@@ -322,3 +322,20 @@ func TestExecuteJoin_OrderBy(t *testing.T) {
 		require.Equal(t, []float64{1, 1, 2}, idSeq(got))
 	})
 }
+
+// Task 2: ORDER BY edge handling.
+func TestExecuteJoin_OrderByEdges(t *testing.T) {
+	t.Run("unknown ORDER BY source errors", func(t *testing.T) {
+		db, ctx := seedForOrdering(t)
+		q := innerJoinQuery(dal.Ascending(dal.NewFieldRef("z", "foo")))
+		reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+		require.Nil(t, reader)
+		require.ErrorContains(t, err, "unknown source")
+	})
+
+	t.Run("non-field ORDER BY key is skipped, rows returned in base-id order", func(t *testing.T) {
+		db, ctx := seedForOrdering(t)
+		got := runJoinQuery(t, db, ctx, innerJoinQuery(dal.Ascending(dal.Constant{Value: 1})))
+		require.Equal(t, []float64{1, 1, 2}, idSeq(got))
+	})
+}

--- a/dalgo2memory/order_test.go
+++ b/dalgo2memory/order_test.go
@@ -1,0 +1,75 @@
+package dalgo2memory
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/stretchr/testify/require"
+)
+
+type orderThing struct {
+	Name string `json:"Name"`
+}
+
+func seedThings(t *testing.T) (*database, context.Context) {
+	t.Helper()
+	db := NewDB().(*database)
+	ctx := context.Background()
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("things", "1"), &orderThing{Name: "b"})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("things", "2"), &orderThing{Name: "a"})))
+	return db, ctx
+}
+
+func thingsQuery(alias string, order ...dal.OrderExpression) dal.Query {
+	return dal.From(dal.NewRootCollectionRef("things", alias)).NewQuery().OrderBy(order...).
+		SelectIntoRecord(func() dal.Record {
+			return dal.NewRecordWithIncompleteKey("things", reflect.String, &orderThing{})
+		})
+}
+
+func runSingleSource(t *testing.T, db *database, ctx context.Context, q dal.Query) []string {
+	t.Helper()
+	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+	require.NoError(t, err)
+	var names []string
+	for {
+		rec, err := reader.Next()
+		if errors.Is(err, dal.ErrNoMoreRecords) {
+			break
+		}
+		require.NoError(t, err)
+		names = append(names, rec.Data().(*orderThing).Name)
+	}
+	return names
+}
+
+// Task 3: single-source ordering is unchanged through the shared comparator.
+func TestSingleSource_OrderBy(t *testing.T) {
+	t.Run("unqualified ascending then descending", func(t *testing.T) {
+		db, ctx := seedThings(t)
+		require.Equal(t, []string{"a", "b"}, runSingleSource(t, db, ctx, thingsQuery("", dal.AscendingField("Name"))))
+		require.Equal(t, []string{"b", "a"}, runSingleSource(t, db, ctx, thingsQuery("", dal.DescendingField("Name"))))
+	})
+
+	t.Run("no ORDER BY returns rows in base-id order", func(t *testing.T) {
+		db, ctx := seedThings(t)
+		// ids "1" (Name b), "2" (Name a) -> base-id order is b, a.
+		require.Equal(t, []string{"b", "a"}, runSingleSource(t, db, ctx, thingsQuery("")))
+	})
+
+	t.Run("alias-qualified ORDER BY resolves to the base", func(t *testing.T) {
+		db, ctx := seedThings(t)
+		got := runSingleSource(t, db, ctx, thingsQuery("t", dal.Ascending(dal.NewFieldRef("t", "Name"))))
+		require.Equal(t, []string{"a", "b"}, got)
+	})
+
+	t.Run("unknown ORDER BY source errors", func(t *testing.T) {
+		db, ctx := seedThings(t)
+		reader, err := db.ExecuteQueryToRecordsReader(ctx, thingsQuery("", dal.Ascending(dal.NewFieldRef("x", "Name"))))
+		require.Nil(t, reader)
+		require.ErrorContains(t, err, "unknown source")
+	})
+}

--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -18,7 +18,7 @@ The Feature format follows [SpecScore](https://specscore.md/feature-specificatio
 | [recordset-computed-columns](recordset-computed-columns/README.md) | Approved | — |
 | [dtql](dtql/README.md) | Approved | — |
 | [query-joins](query-joins/README.md) | Approved | — |
-| [qualified-orderby-resolution](qualified-orderby-resolution/README.md) | Under Review | — |
+| [qualified-orderby-resolution](qualified-orderby-resolution/README.md) | Approved | — |
 
 ## Open Questions
 

--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -18,6 +18,7 @@ The Feature format follows [SpecScore](https://specscore.md/feature-specificatio
 | [recordset-computed-columns](recordset-computed-columns/README.md) | Approved | — |
 | [dtql](dtql/README.md) | Approved | — |
 | [query-joins](query-joins/README.md) | Approved | — |
+| [qualified-orderby-resolution](qualified-orderby-resolution/README.md) | Under Review | — |
 
 ## Open Questions
 

--- a/spec/features/qualified-orderby-resolution/README.md
+++ b/spec/features/qualified-orderby-resolution/README.md
@@ -1,11 +1,12 @@
 # Feature: Source-qualified, multi-key ORDER BY resolution in dalgo2memory
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/qualified-orderby-resolution?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/qualified-orderby-resolution?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/qualified-orderby-resolution?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/qualified-orderby-resolution?op=request-change) |
-**Status:** Under Review
+**Status:** Approved
 **Date:** 2026-06-05
 **Owner:** alex
 **Source Ideas:** qualified-orderby-resolution
 **Supersedes:** —
+**Grade:** A
 
 ## Summary
 

--- a/spec/features/qualified-orderby-resolution/README.md
+++ b/spec/features/qualified-orderby-resolution/README.md
@@ -1,0 +1,137 @@
+# Feature: Source-qualified, multi-key ORDER BY resolution in dalgo2memory
+
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/qualified-orderby-resolution?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/qualified-orderby-resolution?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/qualified-orderby-resolution?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/qualified-orderby-resolution?op=request-change) |
+**Status:** Under Review
+**Date:** 2026-06-05
+**Owner:** alex
+**Source Ideas:** qualified-orderby-resolution
+**Supersedes:** —
+
+## Summary
+
+Gives `dalgo2memory` one source-aware, multi-key `ORDER BY` comparator shared by single-source and join queries: each order key resolves to the recordset its `FieldRef.Source()` names, multiple keys order in declared precedence, and a base-record-id tiebreak keeps the result deterministic. This completes the deferred `OrderBy` resolution the `query-joins` Feature left as an open question.
+
+## Problem
+
+`dalgo2memory` orders results two divergent, incomplete ways. The single-source `sortRows` sorts by a **single** bare field name (`orderBy[0]`, ignoring `FieldRef.Source()`), and the join executor **ignores `OrderBy` entirely**, sorting only by base record id. So a join `ORDER BY o.createdAt` has no effect, a multi-key order is impossible, and a qualified key under a name collision (`u.status` vs `o.status`) cannot be ordered correctly because the join's merged output map overlays one source over the other. The qualified-field resolver already exists for the join `WHERE` clause; this Feature extends the same resolution to ordering and unifies the two sort paths.
+
+## Behavior
+
+### Resolution and ordering
+
+`ORDER BY` keys are resolved against the same per-source data the join `WHERE` clause uses, then applied as an ordered, multi-key comparison.
+
+#### REQ: source-qualified-key-resolution
+
+Each `ORDER BY` `FieldRef` key MUST be resolved to a recordset by its `Source()`: an empty source denotes the `From` base; a non-empty source denotes the recordset whose `Alias()` (falling back to `Name()`) matches. In a join query the value MUST be read from that source's own row data, so a key under a name collision (`u.status` vs `o.status`) orders by the named source's value, not whichever the merged output map happened to retain.
+
+#### REQ: multi-key-ordering
+
+Results MUST be ordered by the `OrderBy()` expressions in declared order: rows compare on the first key, and only when that key compares equal do they compare on the next, and so on. Each key MUST independently honor its `Descending()` flag.
+
+#### REQ: deterministic-tiebreak
+
+When every `ORDER BY` key compares equal, or no `ORDER BY` is given, rows MUST fall back to a deterministic order by base record id, so results are stable across runs.
+
+### Edge handling
+
+#### REQ: unresolvable-order-source-errors
+
+An `ORDER BY` `FieldRef` whose non-empty `Source()` names no recordset in the query MUST produce a descriptive error and yield no rows — consistent with the join `WHERE` clause's unresolvable-source behavior — rather than silently falling back to the tiebreak order.
+
+#### REQ: non-field-order-key
+
+An `ORDER BY` expression that is not a `FieldRef` (e.g. a constant or computed expression) MUST NOT cause a crash; it contributes nothing to ordering and the rows retain the deterministic tiebreak order, mirroring the current single-source behavior.
+
+### Unification
+
+#### REQ: unified-single-source-unchanged
+
+Single-source and join queries MUST share one ordering implementation. A single-source query whose `ORDER BY` fields are unqualified (empty `Source()`, resolving to the one base recordset) MUST return results in the same order as before this Feature.
+
+## Acceptance Criteria
+
+### AC: join-orders-by-qualified-key (verifies REQ:source-qualified-key-resolution)
+
+**Given** an INNER join of `users u` and `orders o` where both rows carry a colliding `status` field and the orders differ in `o.amount`
+**When** the query is executed with `ORDER BY o.amount` ascending
+**Then** the result rows are in ascending `o.amount` order, and ordering by `o.status` orders by the order's status value rather than the user's.
+
+### AC: orders-by-multiple-keys (verifies REQ:multi-key-ordering)
+
+**Given** a join result with two order keys — primary `u.id` ascending, secondary `o.amount` descending
+**When** the query is executed
+**Then** rows are ordered by `u.id` ascending, and within equal `u.id` by `o.amount` descending.
+
+### AC: deterministic-tiebreak-by-base-id (verifies REQ:deterministic-tiebreak)
+
+**Given** a join query with no `ORDER BY` (or whose keys all compare equal)
+**When** it is executed
+**Then** the rows are returned in ascending base-record-id order, deterministically across runs.
+
+### AC: unresolvable-order-source-errors (verifies REQ:unresolvable-order-source-errors)
+
+**Given** a join query with `ORDER BY z.foo` where `z` names neither recordset
+**When** it is executed
+**Then** it returns a descriptive error naming the unresolved source and yields no result rows.
+
+### AC: non-field-order-key-ignored (verifies REQ:non-field-order-key)
+
+**Given** a query whose `ORDER BY` expression is a non-`FieldRef` (e.g. a constant)
+**When** it is executed
+**Then** it returns its rows without error, in the deterministic base-id tiebreak order.
+
+### AC: single-source-order-unchanged (verifies REQ:unified-single-source-unchanged)
+
+**Given** an existing single-source query ordered by an unqualified field, ascending and (separately) descending
+**When** it is executed through the unified comparator
+**Then** the result order matches the pre-Feature `sortRows` behavior for both directions.
+
+## Architecture & Components
+
+- **Shared comparator (`dalgo2memory`).** A single ordering routine takes the `[]dal.OrderExpression` and, per row, a way to resolve a `FieldRef` to a value. It pre-resolves/validates the keys (surfacing `unresolvable-order-source-errors` before sorting, since `sort` callbacks cannot return errors), then performs a stable multi-key sort using the existing `compare()` helper, with base-record-id as the final tiebreak.
+- **Single-source path (`ExecuteQueryToRecordsReader`).** Replaces `sortRows`; resolves an empty/base-matching `Source()` against the one base recordset's `data` map.
+- **Join path (`executeJoinQuery`).** Replaces the base-id-only `sort.SliceStable`; resolves each key against the per-source map already built for `WHERE` (empty → base, alias/name → joined source), reusing the join resolver.
+
+## Data Flow
+
+Rows are produced (single-source scan or join nested loop) → each `ORDER BY` key is resolved/validated against the query's known sources (unknown non-empty source → error, returned before sorting) → rows are stably sorted key-by-key in declared order with per-key `Descending()`, falling back to base-id → `Limit` → output records.
+
+## Error Handling & Failure Modes
+
+- `ORDER BY` key with an unknown non-empty source → descriptive error, no rows (`REQ:unresolvable-order-source-errors`).
+- `ORDER BY` key that is not a `FieldRef` → ignored for ordering, no error (`REQ:non-field-order-key`).
+- A qualified key resolving to an absent value (e.g. the joined source on an unmatched LEFT row) sorts by that absent/zero value via `compare()`, not an error.
+
+## Testing Strategy
+
+Table tests in `dalgo2memory`: a join ordered by a qualified numeric key and by a colliding `status` key; a two-key order (asc then desc); the no-`ORDER BY` / all-equal tiebreak; the unknown-source error; a non-`FieldRef` key; and the single-source ascending/descending order through the unified comparator (asserting parity with prior behavior). `dalgo2memory` MUST remain at 100% statement coverage, so every branch of the comparator and key-resolution is exercised.
+
+## Rehearse Integration
+
+All six ACs are testable through pure Go execution over in-memory collections, so they map directly to `dalgo2memory` table tests (see `## Testing Strategy`). Per-AC Rehearse stub files are deferred to the Plan, where each AC becomes a concrete `*_test.go` case; the rehearsal surface is the Go test suite.
+
+## Out of Scope
+
+- Column projection in `dalgo2memory` (`q.Columns()` is unimplemented adapter-wide) — parked as the sidekick seed `dalgo2memory-column-projection`.
+- `NULLS FIRST`/`NULLS LAST` control — absent/zero values fall out of `compare()`'s natural order.
+- `ORDER BY` on functions/computed expressions as orderable keys — non-`FieldRef` keys are ignored, not evaluated.
+- SQL adapter ordering (`dalgo2sql`/`dalgo2sqlite`) — separate repos.
+- Self-joins and 3+ table ordering — single two-table join, matching the `query-joins` MVP.
+
+## Assumption Carryover
+
+From the source Idea `qualified-orderby-resolution`:
+
+- **Carried (Must):** the join `WHERE` per-source resolver backs `ORDER BY` too, with no new aliasing machinery — validated by `AC:join-orders-by-qualified-key`.
+- **Carried (Must):** unifying single-source ordering into the source-aware comparator does not change existing single-source results — validated by `AC:single-source-order-unchanged`.
+- **Carried (Should):** `compare()` plus key-by-key short-circuit gives deterministic multi-key order — validated by `AC:orders-by-multiple-keys` and `AC:deterministic-tiebreak-by-base-id`.
+- **Resolved (was Should/open question):** an `ORDER BY` key naming no recordset **errors** (not silent fallback) — now `REQ:unresolvable-order-source-errors`; the same rule resolves the Idea's single-source non-matching-source open question (non-base source → error).
+- **Deferred (Might):** whether consumers need multi-key now — this Feature commits to multi-key regardless, as the comparator cost is the same.
+
+## Open Questions
+
+- Final location/signature of the shared comparator so both entry points use it without exposing `dalgo2memory` internals — an implementation detail for the Plan.
+
+---
+*This document follows the https://specscore.md/feature-specification*

--- a/spec/features/qualified-orderby-resolution/README.md
+++ b/spec/features/qualified-orderby-resolution/README.md
@@ -41,7 +41,7 @@ An `ORDER BY` `FieldRef` whose non-empty `Source()` names no recordset in the qu
 
 #### REQ: non-field-order-key
 
-An `ORDER BY` expression that is not a `FieldRef` (e.g. a constant or computed expression) MUST NOT cause a crash; it contributes nothing to ordering and the rows retain the deterministic tiebreak order, mirroring the current single-source behavior.
+An `ORDER BY` expression that is not a `FieldRef` (e.g. a constant or computed expression) MUST NOT cause a crash; it is skipped as an ordering key, and the remaining keys (and finally the base-id tiebreak) still apply.
 
 ### Unification
 
@@ -63,17 +63,29 @@ Single-source and join queries MUST share one ordering implementation. A single-
 **When** the query is executed
 **Then** rows are ordered by `u.id` ascending, and within equal `u.id` by `o.amount` descending.
 
-### AC: deterministic-tiebreak-by-base-id (verifies REQ:deterministic-tiebreak)
+### AC: tiebreak-no-order-by (verifies REQ:deterministic-tiebreak)
 
-**Given** a join query with no `ORDER BY` (or whose keys all compare equal)
+**Given** a join query with no `ORDER BY`
 **When** it is executed
 **Then** the rows are returned in ascending base-record-id order, deterministically across runs.
+
+### AC: tiebreak-all-keys-equal (verifies REQ:deterministic-tiebreak)
+
+**Given** a join query ordered by a key whose value is equal across all result rows
+**When** it is executed
+**Then** the rows fall back to ascending base-record-id order.
 
 ### AC: unresolvable-order-source-errors (verifies REQ:unresolvable-order-source-errors)
 
 **Given** a join query with `ORDER BY z.foo` where `z` names neither recordset
 **When** it is executed
 **Then** it returns a descriptive error naming the unresolved source and yields no result rows.
+
+### AC: single-source-unresolvable-order-source (verifies REQ:unresolvable-order-source-errors)
+
+**Given** a single-source query whose `ORDER BY` key has a non-empty `Source()` that matches neither the base recordset's alias nor its name
+**When** it is executed
+**Then** it returns a descriptive error and yields no result rows (the same rule as joins).
 
 ### AC: non-field-order-key-ignored (verifies REQ:non-field-order-key)
 
@@ -109,7 +121,7 @@ Table tests in `dalgo2memory`: a join ordered by a qualified numeric key and by 
 
 ## Rehearse Integration
 
-All six ACs are testable through pure Go execution over in-memory collections, so they map directly to `dalgo2memory` table tests (see `## Testing Strategy`). Per-AC Rehearse stub files are deferred to the Plan, where each AC becomes a concrete `*_test.go` case; the rehearsal surface is the Go test suite.
+All eight ACs are testable through pure Go execution over in-memory collections, so they map directly to `dalgo2memory` table tests (see `## Testing Strategy`). Per-AC Rehearse stub files are deferred to the Plan, where each AC becomes a concrete `*_test.go` case; the rehearsal surface is the Go test suite.
 
 ## Out of Scope
 
@@ -125,7 +137,7 @@ From the source Idea `qualified-orderby-resolution`:
 
 - **Carried (Must):** the join `WHERE` per-source resolver backs `ORDER BY` too, with no new aliasing machinery — validated by `AC:join-orders-by-qualified-key`.
 - **Carried (Must):** unifying single-source ordering into the source-aware comparator does not change existing single-source results — validated by `AC:single-source-order-unchanged`.
-- **Carried (Should):** `compare()` plus key-by-key short-circuit gives deterministic multi-key order — validated by `AC:orders-by-multiple-keys` and `AC:deterministic-tiebreak-by-base-id`.
+- **Carried (Should):** `compare()` plus key-by-key short-circuit gives deterministic multi-key order — validated by `AC:orders-by-multiple-keys`, `AC:tiebreak-no-order-by`, and `AC:tiebreak-all-keys-equal`.
 - **Resolved (was Should/open question):** an `ORDER BY` key naming no recordset **errors** (not silent fallback) — now `REQ:unresolvable-order-source-errors`; the same rule resolves the Idea's single-source non-matching-source open question (non-base source → error).
 - **Deferred (Might):** whether consumers need multi-key now — this Feature commits to multi-key regardless, as the comparator cost is the same.
 

--- a/spec/ideas/README.md
+++ b/spec/ideas/README.md
@@ -13,7 +13,7 @@ The Idea format follows [SpecScore](https://specscore.md/idea-specification).
 | [dalgo-dialect-aware-sql-emission](dalgo-dialect-aware-sql-emission.md) | Draft | 2026-05-15 | alex | — |
 | [dalgo-schema-modification](dalgo-schema-modification.md) | Approved | 2026-05-12 | alex | — |
 | [first-class-query-joins](first-class-query-joins.md) | Specified | 2026-06-05 | alexander.trakhimenok | query-joins |
-| [qualified-orderby-resolution](qualified-orderby-resolution.md) | Draft | 2026-06-05 | alex | — |
+| [qualified-orderby-resolution](qualified-orderby-resolution.md) | Approved | 2026-06-05 | alex | — |
 | [recordops](recordops.md) | Approved | 2026-05-15 | alex | — |
 | [recordset-computed-columns](recordset-computed-columns.md) | Specified | 2026-06-02 | alex | recordset-computed-columns |
 | [transaction-message](transaction-message.md) | Approved | 2026-06-02 | alex | — |

--- a/spec/ideas/README.md
+++ b/spec/ideas/README.md
@@ -13,6 +13,7 @@ The Idea format follows [SpecScore](https://specscore.md/idea-specification).
 | [dalgo-dialect-aware-sql-emission](dalgo-dialect-aware-sql-emission.md) | Draft | 2026-05-15 | alex | — |
 | [dalgo-schema-modification](dalgo-schema-modification.md) | Approved | 2026-05-12 | alex | — |
 | [first-class-query-joins](first-class-query-joins.md) | Specified | 2026-06-05 | alexander.trakhimenok | query-joins |
+| [qualified-orderby-resolution](qualified-orderby-resolution.md) | Draft | 2026-06-05 | alex | — |
 | [recordops](recordops.md) | Approved | 2026-05-15 | alex | — |
 | [recordset-computed-columns](recordset-computed-columns.md) | Specified | 2026-06-02 | alex | recordset-computed-columns |
 | [transaction-message](transaction-message.md) | Approved | 2026-06-02 | alex | — |

--- a/spec/ideas/README.md
+++ b/spec/ideas/README.md
@@ -13,7 +13,7 @@ The Idea format follows [SpecScore](https://specscore.md/idea-specification).
 | [dalgo-dialect-aware-sql-emission](dalgo-dialect-aware-sql-emission.md) | Draft | 2026-05-15 | alex | — |
 | [dalgo-schema-modification](dalgo-schema-modification.md) | Approved | 2026-05-12 | alex | — |
 | [first-class-query-joins](first-class-query-joins.md) | Specified | 2026-06-05 | alexander.trakhimenok | query-joins |
-| [qualified-orderby-resolution](qualified-orderby-resolution.md) | Approved | 2026-06-05 | alex | — |
+| [qualified-orderby-resolution](qualified-orderby-resolution.md) | Specified | 2026-06-05 | alex | qualified-orderby-resolution |
 | [recordops](recordops.md) | Approved | 2026-05-15 | alex | — |
 | [recordset-computed-columns](recordset-computed-columns.md) | Specified | 2026-06-02 | alex | recordset-computed-columns |
 | [transaction-message](transaction-message.md) | Approved | 2026-06-02 | alex | — |

--- a/spec/ideas/qualified-orderby-resolution.md
+++ b/spec/ideas/qualified-orderby-resolution.md
@@ -1,9 +1,9 @@
 # Idea: Source-qualified, multi-key ORDER BY resolution in dalgo2memory
 
-**Status:** Approved
+**Status:** Specified
 **Date:** 2026-06-05
 **Owner:** alex
-**Promotes To:** —
+**Promotes To:** qualified-orderby-resolution
 **Supersedes:** —
 **Related Ideas:** —
 

--- a/spec/ideas/qualified-orderby-resolution.md
+++ b/spec/ideas/qualified-orderby-resolution.md
@@ -1,0 +1,64 @@
+# Idea: Source-qualified, multi-key ORDER BY resolution in dalgo2memory
+
+**Status:** Draft
+**Date:** 2026-06-05
+**Owner:** alex
+**Promotes To:** —
+**Supersedes:** —
+**Related Ideas:** —
+
+## Problem Statement
+
+How might we let dalgo2memory order query results by multiple source-qualified ORDER BY keys, resolving each key to the correct recordset, for both single-source and join queries?
+
+## Context
+
+Follow-on to the merged query-joins Feature, which deferred OrderBy/Columns qualifier resolution as an explicit open question. Today dalgo2memory's single-source sortRows sorts by a single bare field name (orderBy[0], ignoring FieldRef.Source()), and the join executor (dalgo2memory/join.go) ignores OrderBy entirely, sorting only by base record id. A join ORDER BY on a source-qualified field (e.g. o.createdAt) therefore has no effect, and a qualified field under a name collision (u.status vs o.status) cannot be ordered correctly because the merged output map overlays one over the other. The qualified-field resolver already exists for WHERE in the join path (resolveJoinExpr over a per-source data map). Columns projection is a separate, larger gap: dalgo2memory never consumes q.Columns() at all (single-source or join), so it is out of scope here and parked as its own idea.
+
+## Recommended Direction
+
+Build one source-aware, multi-key ORDER BY comparator and use it for both paths. Reuse the existing per-source resolution (empty Source() -> From base; non-empty -> the recordset whose Alias()/Name() matches) that WHERE already uses, and reuse the existing compare() helper for value ordering. The comparator walks the OrderBy expressions in order, comparing the resolved value of each key until one differs, honoring Descending() per key, with the base record id as a final deterministic tiebreak. For single-source rows the same comparator resolves an empty-source field against the one base recordset, so sortRows and the join sort collapse into a shared implementation rather than two divergent ones. This completes the query-joins Feature's deferred OrderBy resolution, keeps in-memory behavior a faithful preview of what the SQL adapters will later render, and leaves Columns projection as a clean separate effort.
+
+## Alternatives Considered
+
+- **Join-only ORDER BY, leave `sortRows` untouched.** Smaller blast radius — the working single-source path is not modified. Lost because it leaves two divergent sort implementations (a single-key, name-only one for single-source and a new source-aware one for joins) that will drift; an empty `Source()` already means "the base", so one comparator serves both with no behavior change to single-source.
+- **Order the merged output map instead of the per-source data.** The join executor already builds a flat merged map per row, so sorting by `merged[name]` is the least code. Lost because the merge overlays the joined source over the base, so a qualified key under a name collision (`u.status` vs `o.status`) would silently sort by the wrong source's value — exactly the ambiguity source qualification exists to remove.
+- **Bundle Column projection in now (resolve OrderBy and Columns together).** Both are the same deferred open question and share the resolver. Lost because `q.Columns()` is unimplemented adapter-wide (not just for joins), so it is a build-a-feature effort, not a resolution one; folding it in triples the scope and delays the small, well-defined OrderBy win.
+
+## MVP Scope
+
+A short spike: dalgo2memory orders both join and single-source results by one or more source-qualified ORDER BY keys, ascending or descending per key, resolving each key to its recordset (empty source -> base; alias/name -> that source), with a deterministic base-id tiebreak. Verified by table tests: a join ordered by a qualified key (including under a u/o name collision), a multi-key order (primary asc, secondary desc), and existing single-source ordering still green via the unified comparator. dalgo2memory stays at 100% coverage.
+
+## Not Doing (and Why)
+
+- Column projection in dalgo2memory — q.Columns() is unimplemented adapter-wide; separate idea (parked as a sidekick seed)
+- ORDER BY on non-field expressions (functions, constants, computed) — only FieldRef keys are in scope
+- NULLS FIRST/LAST control — absent/zero values fall out of Go's natural compare() ordering
+- SQL adapter ordering (dalgo2sql, dalgo2sqlite) — separate repos, unblocked by the shared semantics not the code
+- Self-joins / 3+ table ordering — single two-table join, matching the query-joins MVP
+
+## Key Assumptions to Validate
+
+| Tier | Assumption | How to validate |
+|------|------------|-----------------|
+| Must-be-true | The per-source resolution WHERE already uses (empty `Source()` -> base; alias/name -> source) can back ORDER BY too, with no new aliasing machinery. | Build the comparator on the existing resolver and order a join by a qualified key under a `u`/`o` name collision; the correct source's value drives the order. |
+| Must-be-true | Folding single-source ordering into the source-aware comparator does not change existing single-source results. | Run the existing `dalgo2memory` ordering tests unchanged; an empty-`Source()` field must resolve to the one base recordset and sort identically to today. |
+| Should-be-true | `compare()` plus key-by-key short-circuit gives deterministic multi-key ordering across mixed value types. | Table test: order by (numeric asc, string desc); assert stable, total order with the base-id tiebreak. |
+| Should-be-true | An ORDER BY key naming no recordset should error, consistent with the join WHERE `unresolvable-source` behavior. | Decide and test: a qualified key with an unknown source returns a descriptive error rather than silently sorting by base id. |
+| Might-be-true | Consumers (DTQL, datatug) actually need multi-key join ordering now rather than single-key. | Review intended consumers before committing to multi-key over the simpler single-key match to today's `sortRows`. |
+
+
+## SpecScore Integration
+
+- **New Features this would create:** A `dalgo2memory` ORDER BY resolution Feature (or a revision extending `query-joins`) covering the unified source-aware, multi-key comparator.
+- **Existing Features affected:** `query-joins` — completes its deferred OrderBy open question and replaces the join executor's base-id-only sort; the single-source `sortRows` is unified into the shared comparator.
+- **Dependencies:** Upstream — the merged `query-joins` Feature (the qualified-field resolver and join executor). Sibling — the parked Column-projection idea, which shares the same resolver but is independent.
+
+## Open Questions
+
+- Does a qualified ORDER BY key whose source names no recordset error (matching the join WHERE `unresolvable-source-errors` behavior) or fall back to the base-id tiebreak? Lean toward error for consistency.
+- For a single-source query, how is a non-empty `Source()` that does not match the base treated — error, or resolve as base? Settle at spec time.
+- Where the comparator lives so both `ExecuteQueryToRecordsReader` (single-source) and `executeJoinQuery` share it without exposing internals.
+
+---
+*This document follows the https://specscore.md/idea-specification*

--- a/spec/ideas/qualified-orderby-resolution.md
+++ b/spec/ideas/qualified-orderby-resolution.md
@@ -1,6 +1,6 @@
 # Idea: Source-qualified, multi-key ORDER BY resolution in dalgo2memory
 
-**Status:** Draft
+**Status:** Approved
 **Date:** 2026-06-05
 **Owner:** alex
 **Promotes To:** —

--- a/spec/ideas/seeds/dalgo2memory-column-projection.md
+++ b/spec/ideas/seeds/dalgo2memory-column-projection.md
@@ -1,0 +1,19 @@
+---
+type: sidekick-seed
+slug: dalgo2memory-column-projection
+captured_at: 2026-06-05T20:30:32Z
+captured_by: user
+captured_during: spec/ideas/qualified-orderby-resolution
+trigger: explicit
+status: queued
+synchestra_task: null
+---
+# dalgo2memory does not implement Column projection
+
+`dalgo2memory` never consumes `q.Columns()` — neither the single-source path
+nor the join executor projects the selected columns; both return full records.
+Surfaced while scoping qualified ORDER BY resolution (where Columns was
+explicitly cut). Making projection source-qualifier-aware for joins first
+requires implementing column projection in the adapter at all. Shares the
+qualified-field resolver with `qualified-orderby-resolution` but is an
+independent, larger effort.

--- a/spec/plans/2026-06-05-qualified-orderby-resolution.md
+++ b/spec/plans/2026-06-05-qualified-orderby-resolution.md
@@ -1,6 +1,6 @@
 # Plan: Source-qualified, multi-key ORDER BY resolution in dalgo2memory
 
-**Status:** Implementing
+**Status:** Completed
 **Source Feature:** qualified-orderby-resolution
 **Date:** 2026-06-05
 **Owner:** alex

--- a/spec/plans/2026-06-05-qualified-orderby-resolution.md
+++ b/spec/plans/2026-06-05-qualified-orderby-resolution.md
@@ -27,7 +27,7 @@ Build one ordering routine that resolves each `ORDER BY` `FieldRef` to its recor
 
 **Verifies:** qualified-orderby-resolution#ac:unresolvable-order-source-errors, qualified-orderby-resolution#ac:non-field-order-key-ignored
 **Depends-On:** 1
-**Status:** pending
+**Status:** done
 
 Validate the resolved `ORDER BY` keys before sorting (since the sort callback cannot return an error): an `ORDER BY` `FieldRef` whose non-empty source names no recordset returns a descriptive error and no rows, while a non-`FieldRef` expression is skipped as an ordering key with the remaining keys and base-id tiebreak still applied.
 

--- a/spec/plans/2026-06-05-qualified-orderby-resolution.md
+++ b/spec/plans/2026-06-05-qualified-orderby-resolution.md
@@ -1,6 +1,6 @@
 # Plan: Source-qualified, multi-key ORDER BY resolution in dalgo2memory
 
-**Status:** Under Review
+**Status:** Approved
 **Source Feature:** qualified-orderby-resolution
 **Date:** 2026-06-05
 **Owner:** alex

--- a/spec/plans/2026-06-05-qualified-orderby-resolution.md
+++ b/spec/plans/2026-06-05-qualified-orderby-resolution.md
@@ -1,0 +1,44 @@
+# Plan: Source-qualified, multi-key ORDER BY resolution in dalgo2memory
+
+**Status:** Under Review
+**Source Feature:** qualified-orderby-resolution
+**Date:** 2026-06-05
+**Owner:** alex
+**Supersedes:** —
+
+## Summary
+
+Decomposes the `qualified-orderby-resolution` Feature into three linear tasks: build the shared source-aware, multi-key ORDER BY comparator and wire it into the join executor, then add the join-ordering edge cases, then unify the single-source path onto the same comparator. All eight acceptance criteria are covered by a task; none are deferred.
+
+## Approach
+
+The Feature is one comparator used at two call sites, so the order is build-then-adopt. Task 1 creates the comparator (per-key source resolution reusing the join WHERE resolver, key-by-key stable sort via the existing `compare()`, base-id tiebreak) and adopts it in `executeJoinQuery`, replacing the base-id-only sort — its four ACs (qualified key, multi-key, and the two tiebreak branches) are the cohesive core behavior the comparator delivers, so they group on one task. Task 2 adds the comparator's edge handling exercised through the join path: pre-sort validation that errors on an unknown ORDER BY source, and skipping a non-`FieldRef` key. Task 3 retires `sortRows`, routing the single-source path through the same comparator (empty `Source()` -> base) and proving both unchanged ordering and the single-source unknown-source error. Tasks 2 and 3 both depend on Task 1's comparator.
+
+## Tasks
+
+### Task 1: Shared source-aware multi-key comparator, adopted by the join executor
+
+**Verifies:** qualified-orderby-resolution#ac:join-orders-by-qualified-key, qualified-orderby-resolution#ac:orders-by-multiple-keys, qualified-orderby-resolution#ac:tiebreak-no-order-by, qualified-orderby-resolution#ac:tiebreak-all-keys-equal
+
+Build one ordering routine that resolves each `ORDER BY` `FieldRef` to its recordset (empty `Source()` -> base; non-empty -> the source whose `Alias()`/`Name()` matches, reusing the join WHERE resolver), stably sorts rows key-by-key in declared order honoring each `Descending()` via the existing `compare()`, and falls back to ascending base record id. Replace the join executor's base-id-only `sort.SliceStable` with it.
+
+### Task 2: Join ORDER BY edge handling — unknown source errors, non-field keys skipped
+
+**Verifies:** qualified-orderby-resolution#ac:unresolvable-order-source-errors, qualified-orderby-resolution#ac:non-field-order-key-ignored
+**Depends-On:** 1
+
+Validate the resolved `ORDER BY` keys before sorting (since the sort callback cannot return an error): an `ORDER BY` `FieldRef` whose non-empty source names no recordset returns a descriptive error and no rows, while a non-`FieldRef` expression is skipped as an ordering key with the remaining keys and base-id tiebreak still applied.
+
+### Task 3: Unify the single-source path onto the shared comparator
+
+**Verifies:** qualified-orderby-resolution#ac:single-source-order-unchanged, qualified-orderby-resolution#ac:single-source-unresolvable-order-source
+**Depends-On:** 1
+
+Route `ExecuteQueryToRecordsReader` through the shared comparator and remove `sortRows`, resolving an empty/base-matching `Source()` against the single base recordset so existing unqualified ordering (ascending and descending) is unchanged, and a non-empty source that matches neither the base alias nor name errors — the same rule as joins.
+
+## Open Questions
+
+- Final location/signature of the shared comparator so both entry points use it without exposing `dalgo2memory` internals — settled during implementation.
+
+---
+*This document follows the https://specscore.md/plan-specification*

--- a/spec/plans/2026-06-05-qualified-orderby-resolution.md
+++ b/spec/plans/2026-06-05-qualified-orderby-resolution.md
@@ -35,7 +35,7 @@ Validate the resolved `ORDER BY` keys before sorting (since the sort callback ca
 
 **Verifies:** qualified-orderby-resolution#ac:single-source-order-unchanged, qualified-orderby-resolution#ac:single-source-unresolvable-order-source
 **Depends-On:** 1
-**Status:** pending
+**Status:** done
 
 Route `ExecuteQueryToRecordsReader` through the shared comparator and remove `sortRows`, resolving an empty/base-matching `Source()` against the single base recordset so existing unqualified ordering (ascending and descending) is unchanged, and a non-empty source that matches neither the base alias nor name errors — the same rule as joins.
 

--- a/spec/plans/2026-06-05-qualified-orderby-resolution.md
+++ b/spec/plans/2026-06-05-qualified-orderby-resolution.md
@@ -1,6 +1,6 @@
 # Plan: Source-qualified, multi-key ORDER BY resolution in dalgo2memory
 
-**Status:** Approved
+**Status:** Implementing
 **Source Feature:** qualified-orderby-resolution
 **Date:** 2026-06-05
 **Owner:** alex
@@ -19,6 +19,7 @@ The Feature is one comparator used at two call sites, so the order is build-then
 ### Task 1: Shared source-aware multi-key comparator, adopted by the join executor
 
 **Verifies:** qualified-orderby-resolution#ac:join-orders-by-qualified-key, qualified-orderby-resolution#ac:orders-by-multiple-keys, qualified-orderby-resolution#ac:tiebreak-no-order-by, qualified-orderby-resolution#ac:tiebreak-all-keys-equal
+**Status:** done
 
 Build one ordering routine that resolves each `ORDER BY` `FieldRef` to its recordset (empty `Source()` -> base; non-empty -> the source whose `Alias()`/`Name()` matches, reusing the join WHERE resolver), stably sorts rows key-by-key in declared order honoring each `Descending()` via the existing `compare()`, and falls back to ascending base record id. Replace the join executor's base-id-only `sort.SliceStable` with it.
 
@@ -26,6 +27,7 @@ Build one ordering routine that resolves each `ORDER BY` `FieldRef` to its recor
 
 **Verifies:** qualified-orderby-resolution#ac:unresolvable-order-source-errors, qualified-orderby-resolution#ac:non-field-order-key-ignored
 **Depends-On:** 1
+**Status:** pending
 
 Validate the resolved `ORDER BY` keys before sorting (since the sort callback cannot return an error): an `ORDER BY` `FieldRef` whose non-empty source names no recordset returns a descriptive error and no rows, while a non-`FieldRef` expression is skipped as an ordering key with the remaining keys and base-id tiebreak still applied.
 
@@ -33,6 +35,7 @@ Validate the resolved `ORDER BY` keys before sorting (since the sort callback ca
 
 **Verifies:** qualified-orderby-resolution#ac:single-source-order-unchanged, qualified-orderby-resolution#ac:single-source-unresolvable-order-source
 **Depends-On:** 1
+**Status:** pending
 
 Route `ExecuteQueryToRecordsReader` through the shared comparator and remove `sortRows`, resolving an empty/base-matching `Source()` against the single base recordset so existing unqualified ordering (ascending and descending) is unchanged, and a non-empty source that matches neither the base alias nor name errors — the same rule as joins.
 


### PR DESCRIPTION
## Summary

Gives `dalgo2memory` one source-aware, multi-key `ORDER BY` comparator shared by single-source and join queries. Completes the `OrderBy` resolution the merged `query-joins` Feature deferred as an open question: a join `ORDER BY` on a source-qualified field now takes effect, multi-key ordering works, and a qualified key under a name collision (`u.status` vs `o.status`) orders by the named source's value.

Full SpecStudio chain: Idea → Feature (`spec/features/qualified-orderby-resolution/`, Grade A) → Plan (`spec/plans/2026-06-05-qualified-orderby-resolution.md`) → implementation.

## What changed

- **`orderBySources`** — a generic, source-aware, multi-key comparator: resolves each `ORDER BY` `FieldRef` to its recordset (empty `Source()` → base; non-empty → the source whose `Alias()`/`Name()` matches), honors per-key `Descending()`, skips non-`FieldRef` keys, and falls back to a base-record-id tiebreak.
- **Join executor** now orders via the comparator (replacing the base-id-only sort).
- **Single-source path** (`ExecuteQueryToRecordsReader`) routed through the same comparator; **`sortRows` retired**. Existing unqualified single-source ordering is unchanged.
- **Validation:** an `ORDER BY` key whose non-empty source names no recordset returns a descriptive error and no rows — for both join and single-source queries.

## Out of scope (follow-ons)
Column projection in `dalgo2memory` (parked seed `dalgo2memory-column-projection`), `NULLS FIRST/LAST`, non-`FieldRef` keys as orderable, SQL adapters, self-joins.

## Verification
- `go build ./...`, `go vet ./...`, `go test ./...` — all pass.
- `golangci-lint run ./...` — 0 issues.
- **Total coverage 100%** (`dalgo2memory` kept at 100%).
- All **8 acceptance criteria** traced to commits via `Verifies:` trailers (one feature per task; see history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)