### PR TITLE
spec(query-column-projection): mark Feature Stable

### DIFF
--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -19,7 +19,7 @@ The Feature format follows [SpecScore](https://specscore.md/feature-specificatio
 | [dtql](dtql/README.md) | Approved | — |
 | [query-joins](query-joins/README.md) | Approved | — |
 | [qualified-orderby-resolution](qualified-orderby-resolution/README.md) | Approved | — |
-| [query-column-projection](query-column-projection/README.md) | Approved | — |
+| [query-column-projection](query-column-projection/README.md) | Stable | — |
 
 ## Open Questions
 

--- a/spec/features/query-column-projection/README.md
+++ b/spec/features/query-column-projection/README.md
@@ -1,7 +1,7 @@
 # Feature: Column selection in the query builder, projected by dalgo2memory
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-column-projection?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-column-projection?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-column-projection?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-column-projection?op=request-change) |
-**Status:** Approved
+**Status:** Stable
 **Date:** 2026-06-05
 **Owner:** alex
 **Source Ideas:** query-column-projection

--- a/spec/ideas/README.md
+++ b/spec/ideas/README.md
@@ -14,7 +14,7 @@ The Idea format follows [SpecScore](https://specscore.md/idea-specification).
 | [dalgo-schema-modification](dalgo-schema-modification.md) | Approved | 2026-05-12 | alex | — |
 | [first-class-query-joins](first-class-query-joins.md) | Specified | 2026-06-05 | alexander.trakhimenok | query-joins |
 | [qualified-orderby-resolution](qualified-orderby-resolution.md) | Specified | 2026-06-05 | alex | qualified-orderby-resolution |
-| [query-column-projection](query-column-projection.md) | Specified | 2026-06-05 | alex | query-column-projection |
+| [query-column-projection](query-column-projection.md) | Implemented | 2026-06-05 | alex | query-column-projection |
 | [recordops](recordops.md) | Approved | 2026-05-15 | alex | — |
 | [recordset-computed-columns](recordset-computed-columns.md) | Specified | 2026-06-02 | alex | recordset-computed-columns |
 | [transaction-message](transaction-message.md) | Approved | 2026-06-02 | alex | — |

--- a/spec/ideas/query-column-projection.md
+++ b/spec/ideas/query-column-projection.md
@@ -1,6 +1,6 @@
 # Idea: Column selection in the query builder, projected by dalgo2memory
 
-**Status:** Specified
+**Status:** Implemented
 **Date:** 2026-06-05
 **Owner:** alex
 **Promotes To:** query-column-projection


### PR DESCRIPTION
Lifecycle bookkeeping after #58 merged. Walks the `query-column-projection` Feature `Approved → Implementing → Stable` via `specscore feature change-status`; the CLI's index sync also advanced the source Idea `Specified → Implemented`.

Doc-only — no code changes.

- `spec/features/query-column-projection/README.md` + features index → **Stable**
- `spec/ideas/query-column-projection.md` + ideas index → **Implemented**

🤖 Generated with [Claude Code](https://claude.com/claude-code)