### PR TITLE
feat: column selection in query builder, projected by dalgo2memory

### DIFF
--- a/dal/q_builder.go
+++ b/dal/q_builder.go
@@ -23,6 +23,7 @@ type IQueryBuilder interface {
 	SelectIntoRecord(func() Record) StructuredQuery
 	SelectIntoRecordset(options ...recordset.Option) StructuredQuery
 	SelectKeysOnly(idKind reflect.Kind) StructuredQuery
+	SelectColumns(columns ...Column) StructuredQuery
 	StartFrom(cursor Cursor) IQueryBuilder
 }
 
@@ -109,6 +110,12 @@ func (s *QueryBuilder) SelectIntoRecordset(options ...recordset.Option) Structur
 func (s *QueryBuilder) SelectKeysOnly(idKind reflect.Kind) StructuredQuery {
 	q := s.newQuery()
 	q.idKind = idKind
+	return q
+}
+
+func (s *QueryBuilder) SelectColumns(columns ...Column) StructuredQuery {
+	q := s.newQuery()
+	q.columns = columns
 	return q
 }
 

--- a/dal/query_select_columns_test.go
+++ b/dal/query_select_columns_test.go
@@ -1,0 +1,20 @@
+package dal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueryBuilder_SelectColumns(t *testing.T) {
+	cols := []Column{
+		{Expression: NewFieldRef("", "id")},
+		{Alias: "s", Expression: NewFieldRef("", "status")},
+	}
+	q := NewQueryBuilder(nil).SelectColumns(cols...)
+	assert.Equal(t, cols, q.Columns())
+
+	// A query finalized by any other terminal has an empty Columns().
+	q2 := NewQueryBuilder(nil).SelectIntoRecord(nil)
+	assert.Empty(t, q2.Columns())
+}

--- a/dalgo2memory/database.go
+++ b/dalgo2memory/database.go
@@ -286,19 +286,20 @@ func (s session) ExecuteQueryToRecordsReader(_ context.Context, query dal.Query)
 	}
 	orderBySources(rows, q.OrderBy(),
 		func(r memoryRow) map[string]map[string]any {
-			src := map[string]map[string]any{"": r.data, base.Name(): r.data}
-			if a := base.Alias(); a != "" {
-				src[a] = r.data
-			}
-			return src
+			return baseSources(base, r.data)
 		},
 		func(r memoryRow) string { return r.id })
 	if limit := q.Limit(); limit > 0 && limit < len(rows) {
 		rows = rows[:limit]
 	}
+	columns := q.Columns()
 	records := make([]dal.Record, len(rows))
 	for i, row := range rows {
 		key := dal.NewKeyWithID(collectionName, row.id)
+		if len(columns) > 0 {
+			records[i] = dal.NewRecordWithData(key, projectRow(columns, baseSources(base, row.data))).SetError(nil)
+			continue
+		}
 		template := q.IntoRecord()
 		if template == nil {
 			records[i] = dal.NewRecord(key).SetError(nil)

--- a/dalgo2memory/database.go
+++ b/dalgo2memory/database.go
@@ -273,6 +273,9 @@ func (s session) ExecuteQueryToRecordsReader(_ context.Context, query dal.Query)
 	if err := validateOrderSources(q.OrderBy(), known); err != nil {
 		return nil, err
 	}
+	if err := validateColumns(q.Columns(), known); err != nil {
+		return nil, err
+	}
 	rows := make([]memoryRow, 0, len(collection))
 	for id, b := range collection {
 		var data map[string]any

--- a/dalgo2memory/join.go
+++ b/dalgo2memory/join.go
@@ -44,6 +44,9 @@ func (s session) executeJoinQuery(q dal.StructuredQuery) (dal.RecordsReader, err
 	if err := validateOrderSources(q.OrderBy(), known); err != nil {
 		return nil, err
 	}
+	if err := validateColumns(q.Columns(), known); err != nil {
+		return nil, err
+	}
 
 	baseRows, err := s.loadRows(base.Name())
 	if err != nil {

--- a/dalgo2memory/join.go
+++ b/dalgo2memory/join.go
@@ -93,9 +93,14 @@ func (s session) executeJoinQuery(q dal.StructuredQuery) (dal.RecordsReader, err
 		filtered = filtered[:limit]
 	}
 
+	columns := q.Columns()
 	records := make([]dal.Record, 0, len(filtered))
 	for _, row := range filtered {
 		key := dal.NewKeyWithID(base.Name(), row.baseID)
+		if len(columns) > 0 {
+			records = append(records, dal.NewRecordWithData(key, projectRow(columns, row.sources)).SetError(nil))
+			continue
+		}
 		if q.IntoRecord() == nil {
 			records = append(records, dal.NewRecord(key).SetError(nil))
 			continue

--- a/dalgo2memory/project.go
+++ b/dalgo2memory/project.go
@@ -1,6 +1,27 @@
 package dalgo2memory
 
-import "github.com/dal-go/dalgo/dal"
+import (
+	"fmt"
+
+	"github.com/dal-go/dalgo/dal"
+)
+
+// validateColumns rejects a projected column whose expression is not a
+// FieldRef, or whose non-empty Source() names no recordset in the query,
+// before any rows are produced -- consistent with the WHERE/ORDER BY
+// unresolvable-source behavior. An empty columns list is valid (no projection).
+func validateColumns(columns []dal.Column, known map[string]bool) error {
+	for _, col := range columns {
+		f, ok := col.Expression.(dal.FieldRef)
+		if !ok {
+			return fmt.Errorf("dalgo2memory: projected column %q is not a field reference", col.String())
+		}
+		if src := f.Source(); src != "" && !known[src] {
+			return fmt.Errorf("dalgo2memory: projected column %q references unknown source %q", f.Name(), src)
+		}
+	}
+	return nil
+}
 
 // baseSources builds the per-source resolution map for a single-source query
 // row: the empty key and the base recordset's name (and alias when set) all

--- a/dalgo2memory/project.go
+++ b/dalgo2memory/project.go
@@ -1,0 +1,36 @@
+package dalgo2memory
+
+import "github.com/dal-go/dalgo/dal"
+
+// baseSources builds the per-source resolution map for a single-source query
+// row: the empty key and the base recordset's name (and alias when set) all
+// resolve to the same row data.
+func baseSources(base dal.RecordsetSource, data map[string]any) map[string]map[string]any {
+	src := map[string]map[string]any{"": data, base.Name(): data}
+	if a := base.Alias(); a != "" {
+		src[a] = data
+	}
+	return src
+}
+
+// columnKey returns the output map key for a projected column: its Alias,
+// falling back to the column's field name when the alias is empty.
+func columnKey(col dal.Column, f dal.FieldRef) string {
+	if col.Alias != "" {
+		return col.Alias
+	}
+	return f.Name()
+}
+
+// projectRow builds the projected output map for one row: one entry per
+// selected column keyed by alias/field-name, resolving each column's FieldRef
+// against the per-source data (empty Source() -> base; alias/name -> that
+// source). Each column expression is expected to be a resolvable FieldRef.
+func projectRow(columns []dal.Column, sources map[string]map[string]any) map[string]any {
+	out := make(map[string]any, len(columns))
+	for _, col := range columns {
+		f := col.Expression.(dal.FieldRef)
+		out[columnKey(col, f)] = sources[f.Source()][f.Name()]
+	}
+	return out
+}

--- a/dalgo2memory/project_test.go
+++ b/dalgo2memory/project_test.go
@@ -75,6 +75,31 @@ func TestJoin_ProjectionQualified(t *testing.T) {
 	}
 }
 
+// AC non-field-column-errors: a selected column whose expression is not a
+// FieldRef produces a descriptive error and no rows.
+func TestSingleSource_NonFieldColumnErrors(t *testing.T) {
+	db, ctx := seedPeople(t)
+	q := dal.From(dal.NewRootCollectionRef("people", "")).NewQuery().SelectColumns(
+		dal.Column{Expression: dal.Constant{Value: 1}},
+	)
+	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+	require.Nil(t, reader)
+	require.ErrorContains(t, err, "not a field reference")
+}
+
+// AC unknown-column-source-errors: a selected column qualified with a source
+// naming no recordset produces a descriptive error and no rows.
+func TestJoin_UnknownColumnSourceErrors(t *testing.T) {
+	db, ctx := seedUsersOrders(t)
+	join := dal.NewJoinedSource(ordersAlias(), dal.JoinInner, onUserEqOrder())
+	q := dal.From(usersAlias()).Join(join).NewQuery().SelectColumns(
+		dal.Column{Expression: dal.NewFieldRef("x", "id")},
+	)
+	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+	require.Nil(t, reader)
+	require.ErrorContains(t, err, "unknown source")
+}
+
 // AC empty-columns-unchanged: an empty Columns() leaves the full-record path
 // untouched.
 func TestSingleSource_EmptyColumnsUnchanged(t *testing.T) {

--- a/dalgo2memory/project_test.go
+++ b/dalgo2memory/project_test.go
@@ -1,0 +1,101 @@
+package dalgo2memory
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/stretchr/testify/require"
+)
+
+// seedPeople loads rows carrying id, name and status to exercise subset
+// projection (selecting fewer columns than the row has).
+func seedPeople(t *testing.T) (*database, context.Context) {
+	t.Helper()
+	db := NewDB().(*database)
+	ctx := context.Background()
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("people", "1"), &map[string]any{"id": 1, "name": "alice", "status": "active"})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("people", "2"), &map[string]any{"id": 2, "name": "bob", "status": "active"})))
+	return db, ctx
+}
+
+func runProjection(t *testing.T, db *database, ctx context.Context, q dal.Query) []map[string]any {
+	t.Helper()
+	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+	require.NoError(t, err)
+	var got []map[string]any
+	for {
+		rec, err := reader.Next()
+		if errors.Is(err, dal.ErrNoMoreRecords) {
+			break
+		}
+		require.NoError(t, err)
+		got = append(got, rec.Data().(map[string]any))
+	}
+	return got
+}
+
+// AC single-source-projection: selecting id and name aliased n yields a data
+// map of exactly {id, n}, with name and status absent.
+func TestSingleSource_Projection(t *testing.T) {
+	db, ctx := seedPeople(t)
+	q := dal.From(dal.NewRootCollectionRef("people", "")).NewQuery().SelectColumns(
+		dal.Column{Expression: dal.NewFieldRef("", "id")},
+		dal.Column{Alias: "n", Expression: dal.NewFieldRef("", "name")},
+	)
+	got := runProjection(t, db, ctx, q)
+	require.Len(t, got, 2)
+	for _, r := range got {
+		require.Len(t, r, 2)
+		require.Contains(t, r, "id")
+		require.Contains(t, r, "n")
+		require.NotContains(t, r, "name")
+		require.NotContains(t, r, "status")
+	}
+}
+
+// AC join-projection-qualified: selecting u.id and o.status yields exactly
+// {id, status} with status taking the order's value (not the user's).
+func TestJoin_ProjectionQualified(t *testing.T) {
+	db, ctx := seedUsersOrders(t)
+	join := dal.NewJoinedSource(ordersAlias(), dal.JoinInner, onUserEqOrder())
+	q := dal.From(usersAlias()).Join(join).NewQuery().SelectColumns(
+		dal.Column{Expression: dal.NewFieldRef("u", "id")},
+		dal.Column{Expression: dal.NewFieldRef("o", "status")},
+	)
+	got := runJoinQuery(t, db, ctx, q)
+	require.Len(t, got, 2)
+	for _, r := range got {
+		require.Len(t, r, 2)
+		require.Contains(t, r, "id")
+		require.EqualValues(t, 1, r["id"])
+		require.Equal(t, "shipped", r["status"], "o.status must take the order's value, not the user's 'active'")
+	}
+}
+
+// AC empty-columns-unchanged: an empty Columns() leaves the full-record path
+// untouched.
+func TestSingleSource_EmptyColumnsUnchanged(t *testing.T) {
+	db, ctx := seedPeople(t)
+	q := dal.From(dal.NewRootCollectionRef("people", "")).NewQuery().SelectIntoRecord(func() dal.Record {
+		return dal.NewRecordWithIncompleteKey("people", reflect.String, &map[string]any{})
+	})
+	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+	require.NoError(t, err)
+	var n int
+	for {
+		rec, err := reader.Next()
+		if errors.Is(err, dal.ErrNoMoreRecords) {
+			break
+		}
+		require.NoError(t, err)
+		r := *rec.Data().(*map[string]any)
+		require.Contains(t, r, "id")
+		require.Contains(t, r, "name")
+		require.Contains(t, r, "status")
+		n++
+	}
+	require.Equal(t, 2, n)
+}

--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -19,7 +19,7 @@ The Feature format follows [SpecScore](https://specscore.md/feature-specificatio
 | [dtql](dtql/README.md) | Approved | — |
 | [query-joins](query-joins/README.md) | Approved | — |
 | [qualified-orderby-resolution](qualified-orderby-resolution/README.md) | Approved | — |
-| [query-column-projection](query-column-projection/README.md) | Under Review | — |
+| [query-column-projection](query-column-projection/README.md) | Approved | — |
 
 ## Open Questions
 

--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -19,6 +19,7 @@ The Feature format follows [SpecScore](https://specscore.md/feature-specificatio
 | [dtql](dtql/README.md) | Approved | — |
 | [query-joins](query-joins/README.md) | Approved | — |
 | [qualified-orderby-resolution](qualified-orderby-resolution/README.md) | Approved | — |
+| [query-column-projection](query-column-projection/README.md) | Under Review | — |
 
 ## Open Questions
 

--- a/spec/features/query-column-projection/README.md
+++ b/spec/features/query-column-projection/README.md
@@ -27,7 +27,7 @@ Adds a `SelectColumns` terminal to `dal.QueryBuilder` so a caller can select a s
 
 #### REQ: project-selected-columns
 
-When `q.Columns()` is non-empty, `dalgo2memory` MUST return each result record's data as a `map[string]any` containing exactly the selected columns and no others, keyed by each column's `Alias` (falling back to the column's field name when the alias is empty), for both single-source and join queries.
+When `q.Columns()` is non-empty, `dalgo2memory` MUST project — regardless of `IntoRecord()` (the keys-only `IntoRecord()==nil` branch is bypassed) — returning each result record's data as a `map[string]any` with one entry per selected column, keyed by the column's `Alias` (falling back to the column's field name when the alias is empty) and carrying the resolved value (a `nil` value when the field is absent on the row, e.g. the joined source of an unmatched LEFT row), for both single-source and join queries. No unselected field appears in the map. (Two selected columns that resolve to the same key are an Open Question; the in-scope ACs use distinct keys.)
 
 #### REQ: qualified-column-resolution
 
@@ -37,9 +37,13 @@ Each selected column's `FieldRef` expression MUST be resolved to a recordset by 
 
 A query with an empty `Columns()` MUST return full records exactly as before this Feature — no projection, the existing `IntoRecord`/keys-only behavior is untouched.
 
-#### REQ: column-error-handling
+#### REQ: unresolvable-column-source-errors
 
-When projecting, a selected column whose `FieldRef` names a non-empty source that matches no recordset in the query, or whose expression is not a `FieldRef`, MUST produce a descriptive error and yield no result rows — consistent with the `WHERE`/`ORDER BY` unresolvable-source behavior. (Non-`FieldRef` column expressions are out of MVP scope and rejected rather than silently dropped.)
+When projecting, a selected column whose `FieldRef` names a non-empty source that matches no recordset in the query MUST produce a descriptive error and yield no result rows — consistent with the `WHERE`/`ORDER BY` unresolvable-source behavior.
+
+#### REQ: non-field-column-rejected
+
+When projecting, a selected column whose expression is not a `FieldRef` MUST produce a descriptive error and yield no result rows; non-`FieldRef` column expressions are out of MVP scope and rejected rather than silently dropped.
 
 ## Acceptance Criteria
 
@@ -67,13 +71,13 @@ When projecting, a selected column whose `FieldRef` names a non-empty source tha
 **When** it is executed by `dalgo2memory`
 **Then** it returns the full records exactly as before this Feature, with no projection applied.
 
-### AC: unknown-column-source-errors (verifies REQ:column-error-handling)
+### AC: unknown-column-source-errors (verifies REQ:unresolvable-column-source-errors)
 
 **Given** a query selecting a column whose `FieldRef` is qualified with a source that names no recordset in the query
 **When** it is executed
 **Then** it returns a descriptive error naming the unresolved source and yields no result rows.
 
-### AC: non-field-column-errors (verifies REQ:column-error-handling)
+### AC: non-field-column-errors (verifies REQ:non-field-column-rejected)
 
 **Given** a query selecting a column whose expression is not a `FieldRef` (e.g. a constant)
 **When** it is executed
@@ -90,9 +94,9 @@ When projecting, a selected column whose `FieldRef` names a non-empty source tha
 
 ## Error Handling & Failure Modes
 
-- Selected column with an unknown non-empty source → descriptive error, no rows (`REQ:column-error-handling`).
-- Selected column whose expression is not a `FieldRef` → descriptive error, no rows (`REQ:column-error-handling`).
-- A resolvable column whose value is absent on a row (e.g. the joined source on an unmatched LEFT row) projects to a `nil`/absent map entry, not an error.
+- Selected column with an unknown non-empty source → descriptive error, no rows (`REQ:unresolvable-column-source-errors`).
+- Selected column whose expression is not a `FieldRef` → descriptive error, no rows (`REQ:non-field-column-rejected`).
+- A resolvable column whose value is absent on a row (e.g. the joined source on an unmatched LEFT row) projects to the selected key with a `nil` value — the key is always present — not an error.
 
 ## Testing Strategy
 
@@ -104,7 +108,7 @@ All six ACs are testable through pure Go — `dal` builder calls and `dalgo2memo
 
 ## Out of Scope
 
-- Computed / function / constant column expressions — only `FieldRef` columns are projected; others are rejected (`REQ:column-error-handling`).
+- Computed / function / constant column expressions — only `FieldRef` columns are projected; others are rejected (`REQ:non-field-column-rejected`).
 - The columnar recordset reader (`ExecuteQueryToRecordsetReader` stays `ErrNotSupported`) — projection lands in the `RecordsReader` path as map records.
 - Projecting into a typed struct target — a column-projected query returns `map[string]any` keyed by alias/name.
 - `DISTINCT`, aggregates, `GROUP BY`.
@@ -118,7 +122,7 @@ From the source Idea `query-column-projection`:
 - **Carried (Must):** the join source-aware resolver can evaluate a column's `FieldRef` for projection — validated by `AC:join-projection-qualified`.
 - **Carried (Should):** a `map[string]any` keyed by alias/name is an acceptable projected-output shape — embodied by `REQ:project-selected-columns` and its ACs.
 - **Carried (Should):** empty `Columns()` preserves today's full-record behavior — validated by `AC:empty-columns-unchanged`.
-- **Resolved:** a non-`FieldRef` or unresolvable column errors (rather than silently dropping) — now `REQ:column-error-handling`.
+- **Resolved:** a non-`FieldRef` or unresolvable column errors (rather than silently dropping) — now `REQ:unresolvable-column-source-errors` and `REQ:non-field-column-rejected`.
 - **Deferred (Might):** whether consumers adopt column selection — not validated here; the capability is delivered regardless.
 
 ## Open Questions

--- a/spec/features/query-column-projection/README.md
+++ b/spec/features/query-column-projection/README.md
@@ -1,11 +1,12 @@
 # Feature: Column selection in the query builder, projected by dalgo2memory
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-column-projection?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-column-projection?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-column-projection?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-column-projection?op=request-change) |
-**Status:** Under Review
+**Status:** Approved
 **Date:** 2026-06-05
 **Owner:** alex
 **Source Ideas:** query-column-projection
 **Supersedes:** —
+**Grade:** A
 
 ## Summary
 

--- a/spec/features/query-column-projection/README.md
+++ b/spec/features/query-column-projection/README.md
@@ -1,0 +1,130 @@
+# Feature: Column selection in the query builder, projected by dalgo2memory
+
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-column-projection?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-column-projection?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-column-projection?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-column-projection?op=request-change) |
+**Status:** Under Review
+**Date:** 2026-06-05
+**Owner:** alex
+**Source Ideas:** query-column-projection
+**Supersedes:** —
+
+## Summary
+
+Adds a `SelectColumns` terminal to `dal.QueryBuilder` so a caller can select a subset of columns, and teaches `dalgo2memory` to honor a non-empty `q.Columns()` by returning each record's data as a map of exactly those columns (aliased), for both single-source and join queries. Empty `Columns()` keeps today's full-record behavior.
+
+## Problem
+
+`dalgo2memory` never consumes `q.Columns()` — but the deeper gap is upstream: `dal.QueryBuilder` exposes only `SelectIntoRecord`/`SelectIntoRecordset`/`SelectKeysOnly` and has no way to set columns, and `structuredQuery.columns` is never assigned anywhere in `dal`. So column selection is unreachable from normal code, and the only producer of a query with non-empty `Columns()` is DTQL's deserialized `reconstructedQuery`. This Feature makes column selection a first-class builder capability and gives it a real executor in the in-memory adapter, reusing the source-aware field resolver the join `WHERE`/`ORDER BY` already use.
+
+## Behavior
+
+### Selecting columns (the `dal` builder)
+
+#### REQ: select-columns-terminal
+
+`dal.QueryBuilder` MUST provide a `SelectColumns(columns ...dal.Column) dal.StructuredQuery` terminal (also on the `IQueryBuilder` interface) that records the given ordered, non-empty column list on the `StructuredQuery`, readable via `Columns()`. A query finalized by any other `Select*` terminal MUST have an empty `Columns()`.
+
+### Projecting columns (`dalgo2memory`)
+
+#### REQ: project-selected-columns
+
+When `q.Columns()` is non-empty, `dalgo2memory` MUST return each result record's data as a `map[string]any` containing exactly the selected columns and no others, keyed by each column's `Alias` (falling back to the column's field name when the alias is empty), for both single-source and join queries.
+
+#### REQ: qualified-column-resolution
+
+Each selected column's `FieldRef` expression MUST be resolved to a recordset by its `Source()` — empty denotes the `From` base; non-empty denotes the recordset whose `Alias()`/`Name()` matches — using the same per-source resolution as the join `WHERE`/`ORDER BY`. A projected column under a name collision (`u.status` vs `o.status`) MUST take the named source's value.
+
+#### REQ: empty-columns-unchanged
+
+A query with an empty `Columns()` MUST return full records exactly as before this Feature — no projection, the existing `IntoRecord`/keys-only behavior is untouched.
+
+#### REQ: column-error-handling
+
+When projecting, a selected column whose `FieldRef` names a non-empty source that matches no recordset in the query, or whose expression is not a `FieldRef`, MUST produce a descriptive error and yield no result rows — consistent with the `WHERE`/`ORDER BY` unresolvable-source behavior. (Non-`FieldRef` column expressions are out of MVP scope and rejected rather than silently dropped.)
+
+## Acceptance Criteria
+
+### AC: select-columns-recorded (verifies REQ:select-columns-terminal)
+
+**Given** a `dal.QueryBuilder`
+**When** `SelectColumns` is called with two columns — `id` and `status` aliased as `s`
+**Then** the resulting query's `Columns()` returns those two columns in order, while a query built with `SelectIntoRecord` returns an empty `Columns()`.
+
+### AC: single-source-projection (verifies REQ:project-selected-columns)
+
+**Given** a single-source query over rows with fields `id`, `name`, `status`, selecting `id` and `name` aliased as `n`
+**When** it is executed by `dalgo2memory`
+**Then** each result record's data map has exactly the keys `id` and `n` (the alias), and does not contain `name` or `status`.
+
+### AC: join-projection-qualified (verifies REQ:project-selected-columns, REQ:qualified-column-resolution)
+
+**Given** an INNER join of `users u` and `orders o` where both carry a `status` field, selecting `u.id` and `o.status`
+**When** it is executed
+**Then** each result record's data map contains exactly `id` and `status`, with `status` taking the order's value (not the user's field of the same name).
+
+### AC: empty-columns-unchanged (verifies REQ:empty-columns-unchanged)
+
+**Given** a query finalized with `SelectIntoRecord` (empty `Columns()`)
+**When** it is executed by `dalgo2memory`
+**Then** it returns the full records exactly as before this Feature, with no projection applied.
+
+### AC: unknown-column-source-errors (verifies REQ:column-error-handling)
+
+**Given** a query selecting a column whose `FieldRef` is qualified with a source that names no recordset in the query
+**When** it is executed
+**Then** it returns a descriptive error naming the unresolved source and yields no result rows.
+
+### AC: non-field-column-errors (verifies REQ:column-error-handling)
+
+**Given** a query selecting a column whose expression is not a `FieldRef` (e.g. a constant)
+**When** it is executed
+**Then** it returns a descriptive error and yields no result rows.
+
+## Architecture & Components
+
+- **`dal` builder.** New `SelectColumns(columns ...dal.Column) StructuredQuery` terminal on `QueryBuilder` (and `IQueryBuilder`) that sets `structuredQuery.columns` via `newQuery()`, mirroring the existing terminals. No other terminal sets columns.
+- **`dalgo2memory` projection.** A projection step applied when `q.Columns()` is non-empty in both `ExecuteQueryToRecordsReader` (single-source) and `executeJoinQuery` (join): validate the selected columns up front (FieldRef-only, source resolvable), then for each row build a `map[string]any` keyed by `Alias`/field-name, resolving each column's `FieldRef` via the shared per-source resolver (empty `Source()` → base; alias/name → source). Reuses the single-source `sources` map and the join `sources` map established by `qualified-orderby-resolution`/`query-joins`.
+
+## Data Flow
+
+`SelectColumns(cols...)` records the columns on the `StructuredQuery` → `dalgo2memory` checks `q.Columns()`; if non-empty it validates the columns (FieldRef + resolvable source, else error before producing rows), assembles rows (single-source scan or join loop), and projects each row to a map of the selected columns keyed by alias/name → records with map data. Empty `Columns()` follows the existing full-record path.
+
+## Error Handling & Failure Modes
+
+- Selected column with an unknown non-empty source → descriptive error, no rows (`REQ:column-error-handling`).
+- Selected column whose expression is not a `FieldRef` → descriptive error, no rows (`REQ:column-error-handling`).
+- A resolvable column whose value is absent on a row (e.g. the joined source on an unmatched LEFT row) projects to a `nil`/absent map entry, not an error.
+
+## Testing Strategy
+
+Table tests in `dal` (the `SelectColumns` terminal records columns; other terminals leave them empty) and in `dalgo2memory` (single-source subset projection with an alias; join projection with a `u`/`o` collision; empty-`Columns()` returns full records unchanged; unknown-source and non-`FieldRef` column errors). `dalgo2memory` MUST remain at 100% statement coverage, exercising every branch of the projection and column validation.
+
+## Rehearse Integration
+
+All six ACs are testable through pure Go — `dal` builder calls and `dalgo2memory` execution over in-memory collections — so they map directly to table tests (see `## Testing Strategy`). Per-AC Rehearse stub files are deferred to the Plan, where each AC becomes a concrete `*_test.go` case; the rehearsal surface is the Go test suite.
+
+## Out of Scope
+
+- Computed / function / constant column expressions — only `FieldRef` columns are projected; others are rejected (`REQ:column-error-handling`).
+- The columnar recordset reader (`ExecuteQueryToRecordsetReader` stays `ErrNotSupported`) — projection lands in the `RecordsReader` path as map records.
+- Projecting into a typed struct target — a column-projected query returns `map[string]any` keyed by alias/name.
+- `DISTINCT`, aggregates, `GROUP BY`.
+- SQL adapter projection (`dalgo2sql`/`dalgo2sqlite`) — separate repos, unblocked by the shared `dal` capability.
+
+## Assumption Carryover
+
+From the source Idea `query-column-projection`:
+
+- **Carried (Must):** a column-selection terminal can be added to `dal.QueryBuilder` without disrupting the existing terminals — validated by `AC:select-columns-recorded`.
+- **Carried (Must):** the join source-aware resolver can evaluate a column's `FieldRef` for projection — validated by `AC:join-projection-qualified`.
+- **Carried (Should):** a `map[string]any` keyed by alias/name is an acceptable projected-output shape — embodied by `REQ:project-selected-columns` and its ACs.
+- **Carried (Should):** empty `Columns()` preserves today's full-record behavior — validated by `AC:empty-columns-unchanged`.
+- **Resolved:** a non-`FieldRef` or unresolvable column errors (rather than silently dropping) — now `REQ:column-error-handling`.
+- **Deferred (Might):** whether consumers adopt column selection — not validated here; the capability is delivered regardless.
+
+## Open Questions
+
+- Final signature/name of the builder terminal (`SelectColumns(...)` vs. a chainable `Columns(...)` before a `Select*`) — an implementation detail for the Plan.
+- Output key collision when two selected columns resolve to the same alias/name (e.g. `u.status` and `o.status` both unaliased) — the MVP's ACs use distinct keys; last-write-wins vs. error is a Plan-time decision.
+
+---
+*This document follows the https://specscore.md/feature-specification*

--- a/spec/ideas/README.md
+++ b/spec/ideas/README.md
@@ -14,6 +14,7 @@ The Idea format follows [SpecScore](https://specscore.md/idea-specification).
 | [dalgo-schema-modification](dalgo-schema-modification.md) | Approved | 2026-05-12 | alex | — |
 | [first-class-query-joins](first-class-query-joins.md) | Specified | 2026-06-05 | alexander.trakhimenok | query-joins |
 | [qualified-orderby-resolution](qualified-orderby-resolution.md) | Specified | 2026-06-05 | alex | qualified-orderby-resolution |
+| [query-column-projection](query-column-projection.md) | Draft | 2026-06-05 | alex | — |
 | [recordops](recordops.md) | Approved | 2026-05-15 | alex | — |
 | [recordset-computed-columns](recordset-computed-columns.md) | Specified | 2026-06-02 | alex | recordset-computed-columns |
 | [transaction-message](transaction-message.md) | Approved | 2026-06-02 | alex | — |

--- a/spec/ideas/README.md
+++ b/spec/ideas/README.md
@@ -14,7 +14,7 @@ The Idea format follows [SpecScore](https://specscore.md/idea-specification).
 | [dalgo-schema-modification](dalgo-schema-modification.md) | Approved | 2026-05-12 | alex | — |
 | [first-class-query-joins](first-class-query-joins.md) | Specified | 2026-06-05 | alexander.trakhimenok | query-joins |
 | [qualified-orderby-resolution](qualified-orderby-resolution.md) | Specified | 2026-06-05 | alex | qualified-orderby-resolution |
-| [query-column-projection](query-column-projection.md) | Draft | 2026-06-05 | alex | — |
+| [query-column-projection](query-column-projection.md) | Approved | 2026-06-05 | alex | — |
 | [recordops](recordops.md) | Approved | 2026-05-15 | alex | — |
 | [recordset-computed-columns](recordset-computed-columns.md) | Specified | 2026-06-02 | alex | recordset-computed-columns |
 | [transaction-message](transaction-message.md) | Approved | 2026-06-02 | alex | — |

--- a/spec/ideas/README.md
+++ b/spec/ideas/README.md
@@ -14,7 +14,7 @@ The Idea format follows [SpecScore](https://specscore.md/idea-specification).
 | [dalgo-schema-modification](dalgo-schema-modification.md) | Approved | 2026-05-12 | alex | — |
 | [first-class-query-joins](first-class-query-joins.md) | Specified | 2026-06-05 | alexander.trakhimenok | query-joins |
 | [qualified-orderby-resolution](qualified-orderby-resolution.md) | Specified | 2026-06-05 | alex | qualified-orderby-resolution |
-| [query-column-projection](query-column-projection.md) | Approved | 2026-06-05 | alex | — |
+| [query-column-projection](query-column-projection.md) | Specified | 2026-06-05 | alex | query-column-projection |
 | [recordops](recordops.md) | Approved | 2026-05-15 | alex | — |
 | [recordset-computed-columns](recordset-computed-columns.md) | Specified | 2026-06-02 | alex | recordset-computed-columns |
 | [transaction-message](transaction-message.md) | Approved | 2026-06-02 | alex | — |

--- a/spec/ideas/query-column-projection.md
+++ b/spec/ideas/query-column-projection.md
@@ -1,0 +1,64 @@
+# Idea: Column selection in the query builder, projected by dalgo2memory
+
+**Status:** Draft
+**Date:** 2026-06-05
+**Owner:** alex
+**Promotes To:** —
+**Supersedes:** —
+**Related Ideas:** —
+
+## Problem Statement
+
+How might we let a dalgo caller select a subset of columns in the query builder and have dalgo2memory return records projected to exactly those columns?
+
+## Context
+
+Surfaced while scoping qualified ORDER BY resolution and parked as the sidekick seed 'dalgo2memory-column-projection'. dalgo2memory never consumes q.Columns() — both the single-source path and the join executor return full records. But the deeper blocker is upstream: dal.QueryBuilder exposes only SelectIntoRecord/SelectIntoRecordset/SelectKeysOnly and has NO way to set Columns; structuredQuery.columns is never assigned anywhere in dal. The only producer of a query with non-empty Columns() today is DTQL's reconstructedQuery wrapper (built from deserialized YAML). So projecting columns in any adapter is currently unreachable from normal code. dal.Column is {Alias string, Expression Expression}; the qualified-field resolver used by the join WHERE/ORDER BY (sources map, empty Source() -> base, alias/name -> source) can evaluate a column's FieldRef expression for projection.
+
+## Recommended Direction
+
+Deliver the capability end to end. First add a column-selection terminal to dal.QueryBuilder (e.g. SelectColumns(cols ...dal.Column) StructuredQuery) that records the selected columns on the StructuredQuery, alongside the existing Select* terminals. Then teach dalgo2memory to honor a non-empty q.Columns(): for each result row of both the single-source and join paths, project to a map[string]any containing only the selected columns, evaluating each column's FieldRef expression via the same source-aware resolver the join WHERE/ORDER BY already use and keying the output by the column's Alias (falling back to the field name). An empty Columns() keeps today's full-record behavior. This reuses the existing resolver and the map-record output shape the join path already returns, so it is a small, cohesive slice that finally makes column selection real for the in-memory adapter and lets a DTQL-deserialized column query actually execute.
+
+## Alternatives Considered
+
+- **Implement projection in `dalgo2memory` only, leave the builder alone.** Smallest code change. Lost because `dal.QueryBuilder` cannot set `Columns()` and `structuredQuery.columns` is never assigned, so the only query that would exercise the projection is a DTQL-deserialized one — the feature would be near-dead code with no normal producer.
+- **Add the columnar recordset reader (`ExecuteQueryToRecordsetReader`) and project there.** Column projection is conceptually a columnar concern, and the recordset package already models columns. Lost because the recordset reader is a much larger surface (currently `ErrNotSupported`) and the existing `RecordsReader` path with a map record is the smaller, already-proven output shape; the recordset reader can adopt the same selection later.
+- **Make selected columns project into the caller's typed `IntoRecord` struct.** Keeps the existing typed-record ergonomics. Lost because a struct already fixes its fields, so column selection cannot restrict them meaningfully and aliasing has nowhere to land; a `map[string]any` keyed by alias/name is the honest shape for an arbitrary projection.
+
+## MVP Scope
+
+A short spike: dal.QueryBuilder can express SELECT of a subset of columns (with optional aliases), and dalgo2memory returns records whose data map contains exactly those columns (aliased), for both a single-source and a two-table join query. Verified by table tests selecting two of several fields (one aliased) over in-memory data; empty Columns() still returns full records; dalgo2memory stays at 100% coverage.
+
+## Not Doing (and Why)
+
+- Computed / function / constant column expressions — only FieldRef columns are in scope; the rest is future work
+- The columnar recordset reader (ExecuteQueryToRecordsetReader stays ErrNotSupported) — projection lands in the RecordsReader path as map records
+- Projecting into a typed struct target — a column-projected query returns map[string]any keyed by alias/name
+- DISTINCT, aggregates, GROUP BY — out of scope
+- SQL adapter projection (dalgo2sql, dalgo2sqlite) — separate repos, unblocked by the shared dal capability
+
+## Key Assumptions to Validate
+
+| Tier | Assumption | How to validate |
+|------|------------|-----------------|
+| Must-be-true | A column-selection terminal can be added to `dal.QueryBuilder` that records `[]Column` on the `StructuredQuery` without disrupting the existing `SelectIntoRecord`/`SelectIntoRecordset`/`SelectKeysOnly` terminals. | Add the terminal, build a query with selected columns, and confirm `q.Columns()` returns them while the existing builder tests stay green. |
+| Must-be-true | The source-aware resolver the join WHERE/ORDER BY already use can evaluate a column's FieldRef expression for projection (empty Source() -> base; alias/name -> source). | Project a join by qualified columns (including a `u`/`o` name collision) and assert each output value comes from the named source. |
+| Should-be-true | A `map[string]any` keyed by the column Alias (falling back to the field name) is an acceptable output shape for a projected query — no typed-target requirement. | Table tests read the projected map; review DTQL/datatug expectations for whether a typed projection is ever required. |
+| Should-be-true | An empty `Columns()` must preserve today's full-record behavior for every existing query. | Run the existing `dalgo2memory` suite unchanged; only queries built with the new terminal project. |
+| Might-be-true | Consumers will actually adopt column selection (smaller reads, DTQL round-trip execution) rather than always fetching full records. | Review DTQL and datatug for a concrete column-selection use before widening past FieldRef columns. |
+
+
+## SpecScore Integration
+
+- **New Features this would create:** a `dal` query-builder column-selection capability and `dalgo2memory` column projection — likely one Feature covering both (the builder terminal plus the executor honoring it).
+- **Existing Features affected:** `dtql` — its serialized `Columns` would gain an executor that actually honors them; `query-joins` and `qualified-orderby-resolution` — projection reuses their source-aware resolver and the join path's map-record output.
+- **Dependencies:** Upstream — the merged `query-joins` (resolver + map output) and `qualified-orderby-resolution` (shared resolution patterns). Sibling — none.
+
+## Open Questions
+
+- Exact builder API: a terminal `SelectColumns(cols ...dal.Column) StructuredQuery` vs. a chainable `Columns(...)` before an existing `Select*` terminal — settle at spec time.
+- Output key when a column has neither an alias nor a `FieldRef` name (only relevant if non-FieldRef columns are ever admitted) — out of scope for the MVP, which is FieldRef-only.
+- Whether a future columnar `ExecuteQueryToRecordsetReader` should share this selection logic, and how a typed-target projection (if ever needed) would be expressed.
+
+---
+*This document follows the https://specscore.md/idea-specification*

--- a/spec/ideas/query-column-projection.md
+++ b/spec/ideas/query-column-projection.md
@@ -1,9 +1,9 @@
 # Idea: Column selection in the query builder, projected by dalgo2memory
 
-**Status:** Approved
+**Status:** Specified
 **Date:** 2026-06-05
 **Owner:** alex
-**Promotes To:** —
+**Promotes To:** query-column-projection
 **Supersedes:** —
 **Related Ideas:** —
 

--- a/spec/ideas/query-column-projection.md
+++ b/spec/ideas/query-column-projection.md
@@ -1,6 +1,6 @@
 # Idea: Column selection in the query builder, projected by dalgo2memory
 
-**Status:** Draft
+**Status:** Approved
 **Date:** 2026-06-05
 **Owner:** alex
 **Promotes To:** —

--- a/spec/plans/2026-06-05-query-column-projection.md
+++ b/spec/plans/2026-06-05-query-column-projection.md
@@ -27,6 +27,7 @@ Add `SelectColumns(columns ...dal.Column) dal.StructuredQuery` to `QueryBuilder`
 
 **Verifies:** query-column-projection#ac:single-source-projection, query-column-projection#ac:join-projection-qualified, query-column-projection#ac:empty-columns-unchanged
 **Depends-On:** 1
+**Status:** done
 
 When `q.Columns()` is non-empty, project each result row of both `ExecuteQueryToRecordsReader` (single-source) and `executeJoinQuery` (join) to a `map[string]any` with one entry per selected column, keyed by its `Alias` (falling back to the field name) and resolved via the shared per-source resolver (empty `Source()` -> base; alias/name -> source, collision-correct), bypassing the keys-only `IntoRecord()==nil` branch. An empty `Columns()` leaves the existing full-record output unchanged.
 

--- a/spec/plans/2026-06-05-query-column-projection.md
+++ b/spec/plans/2026-06-05-query-column-projection.md
@@ -1,6 +1,6 @@
 # Plan: Column selection in the query builder, projected by dalgo2memory
 
-**Status:** Under Review
+**Status:** Approved
 **Source Feature:** query-column-projection
 **Date:** 2026-06-05
 **Owner:** alex

--- a/spec/plans/2026-06-05-query-column-projection.md
+++ b/spec/plans/2026-06-05-query-column-projection.md
@@ -1,0 +1,44 @@
+# Plan: Column selection in the query builder, projected by dalgo2memory
+
+**Status:** Under Review
+**Source Feature:** query-column-projection
+**Date:** 2026-06-05
+**Owner:** alex
+**Supersedes:** —
+
+## Summary
+
+Decomposes the `query-column-projection` Feature into three linear tasks: add the `SelectColumns` terminal to `dal.QueryBuilder`, then project a non-empty `q.Columns()` into map records in `dalgo2memory` (single-source and join), then add the column validation errors. All six acceptance criteria are covered by a task; none are deferred.
+
+## Approach
+
+The Feature is a builder capability plus an executor that honors it, so the order is build-the-input then consume-it. Task 1 adds the `SelectColumns(...)` terminal that records `[]Column` on the `StructuredQuery` (the only producer of non-empty `Columns()` from the core builder), with the other terminals leaving it empty. Task 2 makes `dalgo2memory` honor a non-empty `Columns()`: it projects each result row of both the single-source and join paths to a `map[string]any` of exactly the selected columns (keyed by alias/field-name), resolving each column's `FieldRef` through the shared source-aware resolver, while an empty `Columns()` keeps the existing full-record path untouched — these three ACs are the cohesive core of the projection. Task 3 adds the up-front column validation the projection needs: an unknown column source and a non-`FieldRef` column each error with no rows. Task 2 depends on Task 1's terminal; Task 3 depends on Task 2's projection path.
+
+## Tasks
+
+### Task 1: SelectColumns terminal on dal.QueryBuilder
+
+**Verifies:** query-column-projection#ac:select-columns-recorded
+
+Add `SelectColumns(columns ...dal.Column) dal.StructuredQuery` to `QueryBuilder` and the `IQueryBuilder` interface, recording the ordered column list on the `StructuredQuery` via `newQuery()` (mirroring the existing `Select*` terminals), so `Columns()` returns them while queries built by any other terminal report an empty `Columns()`.
+
+### Task 2: dalgo2memory projects a non-empty Columns() into map records
+
+**Verifies:** query-column-projection#ac:single-source-projection, query-column-projection#ac:join-projection-qualified, query-column-projection#ac:empty-columns-unchanged
+**Depends-On:** 1
+
+When `q.Columns()` is non-empty, project each result row of both `ExecuteQueryToRecordsReader` (single-source) and `executeJoinQuery` (join) to a `map[string]any` with one entry per selected column, keyed by its `Alias` (falling back to the field name) and resolved via the shared per-source resolver (empty `Source()` -> base; alias/name -> source, collision-correct), bypassing the keys-only `IntoRecord()==nil` branch. An empty `Columns()` leaves the existing full-record output unchanged.
+
+### Task 3: column validation errors
+
+**Verifies:** query-column-projection#ac:unknown-column-source-errors, query-column-projection#ac:non-field-column-errors
+**Depends-On:** 2
+
+Validate the selected columns before producing rows: a column whose `FieldRef` names a non-empty source matching no recordset, or whose expression is not a `FieldRef`, returns a descriptive error and no rows — consistent with the `WHERE`/`ORDER BY` unresolvable-source behavior.
+
+## Open Questions
+
+- Output-key collision when two selected columns resolve to the same alias/name — the in-scope ACs use distinct keys; last-write-wins vs. error is settled during implementation.
+
+---
+*This document follows the https://specscore.md/plan-specification*

--- a/spec/plans/2026-06-05-query-column-projection.md
+++ b/spec/plans/2026-06-05-query-column-projection.md
@@ -1,6 +1,6 @@
 # Plan: Column selection in the query builder, projected by dalgo2memory
 
-**Status:** Approved
+**Status:** Implementing
 **Source Feature:** query-column-projection
 **Date:** 2026-06-05
 **Owner:** alex
@@ -19,6 +19,7 @@ The Feature is a builder capability plus an executor that honors it, so the orde
 ### Task 1: SelectColumns terminal on dal.QueryBuilder
 
 **Verifies:** query-column-projection#ac:select-columns-recorded
+**Status:** done
 
 Add `SelectColumns(columns ...dal.Column) dal.StructuredQuery` to `QueryBuilder` and the `IQueryBuilder` interface, recording the ordered column list on the `StructuredQuery` via `newQuery()` (mirroring the existing `Select*` terminals), so `Columns()` returns them while queries built by any other terminal report an empty `Columns()`.
 

--- a/spec/plans/2026-06-05-query-column-projection.md
+++ b/spec/plans/2026-06-05-query-column-projection.md
@@ -1,6 +1,6 @@
 # Plan: Column selection in the query builder, projected by dalgo2memory
 
-**Status:** Implementing
+**Status:** Completed
 **Source Feature:** query-column-projection
 **Date:** 2026-06-05
 **Owner:** alex
@@ -35,6 +35,7 @@ When `q.Columns()` is non-empty, project each result row of both `ExecuteQueryTo
 
 **Verifies:** query-column-projection#ac:unknown-column-source-errors, query-column-projection#ac:non-field-column-errors
 **Depends-On:** 2
+**Status:** done
 
 Validate the selected columns before producing rows: a column whose `FieldRef` names a non-empty source matching no recordset, or whose expression is not a `FieldRef`, returns a descriptive error and no rows — consistent with the `WHERE`/`ORDER BY` unresolvable-source behavior.
 


### PR DESCRIPTION
Implements the **query-column-projection** Feature (Grade A) — adds a `SelectColumns` terminal to `dal.QueryBuilder` and teaches `dalgo2memory` to honor a non-empty `q.Columns()` by returning each record as a `map[string]any` of exactly the selected columns.

## Tasks (per `spec/plans/2026-06-05-query-column-projection.md`)

| Task | ACs |
|------|-----|
| **T1** `SelectColumns(columns ...Column)` terminal on `QueryBuilder`/`IQueryBuilder`, recording the ordered list via `newQuery()` | `select-columns-recorded` |
| **T2** Projection of non-empty `Columns()` into map records in both single-source and join executors, keyed by alias/field-name via the shared per-source resolver; empty `Columns()` unchanged | `single-source-projection`, `join-projection-qualified`, `empty-columns-unchanged` |
| **T3** Up-front column validation: non-`FieldRef` and unknown-source columns error with no rows, consistent with WHERE/ORDER BY | `unknown-column-source-errors`, `non-field-column-errors` |

All 6 acceptance criteria covered; each commit carries a `Verifies:` trailer.

## Quality
- All module tests pass
- `dalgo2memory` at **100.0% statement coverage**
- `golangci-lint run ./...` clean (0 issues)
- `specscore spec lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)