### PR TITLE
feat: GROUP BY with aggregation (dal builder + dalgo2memory)

### DIFF
--- a/dal/q_builder.go
+++ b/dal/q_builder.go
@@ -19,6 +19,8 @@ type IQueryBuilder interface {
 	Where(conditions ...Condition) IQueryBuilder
 	WhereField(name string, operator Operator, v any) IQueryBuilder
 	WhereInArrayField(name string, v any) IQueryBuilder
+	GroupBy(expressions ...Expression) IQueryBuilder
+	Having(conditions ...Condition) IQueryBuilder
 	OrderBy(expressions ...OrderExpression) IQueryBuilder
 	SelectIntoRecord(func() Record) StructuredQuery
 	SelectIntoRecordset(options ...recordset.Option) StructuredQuery
@@ -50,7 +52,8 @@ type QueryBuilder struct {
 	//recordsetSource RecordsetSource
 	//offset          int
 	//limit           int
-	conditions []Condition
+	conditions       []Condition
+	havingConditions []Condition
 	//orderBy         []OrderExpression
 	//startCursor     Cursor
 }
@@ -82,6 +85,16 @@ func (s *QueryBuilder) OrderBy(expressions ...OrderExpression) IQueryBuilder {
 
 func (s *QueryBuilder) Where(conditions ...Condition) IQueryBuilder {
 	s.conditions = append(s.conditions, conditions...)
+	return s
+}
+
+func (s *QueryBuilder) GroupBy(expressions ...Expression) IQueryBuilder {
+	s.q.groupBy = append(s.q.groupBy, expressions...)
+	return s
+}
+
+func (s *QueryBuilder) Having(conditions ...Condition) IQueryBuilder {
+	s.havingConditions = append(s.havingConditions, conditions...)
 	return s
 }
 
@@ -126,6 +139,13 @@ func (s *QueryBuilder) newQuery() structuredQuery {
 		s.q.where = s.conditions[0]
 	default:
 		s.q.where = GroupCondition{conditions: s.conditions, operator: And}
+	}
+	switch len(s.havingConditions) {
+	case 0: // no having conditions
+	case 1:
+		s.q.having = s.havingConditions[0]
+	default:
+		s.q.having = GroupCondition{conditions: s.havingConditions, operator: And}
 	}
 	return s.q
 }

--- a/dal/q_functions.go
+++ b/dal/q_functions.go
@@ -20,6 +20,23 @@ type function struct {
 
 var _ Expression = (*function)(nil)
 
+// AggregateFunc is implemented by aggregate function expressions (SUM, COUNT,
+// MIN, MAX, AVG) so adapters can introspect the function name and its arguments
+// without depending on the unexported concrete type.
+type AggregateFunc interface {
+	Expression
+	FuncName() string
+	FuncArgs() []Expression
+}
+
+var _ AggregateFunc = function{}
+
+// FuncName returns the aggregate function name (e.g. SUM, COUNT).
+func (v function) FuncName() string { return v.Name }
+
+// FuncArgs returns the aggregate function arguments.
+func (v function) FuncArgs() []Expression { return v.Args }
+
 // String returns a text representation of a function
 func (v function) String() string {
 	args := make([]string, len(v.Args))
@@ -27,6 +44,23 @@ func (v function) String() string {
 		args[i] = arg.String()
 	}
 	return fmt.Sprintf("%v(%v)", v.Name, strings.Join(args, ", "))
+}
+
+// star is the `*` argument of COUNT(*); it is not a field reference, which is
+// how the executor distinguishes COUNT(*) (count all rows) from COUNT(field).
+type star struct{}
+
+var _ Expression = star{}
+
+// String renders the star argument as `*`.
+func (star) String() string { return "*" }
+
+// Count returns a COUNT(*) aggregate column counting all rows in a group
+// regardless of nulls. Count() is the alias for COUNT(*); use the returned
+// Column's Alias field to name the output. The existing CountAs(field, alias)
+// keeps its field-count (skip-nulls) semantics.
+func Count() Column {
+	return Column{Expression: function{Name: COUNT, Args: []Expression{star{}}}}
 }
 
 func singleArgFunctionAs(name, alias string, expression Expression) Column {

--- a/dal/q_group_by_test.go
+++ b/dal/q_group_by_test.go
@@ -1,0 +1,76 @@
+package dal
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// AC group-by-recorded: GroupBy records its expressions; a query without a
+// GroupBy call reports an empty GroupBy().
+func TestQueryBuilder_GroupBy(t *testing.T) {
+	grouped := From(NewRootCollectionRef("sales", "")).NewQuery().
+		GroupBy(Field("category")).
+		SelectColumns(Column{Expression: Field("category")})
+	require.Len(t, grouped.GroupBy(), 1)
+	assert.Equal(t, "category", grouped.GroupBy()[0].String())
+
+	ungrouped := From(NewRootCollectionRef("sales", "")).NewQuery().
+		SelectColumns(Column{Expression: Field("category")})
+	assert.Empty(t, ungrouped.GroupBy())
+}
+
+// AC having-recorded-and-rendered: Having records its condition and String()
+// renders a HAVING clause positioned after the GROUP BY clause.
+func TestQueryBuilder_Having(t *testing.T) {
+	q := From(NewRootCollectionRef("sales", "")).NewQuery().
+		GroupBy(Field("category")).
+		Having(NewComparison(Count().Expression, GreaterThen, NewConstant(2))).
+		SelectColumns(Column{Expression: Field("category")})
+
+	require.NotNil(t, q.Having())
+
+	s := q.String()
+	groupAt := strings.Index(s, "GROUP BY")
+	havingAt := strings.Index(s, "HAVING")
+	require.NotEqual(t, -1, groupAt, "expected GROUP BY in %q", s)
+	require.NotEqual(t, -1, havingAt, "expected HAVING in %q", s)
+	assert.Greater(t, havingAt, groupAt, "HAVING must come after GROUP BY in %q", s)
+	assert.Contains(t, s, "HAVING COUNT(*) > 2")
+}
+
+// AC having-recorded-and-rendered (multi-condition): multiple Having conditions
+// AND-combine, mirroring Where.
+func TestQueryBuilder_Having_MultipleConditions(t *testing.T) {
+	q := From(NewRootCollectionRef("sales", "")).NewQuery().
+		GroupBy(Field("category")).
+		Having(NewComparison(Count().Expression, GreaterThen, NewConstant(2))).
+		Having(NewComparison(Field("total"), LessThen, NewConstant(100))).
+		SelectColumns(Column{Expression: Field("category")})
+
+	gc, ok := q.Having().(GroupCondition)
+	require.True(t, ok, "expected GroupCondition, got %T", q.Having())
+	assert.Equal(t, Operator(And), gc.Operator())
+	require.Len(t, gc.Conditions(), 2)
+}
+
+// AC count-star-expressible: Count() is COUNT(*), renders "COUNT(*)", and is
+// distinct from CountAs(field, alias).
+func TestCount_Star(t *testing.T) {
+	c := Count()
+	assert.Empty(t, c.Alias)
+	assert.Equal(t, "COUNT(*)", c.String())
+
+	af, ok := c.Expression.(AggregateFunc)
+	require.True(t, ok, "Count() expression must be an AggregateFunc, got %T", c.Expression)
+	assert.Equal(t, COUNT, af.FuncName())
+	require.Len(t, af.FuncArgs(), 1)
+	_, isField := af.FuncArgs()[0].(FieldRef)
+	assert.False(t, isField, "COUNT(*) argument must not be a field reference")
+
+	field := CountAs(Field("amount"), "n")
+	assert.Equal(t, "COUNT(amount) AS n", field.String())
+	assert.NotEqual(t, c.String(), field.String())
+}

--- a/dal/query.go
+++ b/dal/query.go
@@ -38,6 +38,9 @@ type StructuredQuery interface {
 	// GroupBy defines expressions to group by
 	GroupBy() []Expression
 
+	// Having defines a post-aggregation filter condition
+	Having() Condition
+
 	// OrderBy defines expressions to order by
 	OrderBy() []OrderExpression
 

--- a/dal/query_struct.go
+++ b/dal/query_struct.go
@@ -24,6 +24,9 @@ type structuredQuery struct {
 	// GroupBy defines expressions to group by
 	groupBy []Expression
 
+	// Having defines a post-aggregation filter condition
+	having Condition
+
 	// OrderBy defines expressions to order by
 	orderBy []OrderExpression
 
@@ -67,6 +70,10 @@ func (q structuredQuery) Where() Condition {
 
 func (q structuredQuery) GroupBy() []Expression {
 	return q.groupBy[:]
+}
+
+func (q structuredQuery) Having() Condition {
+	return q.having
 }
 
 func (q structuredQuery) OrderBy() []OrderExpression {
@@ -158,6 +165,9 @@ func (q structuredQuery) String() string {
 			}
 			_, _ = writer.WriteString(expr.String())
 		}
+	}
+	if q.having != nil {
+		_, _ = writer.WriteString("\nHAVING " + q.having.String())
 	}
 	if len(q.orderBy) > 0 {
 		_, _ = writer.WriteString("\nORDER BY ")

--- a/dalgo2memory/database.go
+++ b/dalgo2memory/database.go
@@ -273,8 +273,11 @@ func (s session) ExecuteQueryToRecordsReader(_ context.Context, query dal.Query)
 	if err := validateOrderSources(q.OrderBy(), known); err != nil {
 		return nil, err
 	}
-	if err := validateColumns(q.Columns(), known); err != nil {
-		return nil, err
+	grouped := len(q.GroupBy()) > 0
+	if !grouped {
+		if err := validateColumns(q.Columns(), known); err != nil {
+			return nil, err
+		}
 	}
 	rows := make([]memoryRow, 0, len(collection))
 	for id, b := range collection {
@@ -286,6 +289,13 @@ func (s session) ExecuteQueryToRecordsReader(_ context.Context, query dal.Query)
 			continue
 		}
 		rows = append(rows, memoryRow{id: id, data: data, raw: b})
+	}
+	if grouped {
+		srcs := make([]rowSources, len(rows))
+		for i, row := range rows {
+			srcs[i] = baseSources(base, row.data)
+		}
+		return executeGroupedReader(q, srcs, collectionName, known)
 	}
 	orderBySources(rows, q.OrderBy(),
 		func(r memoryRow) map[string]map[string]any {

--- a/dalgo2memory/group.go
+++ b/dalgo2memory/group.go
@@ -1,0 +1,358 @@
+package dalgo2memory
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/dal-go/dalgo/dal"
+)
+
+// rowSources is one input row's per-source resolution map — the same shape the
+// join WHERE/ORDER BY resolver and baseSources produce (empty key -> base data;
+// alias/name -> that source's data). The grouping engine consumes rows of this
+// shape so a single implementation serves both the single-source and join paths.
+type rowSources = map[string]map[string]any
+
+// aggGroup is one GROUP BY partition: the member rows (for aggregate
+// evaluation) and the projected output row (set during projection, then read
+// back by HAVING/ORDER BY when an operand references a SELECT alias).
+type aggGroup struct {
+	rows []rowSources
+	out  map[string]any
+}
+
+// executeGroupedReader runs the grouping/aggregation pass shared by the
+// single-source and join executors. rows are the WHERE-matched input rows in
+// per-source shape; collection names the result key collection; known is the
+// set of resolvable source qualifiers.
+func executeGroupedReader(q dal.StructuredQuery, rows []rowSources, collection string, known map[string]bool) (dal.RecordsReader, error) {
+	groupBy := q.GroupBy()
+	columns := q.Columns()
+
+	// Validate GROUP BY field sources up front.
+	for _, ge := range groupBy {
+		if f, ok := ge.(dal.FieldRef); ok {
+			if src := f.Source(); src != "" && !known[src] {
+				return nil, fmt.Errorf("dalgo2memory: GROUP BY field %q references unknown source %q", f.Name(), src)
+			}
+		}
+	}
+
+	// Validate selected columns: each must be an aggregate or a GROUP BY
+	// expression (the SQL grouping rule), rejected before any group is emitted.
+	groupKeys := make(map[string]bool, len(groupBy))
+	for _, ge := range groupBy {
+		groupKeys[ge.String()] = true
+	}
+	for _, col := range columns {
+		if _, ok := col.Expression.(dal.AggregateFunc); ok {
+			continue
+		}
+		if groupKeys[col.Expression.String()] {
+			continue
+		}
+		return nil, fmt.Errorf("dalgo2memory: selected column %q is neither an aggregate nor in GROUP BY", col.String())
+	}
+
+	// Partition into groups, preserving first-seen order.
+	groupOrder := make([]string, 0)
+	byKey := make(map[string]*aggGroup)
+	for _, r := range rows {
+		key, err := groupKey(groupBy, r, known)
+		if err != nil {
+			return nil, err
+		}
+		g := byKey[key]
+		if g == nil {
+			g = &aggGroup{}
+			byKey[key] = g
+			groupOrder = append(groupOrder, key)
+		}
+		g.rows = append(g.rows, r)
+	}
+	groups := make([]*aggGroup, len(groupOrder))
+	for i, k := range groupOrder {
+		groups[i] = byKey[k]
+	}
+
+	// Project each group's selected columns into its output row.
+	for _, g := range groups {
+		out := make(map[string]any, len(columns))
+		for _, col := range columns {
+			val, err := resolveGroupValue(col.Expression, g, known)
+			if err != nil {
+				return nil, err
+			}
+			out[columnOutKey(col)] = val
+		}
+		g.out = out
+	}
+
+	// HAVING: post-aggregation filter over each group's row.
+	if having := q.Having(); having != nil {
+		kept := make([]*aggGroup, 0, len(groups))
+		for _, g := range groups {
+			ok, err := matchesHaving(having, g, known)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				kept = append(kept, g)
+			}
+		}
+		groups = kept
+	}
+
+	// ORDER BY over the grouped rows. Sort keys are resolved once per group
+	// up front so any resolution error surfaces before sorting (the comparator
+	// itself cannot return an error).
+	if orderBy := q.OrderBy(); len(orderBy) > 0 {
+		keys := make([][]any, len(groups))
+		for i, g := range groups {
+			row := make([]any, len(orderBy))
+			for k, oe := range orderBy {
+				v, err := resolveGroupValue(oe.Expression(), g, known)
+				if err != nil {
+					return nil, err
+				}
+				row[k] = v
+			}
+			keys[i] = row
+		}
+		indexed := make([]int, len(groups))
+		for i := range indexed {
+			indexed[i] = i
+		}
+		sort.SliceStable(indexed, func(a, b int) bool {
+			ki, kj := keys[indexed[a]], keys[indexed[b]]
+			for k, oe := range orderBy {
+				c := compare(ki[k], kj[k])
+				if oe.Descending() {
+					c = -c
+				}
+				if c != 0 {
+					return c < 0
+				}
+			}
+			return false
+		})
+		sorted := make([]*aggGroup, len(groups))
+		for i, idx := range indexed {
+			sorted[i] = groups[idx]
+		}
+		groups = sorted
+	}
+
+	// OFFSET then LIMIT on the grouped rows.
+	if offset := q.Offset(); offset > 0 {
+		if offset >= len(groups) {
+			groups = nil
+		} else {
+			groups = groups[offset:]
+		}
+	}
+	if limit := q.Limit(); limit > 0 && limit < len(groups) {
+		groups = groups[:limit]
+	}
+
+	records := make([]dal.Record, len(groups))
+	for i, g := range groups {
+		key := dal.NewKeyWithID(collection, fmt.Sprint(i))
+		records[i] = dal.NewRecordWithData(key, g.out).SetError(nil)
+	}
+	return dal.NewRecordsReader(records), nil
+}
+
+// groupKey builds a stable partition key from the resolved GROUP BY expression
+// values of a single row. The type tag avoids collisions between values of
+// different types that share a textual form (e.g. int 1 vs string "1").
+func groupKey(groupBy []dal.Expression, r rowSources, known map[string]bool) (string, error) {
+	parts := make([]string, len(groupBy))
+	for i, ge := range groupBy {
+		v, _, err := resolveJoinExpr(ge, r, known)
+		if err != nil {
+			return "", err
+		}
+		parts[i] = fmt.Sprintf("%T:%v", v, v)
+	}
+	return strings.Join(parts, "\x00"), nil
+}
+
+// resolveGroupValue resolves an expression to a single per-group value: an
+// aggregate is evaluated over the group's rows; a FieldRef resolves first
+// against the already-projected output row (so HAVING/ORDER BY can reference a
+// SELECT alias), then as a GROUP BY field from a member row; a Constant yields
+// its value.
+func resolveGroupValue(e dal.Expression, g *aggGroup, known map[string]bool) (any, error) {
+	switch ex := e.(type) {
+	case dal.AggregateFunc:
+		return evalAggregate(ex, g.rows, known)
+	case dal.FieldRef:
+		if ex.Source() == "" && g.out != nil {
+			if v, ok := g.out[ex.Name()]; ok {
+				return v, nil
+			}
+		}
+		// A group always has at least one member row.
+		v, _, err := resolveJoinExpr(ex, g.rows[0], known)
+		return v, err
+	case dal.Constant:
+		return ex.Value, nil
+	default:
+		return nil, fmt.Errorf("dalgo2memory: unsupported grouped expression %T", e)
+	}
+}
+
+// evalAggregate computes one aggregate over a group's rows with standard SQL
+// null handling (NULLs skipped). COUNT(*) (a non-field argument) counts all
+// rows; COUNT(field) counts non-null values; SUM/AVG operate on numeric values
+// (all-null -> nil); MIN/MAX reduce by the shared comparator (all-null -> nil).
+func evalAggregate(af dal.AggregateFunc, rows []rowSources, known map[string]bool) (any, error) {
+	args := af.FuncArgs()
+	switch af.FuncName() {
+	case dal.COUNT:
+		if len(args) == 1 {
+			if _, isField := args[0].(dal.FieldRef); !isField {
+				return len(rows), nil
+			}
+		}
+		n := 0
+		for _, r := range rows {
+			v, present, err := resolveJoinExpr(args[0], r, known)
+			if err != nil {
+				return nil, err
+			}
+			if present && v != nil {
+				n++
+			}
+		}
+		return n, nil
+	case dal.SUM, dal.AVERAGE:
+		sum, cnt := 0.0, 0
+		for _, r := range rows {
+			v, present, err := resolveJoinExpr(args[0], r, known)
+			if err != nil {
+				return nil, err
+			}
+			if !present || v == nil {
+				continue
+			}
+			f, ok := number(v)
+			if !ok {
+				continue
+			}
+			sum += f
+			cnt++
+		}
+		if cnt == 0 {
+			return nil, nil
+		}
+		if af.FuncName() == dal.AVERAGE {
+			return sum / float64(cnt), nil
+		}
+		return sum, nil
+	case dal.MIN, dal.MAX:
+		var best any
+		found := false
+		for _, r := range rows {
+			v, present, err := resolveJoinExpr(args[0], r, known)
+			if err != nil {
+				return nil, err
+			}
+			if !present || v == nil {
+				continue
+			}
+			if !found {
+				best, found = v, true
+				continue
+			}
+			c := compare(v, best)
+			if (af.FuncName() == dal.MIN && c < 0) || (af.FuncName() == dal.MAX && c > 0) {
+				best = v
+			}
+		}
+		if !found {
+			return nil, nil
+		}
+		return best, nil
+	default:
+		return nil, fmt.Errorf("dalgo2memory: unsupported aggregate %q", af.FuncName())
+	}
+}
+
+// matchesHaving evaluates a HAVING condition over a projected group. A
+// Comparison resolves both operands to per-group values (alias or aggregate
+// expression) and applies the operator; a GroupCondition composes AND/OR.
+func matchesHaving(cond dal.Condition, g *aggGroup, known map[string]bool) (bool, error) {
+	switch c := cond.(type) {
+	case dal.Comparison:
+		l, err := resolveGroupValue(c.Left, g, known)
+		if err != nil {
+			return false, err
+		}
+		r, err := resolveGroupValue(c.Right, g, known)
+		if err != nil {
+			return false, err
+		}
+		return compareOp(c.Operator, l, r), nil
+	case dal.GroupCondition:
+		conds := c.Conditions()
+		if c.Operator() == dal.Or {
+			for _, sub := range conds {
+				ok, err := matchesHaving(sub, g, known)
+				if err != nil {
+					return false, err
+				}
+				if ok {
+					return true, nil
+				}
+			}
+			return false, nil
+		}
+		for _, sub := range conds {
+			ok, err := matchesHaving(sub, g, known)
+			if err != nil {
+				return false, err
+			}
+			if !ok {
+				return false, nil
+			}
+		}
+		return true, nil
+	default:
+		return false, fmt.Errorf("dalgo2memory: unsupported HAVING condition %T", cond)
+	}
+}
+
+// compareOp applies a comparison operator to two values via the shared
+// numeric/string comparator.
+func compareOp(op dal.Operator, l, r any) bool {
+	c := compare(l, r)
+	switch op {
+	case dal.Equal:
+		return c == 0
+	case dal.GreaterThen:
+		return c > 0
+	case dal.GreaterOrEqual:
+		return c >= 0
+	case dal.LessThen:
+		return c < 0
+	case dal.LessOrEqual:
+		return c <= 0
+	default:
+		return false
+	}
+}
+
+// columnOutKey is the output map key for a selected column: its Alias, else a
+// FieldRef's name, else the expression's textual form.
+func columnOutKey(col dal.Column) string {
+	if col.Alias != "" {
+		return col.Alias
+	}
+	if f, ok := col.Expression.(dal.FieldRef); ok {
+		return f.Name()
+	}
+	return col.Expression.String()
+}

--- a/dalgo2memory/group_coverage_test.go
+++ b/dalgo2memory/group_coverage_test.go
@@ -1,0 +1,317 @@
+package dalgo2memory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/stretchr/testify/require"
+)
+
+// --- fakes to reach the unsupported-type error branches ---
+
+type fakeCond struct{}
+
+func (fakeCond) String() string { return "FAKE_COND" }
+
+type fakeExpr struct{}
+
+func (fakeExpr) String() string { return "FAKE_EXPR" }
+
+type fakeAgg struct{}
+
+func (fakeAgg) String() string             { return "MEDIAN(amount)" }
+func (fakeAgg) FuncName() string           { return "MEDIAN" }
+func (fakeAgg) FuncArgs() []dal.Expression { return []dal.Expression{dal.Field("amount")} }
+
+// MIN/MAX over a group, with the null amount skipped.
+func TestGroupBy_MinMax(t *testing.T) {
+	db, ctx := seedSales(t)
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		SelectColumns(
+			dal.Column{Expression: dal.Field("category")},
+			dal.MinAs(dal.Field("amount"), "lo"),
+			dal.MaxAs(dal.Field("amount"), "hi"),
+		)
+	groups := byCategory(t, runProjection(t, db, ctx, q))
+	require.EqualValues(t, 10, groups["A"]["lo"])
+	require.EqualValues(t, 20, groups["A"]["hi"])
+	require.EqualValues(t, 5, groups["B"]["lo"])
+	require.EqualValues(t, 5, groups["B"]["hi"])
+}
+
+// COUNT(field) counts non-null values only (group A's null amount excluded).
+func TestGroupBy_CountField(t *testing.T) {
+	db, ctx := seedSales(t)
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		SelectColumns(
+			dal.Column{Expression: dal.Field("category")},
+			dal.CountAs(dal.Field("amount"), "nonNull"),
+		)
+	groups := byCategory(t, runProjection(t, db, ctx, q))
+	require.EqualValues(t, 2, groups["A"]["nonNull"], "A has 2 non-null amounts of 3 rows")
+	require.EqualValues(t, 1, groups["B"]["nonNull"])
+}
+
+// OFFSET skips leading groups; an offset beyond the group count yields none.
+func TestGroupBy_Offset(t *testing.T) {
+	db, ctx := seedSales(t)
+	mk := func(offset int) []map[string]any {
+		countAll := dal.Count()
+		countAll.Alias = "n"
+		q := salesQuery().
+			GroupBy(dal.Field("category")).
+			OrderBy(dal.AscendingField("category")).
+			Offset(offset).
+			SelectColumns(dal.Column{Expression: dal.Field("category")}, countAll)
+		return runProjection(t, db, ctx, q)
+	}
+	after1 := mk(1)
+	require.Len(t, after1, 1)
+	require.Equal(t, "B", after1[0]["category"])
+	require.Empty(t, mk(5), "offset past the last group yields no rows")
+}
+
+// An unaliased aggregate column is keyed by its expression text.
+func TestGroupBy_UnaliasedAggregateKey(t *testing.T) {
+	db, ctx := seedSales(t)
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		SelectColumns(dal.Column{Expression: dal.Field("category")}, dal.Count())
+	rows := runProjection(t, db, ctx, q)
+	require.Len(t, rows, 2)
+	for _, r := range rows {
+		require.Contains(t, r, "COUNT(*)")
+	}
+}
+
+// Every comparison operator routed through HAVING, plus an unsupported operator
+// that drops all groups.
+func TestGroupBy_HavingOperators(t *testing.T) {
+	cases := []struct {
+		name string
+		op   dal.Operator
+		val  int
+		want []string
+	}{
+		{"equal", dal.Equal, 30, []string{"A"}},
+		{"greaterOrEqual", dal.GreaterOrEqual, 30, []string{"A"}},
+		{"lessThen", dal.LessThen, 10, []string{"B"}},
+		{"lessOrEqual", dal.LessOrEqual, 5, []string{"B"}},
+		{"unsupportedOp", dal.In, 30, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, ctx := seedSales(t)
+			q := salesQuery().
+				GroupBy(dal.Field("category")).
+				Having(dal.NewComparison(dal.Field("total"), tc.op, dal.NewConstant(tc.val))).
+				SelectColumns(dal.Column{Expression: dal.Field("category")}, dal.SumAs(dal.Field("amount"), "total"))
+			got := byCategory(t, runProjection(t, db, ctx, q))
+			require.Len(t, got, len(tc.want))
+			for _, cat := range tc.want {
+				require.Contains(t, got, cat)
+			}
+		})
+	}
+}
+
+// Multiple HAVING conditions AND-compose; A passes both, B fails one.
+func TestGroupBy_HavingAnd(t *testing.T) {
+	db, ctx := seedSales(t)
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		Having(dal.NewComparison(dal.Field("total"), dal.GreaterThen, dal.NewConstant(10))).
+		Having(dal.NewComparison(dal.Count().Expression, dal.GreaterOrEqual, dal.NewConstant(2))).
+		SelectColumns(dal.Column{Expression: dal.Field("category")}, dal.SumAs(dal.Field("amount"), "total"))
+	rows := runProjection(t, db, ctx, q)
+	require.Len(t, rows, 1)
+	require.Equal(t, "A", rows[0]["category"])
+}
+
+// A HAVING GroupCondition with OR: A matches the second disjunct, B matches
+// neither.
+func TestGroupBy_HavingOr(t *testing.T) {
+	db, ctx := seedSales(t)
+	or := dal.NewGroupCondition(dal.Or,
+		dal.NewComparison(dal.Field("total"), dal.GreaterThen, dal.NewConstant(100)),
+		dal.NewComparison(dal.Field("total"), dal.GreaterThen, dal.NewConstant(10)),
+	)
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		Having(or).
+		SelectColumns(dal.Column{Expression: dal.Field("category")}, dal.SumAs(dal.Field("amount"), "total"))
+	rows := runProjection(t, db, ctx, q)
+	require.Len(t, rows, 1)
+	require.Equal(t, "A", rows[0]["category"])
+}
+
+// HAVING comparing two constants resolves both operands as constants.
+func TestGroupBy_HavingConstants(t *testing.T) {
+	db, ctx := seedSales(t)
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		Having(dal.NewComparison(dal.NewConstant(5), dal.GreaterThen, dal.NewConstant(2))).
+		SelectColumns(dal.Column{Expression: dal.Field("category")})
+	require.Len(t, runProjection(t, db, ctx, q), 2, "5 > 2 is always true; both groups kept")
+}
+
+// --- error branches ---
+
+func runGroupedExpectError(t *testing.T, q dal.Query, contains string) {
+	t.Helper()
+	db, ctx := seedSales(t)
+	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+	require.Nil(t, reader)
+	require.ErrorContains(t, err, contains)
+}
+
+func TestGroupBy_UnknownGroupBySource(t *testing.T) {
+	q := salesQuery().
+		GroupBy(dal.NewFieldRef("bad", "category")).
+		SelectColumns(dal.Column{Expression: dal.NewFieldRef("bad", "category")})
+	runGroupedExpectError(t, q, "GROUP BY field")
+}
+
+func TestGroupBy_GroupByUnsupportedExpr(t *testing.T) {
+	q := salesQuery().
+		GroupBy(dal.Count().Expression).
+		SelectColumns(dal.Count())
+	runGroupedExpectError(t, q, "unsupported expression")
+}
+
+func TestGroupBy_AggregateBadSourceInProjection(t *testing.T) {
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		SelectColumns(
+			dal.Column{Expression: dal.Field("category")},
+			dal.SumAs(dal.NewFieldRef("bad", "amount"), "total"),
+		)
+	runGroupedExpectError(t, q, "unknown source")
+}
+
+func TestGroupBy_CountBadSourceInProjection(t *testing.T) {
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		SelectColumns(
+			dal.Column{Expression: dal.Field("category")},
+			dal.CountAs(dal.NewFieldRef("bad", "amount"), "n"),
+		)
+	runGroupedExpectError(t, q, "unknown source")
+}
+
+func TestGroupBy_MinBadSourceInProjection(t *testing.T) {
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		SelectColumns(
+			dal.Column{Expression: dal.Field("category")},
+			dal.MinAs(dal.NewFieldRef("bad", "amount"), "lo"),
+		)
+	runGroupedExpectError(t, q, "unknown source")
+}
+
+// Two groups tie on the ORDER BY aggregate; the stable comparator keeps both.
+func TestGroupBy_OrderByTie(t *testing.T) {
+	db := NewDB().(*database)
+	ctx := context.Background()
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("sales", "1"), &map[string]any{"category": "A"})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("sales", "2"), &map[string]any{"category": "B"})))
+	countAll := dal.Count()
+	countAll.Alias = "n"
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		OrderBy(dal.Descending(dal.Count().Expression)).
+		SelectColumns(dal.Column{Expression: dal.Field("category")}, countAll)
+	rows := runProjection(t, db, ctx, q)
+	require.Len(t, rows, 2, "both groups have COUNT(*)=1; tie keeps both")
+}
+
+// A HAVING whose right operand errors propagates the error.
+func TestGroupBy_HavingRightOperandError(t *testing.T) {
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		Having(dal.NewComparison(dal.Field("total"), dal.GreaterThen, dal.SumAs(dal.NewFieldRef("bad", "amount"), "").Expression)).
+		SelectColumns(dal.Column{Expression: dal.Field("category")}, dal.SumAs(dal.Field("amount"), "total"))
+	runGroupedExpectError(t, q, "unknown source")
+}
+
+func TestGroupBy_HavingBadSource(t *testing.T) {
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		Having(dal.NewComparison(dal.SumAs(dal.NewFieldRef("bad", "amount"), "").Expression, dal.GreaterThen, dal.NewConstant(1))).
+		SelectColumns(dal.Column{Expression: dal.Field("category")})
+	runGroupedExpectError(t, q, "unknown source")
+}
+
+func TestGroupBy_OrderByBadSource(t *testing.T) {
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		OrderBy(dal.Descending(dal.SumAs(dal.NewFieldRef("bad", "amount"), "").Expression)).
+		SelectColumns(dal.Column{Expression: dal.Field("category")})
+	runGroupedExpectError(t, q, "unknown source")
+}
+
+// SUM skips a non-numeric (non-null) value in the group.
+func TestGroupBy_SumSkipsNonNumeric(t *testing.T) {
+	db := NewDB().(*database)
+	ctx := context.Background()
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("sales", "1"), &map[string]any{"category": "A", "amount": 10})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("sales", "2"), &map[string]any{"category": "A", "amount": "oops"})))
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		SelectColumns(dal.Column{Expression: dal.Field("category")}, dal.SumAs(dal.Field("amount"), "total"))
+	rows := runProjection(t, db, ctx, q)
+	require.Len(t, rows, 1)
+	require.EqualValues(t, 10, rows[0]["total"], "non-numeric amount skipped")
+}
+
+// A HAVING OR whose first disjunct errors propagates the error.
+func TestGroupBy_HavingOrError(t *testing.T) {
+	or := dal.NewGroupCondition(dal.Or,
+		dal.NewComparison(dal.SumAs(dal.NewFieldRef("bad", "amount"), "").Expression, dal.GreaterThen, dal.NewConstant(1)),
+		dal.NewComparison(dal.Field("total"), dal.GreaterThen, dal.NewConstant(1)),
+	)
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		Having(or).
+		SelectColumns(dal.Column{Expression: dal.Field("category")}, dal.SumAs(dal.Field("amount"), "total"))
+	runGroupedExpectError(t, q, "unknown source")
+}
+
+// A HAVING AND whose first conjunct errors propagates the error.
+func TestGroupBy_HavingAndError(t *testing.T) {
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		Having(dal.NewComparison(dal.SumAs(dal.NewFieldRef("bad", "amount"), "").Expression, dal.GreaterThen, dal.NewConstant(1))).
+		Having(dal.NewComparison(dal.Field("total"), dal.GreaterThen, dal.NewConstant(1))).
+		SelectColumns(dal.Column{Expression: dal.Field("category")}, dal.SumAs(dal.Field("amount"), "total"))
+	runGroupedExpectError(t, q, "unknown source")
+}
+
+func TestGroupBy_HavingUnsupportedExpr(t *testing.T) {
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		Having(dal.NewComparison(fakeExpr{}, dal.GreaterThen, dal.NewConstant(1))).
+		SelectColumns(dal.Column{Expression: dal.Field("category")})
+	runGroupedExpectError(t, q, "unsupported grouped expression")
+}
+
+func TestGroupBy_HavingUnsupportedCondition(t *testing.T) {
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		Having(fakeCond{}).
+		SelectColumns(dal.Column{Expression: dal.Field("category")})
+	runGroupedExpectError(t, q, "unsupported HAVING condition")
+}
+
+func TestGroupBy_UnsupportedAggregate(t *testing.T) {
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		SelectColumns(
+			dal.Column{Expression: dal.Field("category")},
+			dal.Column{Alias: "m", Expression: fakeAgg{}},
+		)
+	runGroupedExpectError(t, q, "unsupported aggregate")
+}

--- a/dalgo2memory/group_test.go
+++ b/dalgo2memory/group_test.go
@@ -1,0 +1,238 @@
+package dalgo2memory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/stretchr/testify/require"
+)
+
+// seedSales loads sales rows carrying category and amount to exercise GROUP BY
+// aggregation. Category A has three rows (10, 20, null); category B has one (5).
+func seedSales(t *testing.T) (*database, context.Context) {
+	t.Helper()
+	db := NewDB().(*database)
+	ctx := context.Background()
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("sales", "1"), &map[string]any{"category": "A", "amount": 10})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("sales", "2"), &map[string]any{"category": "A", "amount": 20})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("sales", "3"), &map[string]any{"category": "A", "amount": nil})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("sales", "4"), &map[string]any{"category": "B", "amount": 5})))
+	return db, ctx
+}
+
+func salesQuery() *dal.QueryBuilder {
+	return dal.From(dal.NewRootCollectionRef("sales", "")).NewQuery()
+}
+
+// byCategory indexes grouped result rows by their "category" output key.
+func byCategory(t *testing.T, rows []map[string]any) map[string]map[string]any {
+	t.Helper()
+	out := make(map[string]map[string]any, len(rows))
+	for _, r := range rows {
+		cat, ok := r["category"].(string)
+		require.True(t, ok, "row missing string category: %v", r)
+		out[cat] = r
+	}
+	return out
+}
+
+// AC single-source-grouping-with-aggregates: COUNT(*), SUM and AVG per group,
+// with the null amount skipped so A's avg divides by 2.
+func TestGroupBy_SingleSourceAggregates(t *testing.T) {
+	db, ctx := seedSales(t)
+	countAll := dal.Count()
+	countAll.Alias = "n"
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		SelectColumns(
+			dal.Column{Expression: dal.Field("category")},
+			countAll,
+			dal.SumAs(dal.Field("amount"), "total"),
+			dal.AverageAs(dal.Field("amount"), "avg"),
+		)
+	rows := runProjection(t, db, ctx, q)
+	require.Len(t, rows, 2)
+	groups := byCategory(t, rows)
+
+	require.EqualValues(t, 3, groups["A"]["n"])
+	require.EqualValues(t, 30, groups["A"]["total"])
+	require.EqualValues(t, 15, groups["A"]["avg"])
+
+	require.EqualValues(t, 1, groups["B"]["n"])
+	require.EqualValues(t, 5, groups["B"]["total"])
+	require.EqualValues(t, 5, groups["B"]["avg"])
+}
+
+// AC all-null-group-aggregates-null: a group whose values are all null yields
+// nil SUM/MAX while COUNT(*) still counts the rows.
+func TestGroupBy_AllNullGroup(t *testing.T) {
+	db := NewDB().(*database)
+	ctx := context.Background()
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("sales", "1"), &map[string]any{"category": "A", "amount": nil})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("sales", "2"), &map[string]any{"category": "A", "amount": nil})))
+
+	countAll := dal.Count()
+	countAll.Alias = "n"
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		SelectColumns(
+			dal.Column{Expression: dal.Field("category")},
+			dal.SumAs(dal.Field("amount"), "total"),
+			dal.MaxAs(dal.Field("amount"), "hi"),
+			countAll,
+		)
+	rows := runProjection(t, db, ctx, q)
+	require.Len(t, rows, 1)
+	require.Nil(t, rows[0]["total"])
+	require.Nil(t, rows[0]["hi"])
+	require.EqualValues(t, 2, rows[0]["n"])
+}
+
+// AC non-grouped-select-column-errors: selecting a non-aggregate column absent
+// from GROUP BY errors before producing rows.
+func TestGroupBy_NonGroupedColumnErrors(t *testing.T) {
+	db, ctx := seedSales(t)
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		SelectColumns(
+			dal.Column{Expression: dal.Field("category")},
+			dal.Column{Expression: dal.Field("amount")}, // not aggregated, not in GROUP BY
+		)
+	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+	require.Nil(t, reader)
+	require.ErrorContains(t, err, "neither an aggregate nor in GROUP BY")
+}
+
+// AC having-filters-by-alias: HAVING total > 10 keeps only group A.
+func TestGroupBy_HavingByAlias(t *testing.T) {
+	db, ctx := seedSales(t)
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		Having(dal.NewComparison(dal.Field("total"), dal.GreaterThen, dal.NewConstant(10))).
+		SelectColumns(
+			dal.Column{Expression: dal.Field("category")},
+			dal.SumAs(dal.Field("amount"), "total"),
+		)
+	rows := runProjection(t, db, ctx, q)
+	require.Len(t, rows, 1)
+	require.Equal(t, "A", rows[0]["category"])
+	require.EqualValues(t, 30, rows[0]["total"])
+}
+
+// AC having-filters-by-aggregate-expression: HAVING SUM(amount) > 10 yields the
+// identical result to the alias form.
+func TestGroupBy_HavingByAggregateExpression(t *testing.T) {
+	db, ctx := seedSales(t)
+	sum := dal.SumAs(dal.Field("amount"), "total")
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		Having(dal.NewComparison(sum.Expression, dal.GreaterThen, dal.NewConstant(10))).
+		SelectColumns(
+			dal.Column{Expression: dal.Field("category")},
+			sum,
+		)
+	rows := runProjection(t, db, ctx, q)
+	require.Len(t, rows, 1)
+	require.Equal(t, "A", rows[0]["category"])
+}
+
+// AC having-on-unselected-aggregate: HAVING references SUM(amount) which is not
+// selected; group A survives and the output carries only category and n.
+func TestGroupBy_HavingOnUnselectedAggregate(t *testing.T) {
+	db, ctx := seedSales(t)
+	countAll := dal.Count()
+	countAll.Alias = "n"
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		Having(dal.NewComparison(dal.SumAs(dal.Field("amount"), "").Expression, dal.GreaterThen, dal.NewConstant(10))).
+		SelectColumns(
+			dal.Column{Expression: dal.Field("category")},
+			countAll,
+		)
+	rows := runProjection(t, db, ctx, q)
+	require.Len(t, rows, 1)
+	require.Equal(t, "A", rows[0]["category"])
+	require.EqualValues(t, 3, rows[0]["n"])
+	require.NotContains(t, rows[0], "total")
+	require.Len(t, rows[0], 2, "output must contain only category and n")
+}
+
+// AC grouped-order-and-limit: order by COUNT(*) descending with LIMIT 2 returns
+// the two highest-count groups in order.
+func TestGroupBy_OrderAndLimit(t *testing.T) {
+	db := NewDB().(*database)
+	ctx := context.Background()
+	// 5 rows in A, 3 in B, 1 in C.
+	add := func(id, cat string) {
+		require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("sales", id), &map[string]any{"category": cat})))
+	}
+	add("a1", "A")
+	add("a2", "A")
+	add("a3", "A")
+	add("a4", "A")
+	add("a5", "A")
+	add("b1", "B")
+	add("b2", "B")
+	add("b3", "B")
+	add("c1", "C")
+
+	countAll := dal.Count()
+	countAll.Alias = "n"
+	q := salesQuery().
+		GroupBy(dal.Field("category")).
+		OrderBy(dal.Descending(dal.Count().Expression)).
+		Limit(2).
+		SelectColumns(
+			dal.Column{Expression: dal.Field("category")},
+			countAll,
+		)
+	rows := runProjection(t, db, ctx, q)
+	require.Len(t, rows, 2)
+	require.Equal(t, "A", rows[0]["category"])
+	require.EqualValues(t, 5, rows[0]["n"])
+	require.Equal(t, "B", rows[1]["category"])
+	require.EqualValues(t, 3, rows[1]["n"])
+}
+
+// AC empty-groupby-unchanged: a query with no GroupBy is unaffected — the
+// projection path still returns one record per row.
+func TestGroupBy_EmptyUnchanged(t *testing.T) {
+	db, ctx := seedSales(t)
+	q := salesQuery().SelectColumns(dal.Column{Expression: dal.Field("category")})
+	rows := runProjection(t, db, ctx, q)
+	require.Len(t, rows, 4, "no GROUP BY: one record per source row, not aggregated")
+}
+
+// AC join-grouping-qualified: GROUP BY u.country over a join, COUNT(*) of joined
+// rows per country.
+func TestGroupBy_JoinQualified(t *testing.T) {
+	db := NewDB().(*database)
+	ctx := context.Background()
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("users", "1"), &map[string]any{"id": 1, "country": "US"})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("users", "2"), &map[string]any{"id": 2, "country": "US"})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("users", "3"), &map[string]any{"id": 3, "country": "DE"})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("orders", "a"), &map[string]any{"userId": 1})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("orders", "b"), &map[string]any{"userId": 2})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("orders", "c"), &map[string]any{"userId": 3})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("orders", "d"), &map[string]any{"userId": 1})))
+
+	join := dal.NewJoinedSource(ordersAlias(), dal.JoinInner,
+		dal.NewComparison(dal.NewFieldRef("u", "id"), dal.Equal, dal.NewFieldRef("o", "userId")))
+	countAll := dal.Count()
+	countAll.Alias = "orders"
+	q := dal.From(usersAlias()).Join(join).NewQuery().
+		GroupBy(dal.NewFieldRef("u", "country")).
+		SelectColumns(
+			dal.Column{Expression: dal.NewFieldRef("u", "country")},
+			countAll,
+		)
+	rows := runJoinQuery(t, db, ctx, q)
+	require.Len(t, rows, 2)
+	groups := make(map[string]any, 2)
+	for _, r := range rows {
+		groups[r["country"].(string)] = r["orders"]
+	}
+	require.EqualValues(t, 3, groups["US"], "US: orders a,b,d joined")
+	require.EqualValues(t, 1, groups["DE"], "DE: order c joined")
+}

--- a/dalgo2memory/join.go
+++ b/dalgo2memory/join.go
@@ -44,8 +44,11 @@ func (s session) executeJoinQuery(q dal.StructuredQuery) (dal.RecordsReader, err
 	if err := validateOrderSources(q.OrderBy(), known); err != nil {
 		return nil, err
 	}
-	if err := validateColumns(q.Columns(), known); err != nil {
-		return nil, err
+	grouped := len(q.GroupBy()) > 0
+	if !grouped {
+		if err := validateColumns(q.Columns(), known); err != nil {
+			return nil, err
+		}
 	}
 
 	baseRows, err := s.loadRows(base.Name())
@@ -88,6 +91,14 @@ func (s session) executeJoinQuery(q dal.StructuredQuery) (dal.RecordsReader, err
 		if ok {
 			filtered = append(filtered, row)
 		}
+	}
+
+	if grouped {
+		srcs := make([]rowSources, len(filtered))
+		for i, row := range filtered {
+			srcs[i] = row.sources
+		}
+		return executeGroupedReader(q, srcs, base.Name(), known)
 	}
 
 	orderJoinedRows(filtered, q.OrderBy())

--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -20,6 +20,7 @@ The Feature format follows [SpecScore](https://specscore.md/feature-specificatio
 | [query-joins](query-joins/README.md) | Approved | — |
 | [qualified-orderby-resolution](qualified-orderby-resolution/README.md) | Approved | — |
 | [query-column-projection](query-column-projection/README.md) | Stable | — |
+| [query-group-by-aggregation](query-group-by-aggregation/README.md) | Implementing | — |
 
 ## Open Questions
 

--- a/spec/features/query-group-by-aggregation/README.md
+++ b/spec/features/query-group-by-aggregation/README.md
@@ -1,0 +1,187 @@
+# Feature: GROUP BY with aggregation in the query builder, executed by dalgo2memory
+
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-group-by-aggregation?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-group-by-aggregation?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-group-by-aggregation?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-group-by-aggregation?op=request-change) |
+**Status:** Implementing
+**Date:** 2026-06-05
+**Owner:** alex
+**Source Ideas:** query-group-by-aggregation
+**Supersedes:** —
+**Grade:** A
+
+## Summary
+
+Adds `GroupBy` and `Having` to `dal.QueryBuilder` (plus a `COUNT(*)` star expression with a `Count()` alias), and teaches `dalgo2memory` to execute grouped queries: partition matched rows into groups, emit one aggregated row per group, evaluate `SUM`/`COUNT`/`MIN`/`MAX`/`AVG` with standard SQL null handling, and filter groups with `HAVING` — for both single-source and join queries. An empty `GroupBy()` keeps today's behavior unchanged.
+
+## Problem
+
+The grouping infrastructure is half-built and unreachable. `dal.StructuredQuery` already exposes `GroupBy() []Expression`, `structuredQuery` carries the `groupBy` field and getter, and `String()` already renders a `GROUP BY` clause — but `IQueryBuilder`/`QueryBuilder` has no setter, so `structuredQuery.groupBy` is never assigned from normal code (the same dead-code trap `query-column-projection` found with `columns`). The aggregate `Column` builders (`SumAs`/`CountAs`/`MinAs`/`MaxAs`/`AverageAs`) exist too, but `dalgo2memory` never reads `q.GroupBy()` and its `validateColumns` actively rejects any non-`FieldRef` column, so those aggregates cannot execute against the in-memory adapter. There is no `Having()` anywhere, and no way to express `COUNT(*)`. This Feature makes GROUP BY a first-class builder capability and gives it a real executor, reusing the source-aware field resolver the join `WHERE`/`ORDER BY` already use.
+
+## Behavior
+
+### Expressing grouped queries (the `dal` builder)
+
+#### REQ: group-by-builder
+
+`dal.QueryBuilder` MUST provide a `GroupBy(expressions ...dal.Expression) dal.IQueryBuilder` method (also on the `IQueryBuilder` interface) that appends the given expressions to the query's group-by list, readable via `GroupBy()`, chainable like `OrderBy`. A query on which `GroupBy` is never called MUST have an empty `GroupBy()`.
+
+#### REQ: having-builder
+
+`dal.StructuredQuery` MUST expose `Having() dal.Condition`, backed by a new `having` field on `structuredQuery`. `dal.QueryBuilder` MUST provide a `Having(conditions ...dal.Condition) dal.IQueryBuilder` method (also on `IQueryBuilder`) that records the condition, AND-combining multiple conditions exactly as `Where` does. `structuredQuery.String()` MUST render the `HAVING` clause after the `GROUP BY` clause. A query on which `Having` is never called MUST have a nil `Having()`.
+
+#### REQ: count-star
+
+The `dal` query model MUST provide a way to express `COUNT(*)` — counting all rows in a group regardless of nulls — via a star/row expression, with a `Count()` builder defined as an alias for `Count(*)`. The expression MUST render as `COUNT(*)` in `String()`. The existing `CountAs(field, alias)` MUST retain its field-count (skip-nulls) semantics, distinct from `COUNT(*)`.
+
+### Executing grouped queries (`dalgo2memory`)
+
+#### REQ: partition-into-groups
+
+When `q.GroupBy()` is non-empty, `dalgo2memory` MUST, after applying `WHERE`, partition the matched rows into groups keyed by the ordered tuple of the group-by expression values — each resolved via the same per-source resolver used by `WHERE`/`ORDER BY` (empty `Source()` → `From` base; non-empty → the recordset whose `Alias()`/`Name()` matches) — and emit exactly one result row per distinct group, for both single-source and join queries.
+
+#### REQ: aggregate-evaluation
+
+For a grouped query, each selected aggregate function column (`SUM`, `COUNT`, `MIN`, `MAX`, `AVG`, and `COUNT(*)`) MUST be evaluated over the rows of its group using standard SQL null handling: `NULL` inputs are skipped; `AVG` divides the sum by the non-null count; `SUM`/`AVG`/`MIN`/`MAX` over a group with no non-null value yield `NULL`; `COUNT(<field>)` counts non-null values; `COUNT(*)` counts all rows in the group. Numeric inputs reuse the adapter's existing numeric coercion. A selected group-by column resolves to that group's key value.
+
+#### REQ: select-grouping-rule
+
+When `q.GroupBy()` is non-empty, a selected column that is neither an aggregate function expression nor one of the group-by expressions MUST produce a descriptive error and yield no result rows, before any group row is emitted — consistent with the eager-validation, hard-reject behavior `validateColumns` already applies.
+
+#### REQ: having-filter
+
+When `q.Having()` is non-nil, `dalgo2memory` MUST evaluate it as a post-aggregation filter over each group's aggregated row and drop the groups for which it is false. A `HAVING` operand MUST resolve an aggregate referenced **either** by its aggregate expression (e.g. `SUM(amount)`) **or** by the SELECT alias bound to that aggregate (e.g. `total`); both forms MUST yield the same per-group value. An aggregate referenced only in `HAVING` (not selected) MUST still be computed over the group and MUST NOT appear in the output row.
+
+#### REQ: grouped-order-limit
+
+For a grouped query, `ORDER BY`, `LIMIT`, and `OFFSET` MUST be applied to the post-`HAVING` group rows, not to the pre-grouping input rows.
+
+#### REQ: empty-groupby-unchanged
+
+A query with an empty `GroupBy()` MUST behave exactly as before this Feature — the grouping/aggregation path is not entered, and the existing projection / full-record / keys-only behavior is untouched.
+
+## Acceptance Criteria
+
+### AC: group-by-recorded (verifies REQ:group-by-builder)
+
+**Given** a `dal.QueryBuilder`
+**When** `GroupBy` is called with the field `category`
+**Then** the resulting query's `GroupBy()` returns that one expression, while a query on which `GroupBy` was never called returns an empty `GroupBy()`.
+
+### AC: having-recorded-and-rendered (verifies REQ:having-builder)
+
+**Given** a query grouped by `category`
+**When** `Having` is called with a condition `COUNT(*) > 2`
+**Then** `Having()` returns that condition and `String()` renders a `HAVING` clause positioned after the `GROUP BY` clause.
+
+### AC: count-star-expressible (verifies REQ:count-star)
+
+**Given** the `dal` query model
+**When** a column is built via `Count()`
+**Then** it equals the `Count(*)` star form, renders as `COUNT(*)`, and is distinct from `CountAs("amount", "n")` which counts a field.
+
+### AC: single-source-grouping-with-aggregates (verifies REQ:partition-into-groups, REQ:aggregate-evaluation)
+
+**Given** a single-source collection with three rows in category `A` (amounts `10`, `20`, `null`) and one row in category `B` (amount `5`), grouped by `category`, selecting `category`, `Count(*)` as `n`, `SumAs(amount,"total")`, and `AverageAs(amount,"avg")`
+**When** it is executed by `dalgo2memory`
+**Then** exactly two rows are returned — `A` with `n=3`, `total=30`, `avg=15` (the null amount skipped, so avg divides by 2); `B` with `n=1`, `total=5`, `avg=5`.
+
+### AC: join-grouping-qualified (verifies REQ:partition-into-groups)
+
+**Given** an INNER join of `users u` and `orders o` grouped by `u.country`, selecting `u.country` and `Count(*)` as `orders`
+**When** it is executed
+**Then** exactly one row per distinct country is returned, each carrying the count of joined `u`/`o` rows for that country.
+
+### AC: non-grouped-select-column-errors (verifies REQ:select-grouping-rule)
+
+**Given** a query grouped by `category` that selects a non-aggregate column `name` which is not in the `GROUP BY` list
+**When** it is executed
+**Then** it returns a descriptive error and yields no result rows.
+
+### AC: all-null-group-aggregates-null (verifies REQ:aggregate-evaluation)
+
+**Given** a single-source collection where every row of group `A` has a `null` `amount`, grouped by `category`, selecting `SumAs(amount,"total")`, `MaxAs(amount,"hi")`, and `Count(*)` as `n`
+**When** it is executed
+**Then** group `A`'s row has `total=null` and `hi=null` while `n` equals the row count of the group.
+
+### AC: having-filters-by-alias (verifies REQ:having-filter)
+
+**Given** the rows grouped by `category` (group `A` total `30`, group `B` total `5`), `SumAs(amount,"total")` selected, with `HAVING total > 10`
+**When** it is executed
+**Then** only group `A` is returned; group `B` is dropped.
+
+### AC: having-filters-by-aggregate-expression (verifies REQ:having-filter)
+
+**Given** the same grouping with `HAVING SUM(amount) > 10` (the aggregate-expression form)
+**When** it is executed
+**Then** the result is identical to the alias form — only group `A` is returned.
+
+### AC: having-on-unselected-aggregate (verifies REQ:having-filter)
+
+**Given** rows grouped by `category` selecting only `category` and `Count(*)` as `n`, with `HAVING SUM(amount) > 10` where `SUM(amount)` is not selected
+**When** it is executed
+**Then** group `A` (sum `30`) is returned and group `B` (sum `5`) is dropped, and each output row contains only `category` and `n` — no `SUM` value is added to the output.
+
+### AC: grouped-order-and-limit (verifies REQ:grouped-order-limit)
+
+**Given** rows producing three groups with `Count(*)` values `5`, `3`, and `1`, grouped and ordered by `Count(*)` descending with `LIMIT 2`
+**When** it is executed
+**Then** exactly the two highest-count groups are returned, in descending count order.
+
+### AC: empty-groupby-unchanged (verifies REQ:empty-groupby-unchanged)
+
+**Given** a query with no `GroupBy` call (empty `GroupBy()`)
+**When** it is executed by `dalgo2memory`
+**Then** it returns records exactly as before this Feature, with no grouping or aggregation applied.
+
+## Architecture & Components
+
+- **`dal` builder.** New chainable `GroupBy(expressions ...Expression) IQueryBuilder` and `Having(conditions ...Condition) IQueryBuilder` on `QueryBuilder` (and `IQueryBuilder`); `GroupBy` appends to `structuredQuery.groupBy`, `Having` records onto a new `having Condition` field (AND-combined like `Where`'s `conditions`). `StructuredQuery` gains `Having() Condition`; `String()` renders `HAVING` after the existing `GROUP BY` block. A new star/row `Expression` plus a `Count()` builder (alias for `Count(*)`) extend `q_functions.go` alongside the existing `CountAs`.
+- **`dalgo2memory` grouping engine.** When `q.GroupBy()` is non-empty, both `ExecuteQueryToRecordsReader` (single-source) and `executeJoinQuery` (join) route through a grouping pass: validate selected columns (each must be an aggregate `function` or a group-by expression, else error before rows), partition WHERE-matched rows by the group-key tuple via the shared per-source resolver, evaluate each selected aggregate per group (reusing the existing `number()` coercion), build the aggregated output row keyed by alias/field-name, apply `Having()` over that row, then apply `ORDER BY`/`LIMIT`/`OFFSET` to the surviving group rows. Empty `GroupBy()` bypasses the pass entirely.
+- **HAVING resolver.** A small operand resolver that maps a `HAVING` operand to a per-group value by matching either the SELECT alias→value map or an aggregate expression evaluated over the group (computing it on demand when it is not in SELECT), then feeds the existing `Condition` evaluator (`matchesWhere`-style).
+
+## Data Flow
+
+`GroupBy(exprs...)`/`Having(conds...)` record on the `StructuredQuery` → `dalgo2memory` checks `q.GroupBy()`; if empty it follows the existing path. If non-empty: validate selected columns (aggregate-or-group-key, else error) → scan/join to WHERE-matched rows → partition rows into groups by the group-key tuple → per group, resolve group-key columns and evaluate aggregate columns (null-skipping, `number()` coercion) into one output row → evaluate `Having()` over each group row (operand resolved by alias or aggregate expression) and drop failing groups → apply `ORDER BY`/`LIMIT`/`OFFSET` to the group rows → records with map data.
+
+## Error Handling & Failure Modes
+
+- Selected column that is neither an aggregate nor a group-by expression → descriptive error, no rows (`REQ:select-grouping-rule`).
+- A group-by or aggregate `FieldRef` naming a non-empty source that matches no recordset → descriptive error, no rows — consistent with the existing `WHERE`/`ORDER BY`/projection unresolvable-source behavior.
+- An aggregate over a group with no non-null value yields a `null` cell (not an error); `COUNT` of such a group yields `0`/the row count, never `null`.
+- A `HAVING` operand referencing an alias/aggregate that resolves to nothing computable → descriptive error, no rows.
+
+## Testing Strategy
+
+Table tests in `dal` (the `GroupBy`/`Having` methods record and `String()` renders them in order; `Count()` equals `Count(*)` and renders `COUNT(*)`) and in `dalgo2memory` (single-source grouping with `COUNT(*)`/`SUM`/`AVG` and a null amount; all-null group yields null aggregates; join grouping by a qualified key; the non-grouped-select-column error; `HAVING` by alias, by aggregate expression, and on an unselected aggregate; grouped `ORDER BY` + `LIMIT`; empty-`GroupBy()` unchanged). `dalgo2memory` MUST remain at 100% statement coverage, exercising every branch of the grouping, aggregation, validation, and `HAVING` paths.
+
+## Rehearse Integration
+
+All ACs are testable through pure Go — `dal` builder calls and `dalgo2memory` execution over in-memory collections — so they map directly to table tests (see `## Testing Strategy`). Per-AC Rehearse stub files are deferred to the Plan, where each AC becomes a concrete `*_test.go` case; the rehearsal surface is the Go test suite.
+
+## Out of Scope
+
+- DTQL serialization of `GROUP BY`/`HAVING` — `dtql/serialize.go` already rejects `GroupBy` as unsupported; left unchanged.
+- SQL adapters (`dalgo2sql`/`dalgo2sqlite`) — separate repos, unblocked by the shared `dal` capability.
+- `DISTINCT`, `GROUPING SETS`/`ROLLUP`/`CUBE`, and window functions — only flat `GROUP BY` is in scope.
+- New aggregate functions beyond the existing `SUM`/`COUNT`/`MIN`/`MAX`/`AVG` (plus the `COUNT(*)` star form) — no other function builders are added.
+- The columnar `ExecuteQueryToRecordsetReader` — stays `ErrNotSupported`; aggregation lands in the `RecordsReader` path as map records.
+
+## Assumption Carryover
+
+From the source Idea `query-group-by-aggregation`:
+
+- **Carried (Must):** `GroupBy`/`Having` terminals fit `dal.QueryBuilder` without disrupting the existing terminals — validated by `AC:group-by-recorded`, `AC:having-recorded-and-rendered`.
+- **Carried (Must):** the source-aware resolver computes group-key tuples and aggregate inputs over single-source and join rows — validated by `AC:single-source-grouping-with-aggregates`, `AC:join-grouping-qualified`.
+- **Carried (Must):** `validateColumns`/`projectRow` extend to evaluate aggregate `function` expressions and enforce the group-key-or-aggregate SELECT rule — validated by `AC:single-source-grouping-with-aggregates`, `AC:non-grouped-select-column-errors`.
+- **Resolved (was Should):** `HAVING` reuses `dal.Condition`, evaluated post-grouping, with operands by alias or aggregate expression — now `REQ:having-filter`, validated by the three `having-*` ACs.
+- **Carried (Should):** empty `GroupBy()` preserves today's behavior — validated by `AC:empty-groupby-unchanged`.
+- **Resolved decisions:** hard-error on the SELECT-grouping rule; `COUNT(*)` star expression with `Count()` alias; standard-SQL null skipping — now `REQ:select-grouping-rule`, `REQ:count-star`, `REQ:aggregate-evaluation`.
+- **Deferred (Might):** whether consumers adopt in-memory aggregation — not validated here; the capability is delivered regardless.
+
+## Open Questions
+
+- Exact name/shape of the star expression and the `Count()`/`CountAll` builder, and the `GroupBy`/`Having` method signatures — implementation details for the Plan.
+- Output-key collision when two selected columns resolve to the same alias/name — out of the MVP ACs (distinct keys used); last-write-wins vs. error is a Plan-time decision, consistent with the same open question in `query-column-projection`.
+- `MIN`/`MAX` over non-numeric (string) values — the in-scope ACs aggregate numeric fields; ordering semantics for non-numeric aggregates is deferred.
+
+---
+*This document follows the https://specscore.md/feature-specification*

--- a/spec/ideas/README.md
+++ b/spec/ideas/README.md
@@ -15,6 +15,7 @@ The Idea format follows [SpecScore](https://specscore.md/idea-specification).
 | [first-class-query-joins](first-class-query-joins.md) | Specified | 2026-06-05 | alexander.trakhimenok | query-joins |
 | [qualified-orderby-resolution](qualified-orderby-resolution.md) | Specified | 2026-06-05 | alex | qualified-orderby-resolution |
 | [query-column-projection](query-column-projection.md) | Implemented | 2026-06-05 | alex | query-column-projection |
+| [query-group-by-aggregation](query-group-by-aggregation.md) | Implementing | 2026-06-05 | alex | query-group-by-aggregation |
 | [recordops](recordops.md) | Approved | 2026-05-15 | alex | — |
 | [recordset-computed-columns](recordset-computed-columns.md) | Specified | 2026-06-02 | alex | recordset-computed-columns |
 | [transaction-message](transaction-message.md) | Approved | 2026-06-02 | alex | — |

--- a/spec/ideas/query-group-by-aggregation.md
+++ b/spec/ideas/query-group-by-aggregation.md
@@ -1,0 +1,78 @@
+# Idea: GROUP BY with aggregation in the query builder, executed by dalgo2memory
+
+**Status:** Implementing
+**Date:** 2026-06-05
+**Owner:** alex
+**Promotes To:** query-group-by-aggregation
+**Supersedes:** —
+**Related Ideas:** —
+
+## Problem Statement
+
+How might we let a dalgo caller express GROUP BY with aggregate functions and HAVING in the query builder, and have dalgo2memory return one aggregated row per group across single-source and joined queries?
+
+## Context
+
+Direct successor to query-column-projection (Implemented), which made dalgo2memory honor `q.Columns()` for plain FieldRef columns over single-source and join queries. The grouping infrastructure is half-built and currently unreachable: `dal.StructuredQuery` exposes `GroupBy() []Expression`, `structuredQuery` has the `groupBy []Expression` field plus getter, and `structuredQuery.String()` already renders a `GROUP BY` clause (`dal/query.go:38`, `dal/query_struct.go:25,68,153`). Aggregate Column builders already exist too — `SumAs`/`CountAs`/`MinAs`/`MaxAs`/`AverageAs` produce a `function` Expression wrapped in a `Column` (`dal/q_functions.go`). Two gaps make all of this dead code: (1) `IQueryBuilder`/`QueryBuilder` has no `GroupBy(...)` setter, so `structuredQuery.groupBy` is never assigned from normal code (same trap query-column-projection found with `columns`); (2) `dalgo2memory` never reads `q.GroupBy()`, and its `validateColumns` actively *rejects* any non-FieldRef column ("not a field reference"), so the existing aggregate builders cannot even execute against the in-memory adapter. There is also no `Having()` anywhere — not in the interface, struct, builder, or `String()`. The source-aware resolver introduced by qualified-orderby-resolution / first-class-query-joins (sources map: empty `Source()` → base, alias/name → source) is the same machinery that can compute group-key tuples and aggregate inputs.
+
+## Recommended Direction
+
+Deliver GROUP BY end to end against the in-memory adapter, sequenced so each step is independently shippable and testable rather than one big-bang change.
+
+**Step 1 — builder plumbing (dal).** Add a chainable `GroupBy(expressions ...Expression) IQueryBuilder` to `IQueryBuilder`/`QueryBuilder` that appends to `s.q.groupBy`, mirroring `OrderBy` exactly. Add the HAVING clause that does not yet exist: a `Having() Condition` getter on `StructuredQuery`, a `having Condition` field on `structuredQuery`, a `Having(conditions ...Condition) IQueryBuilder` builder method, and `String()` rendering of a `HAVING` clause after `GROUP BY`. HAVING reuses `dal.Condition` — the same type and evaluator as WHERE — the only difference being it runs *after* grouping, over the aggregated row (so its operands reference aggregate aliases). Also add a star/row expression and a `CountAll`/`Count()` builder so `COUNT(*)` is expressible, with `Count()` defined as an alias for `Count(*)` (counts all rows in a group regardless of nulls); the existing `CountAs(field, alias)` keeps its skip-nulls field semantics. No execution semantics yet — just make the query expressible and verify `q.GroupBy()`/`q.Having()` round-trip.
+
+**Step 2 — aggregation engine (dalgo2memory).** When `q.GroupBy()` is non-empty, after WHERE filtering, partition the matched rows into groups keyed by the tuple of group-key expression values (resolved via the existing source-aware resolver). Emit exactly one output row per distinct group. For each selected column: a group-key FieldRef resolves to that group's key value; an aggregate `function` Expression (SUM/COUNT/MIN/MAX/AVG) is evaluated over all rows in the group with **standard SQL null handling** — NULLs are skipped, `AVG` divides by the non-null count, and `SUM`/`AVG`/`MIN`/`MAX` over an all-null group return NULL; `COUNT(<field>)` counts non-null values while `COUNT(*)` counts all rows; numeric inputs reuse the existing `number()` coercion. Extend `validateColumns`/`projectRow` to accept aggregate `function` expressions when grouping is active, and **hard-reject** (before producing rows, consistent with `validateColumns` today) any grouped query whose SELECT has a non-aggregate column not present in `GROUP BY`. Apply `Having()` as a post-aggregation filter over the aggregated row. A HAVING operand may reference an aggregate by **either** form — the aggregate expression itself (`SUM(f2) > 5`) **or** its SELECT alias (`F_2 > 5`) — both resolving to the same per-group computed value; an aggregate referenced only in HAVING (not in SELECT) is still evaluated over the group. After HAVING, ORDER BY / LIMIT / OFFSET operate on the grouped rows.
+
+**Step 3 — joins.** Make the join executor (`join.go`) feed the same grouping/aggregation pass, so group keys and aggregate inputs can reference qualified sources, reusing the resolver the join WHERE/ORDER BY already use.
+
+This reuses three already-proven pieces — the `function` aggregate builders, the source-aware resolver, and the `map[string]any` projected-record output shape — so the new surface is the grouping driver itself plus the HAVING clause type, not a rewrite of the query model.
+
+## Alternatives Considered
+
+- **Grouping only, no aggregate evaluation.** Add `GroupBy(...)` and emit one row per distinct group-key tuple (group-key columns only), deferring aggregates. Smallest code change. Lost because GROUP BY without aggregation is just `DISTINCT` on the keys — and the pre-existing `SumAs`/`CountAs`/… builders make clear aggregation is the actual intent; shipping the keys-only version would leave those builders rejected and useless.
+- **Builder plumbing only; dalgo2memory returns `ErrNotSupported` for grouped queries.** Cheapest possible slice. Lost because it recreates exactly the dead-code trap query-column-projection diagnosed: a builder method whose only effect is a query no adapter can run.
+- **Defer HAVING and joins to follow-up Ideas; single-source aggregation only as the MVP.** Genuinely the simpler, lower-risk MVP, and it was offered. Lost to an explicit, informed scope decision by the owner to include joins and HAVING now. Recorded here because if the slice proves too large in practice, this is the fallback decomposition — Step 3 (joins) and the HAVING half of Step 2 are the natural cut lines.
+
+## MVP Scope
+
+A build that lands GROUP BY end to end in the in-memory adapter: `dal.QueryBuilder` can express `GroupBy(...)` group keys, aggregate columns (via the existing `SumAs`/`CountAs`/`MinAs`/`MaxAs`/`AverageAs`), and a `Having(...)` filter; and dalgo2memory returns one aggregated row per group. Verified by table tests over in-memory data: a single-source GROUP BY with a COUNT and a SUM per group; a HAVING that drops a group by its aggregate; the same over a two-table join with qualified group keys; an empty `GroupBy()` still returns full/ungrouped records unchanged; and dalgo2memory stays at 100% coverage. Sequenced internally (builder+HAVING clause → single-source aggregation → joins) so each step lands and is verified before the next.
+
+## Not Doing (and Why)
+
+- DTQL serialization of GROUP BY -- dtql/serialize.go already rejects GroupBy as unsupported; left unchanged
+- SQL adapters (dalgo2sql, dalgo2sqlite) -- separate repos, unblocked by the shared dal capability
+- DISTINCT, GROUPING SETS / ROLLUP / CUBE, window functions -- only flat GROUP BY is in scope
+- New aggregate functions beyond the existing SUM/COUNT/MIN/MAX/AVG -- no new function builders added
+- The columnar ExecuteQueryToRecordsetReader -- stays ErrNotSupported; aggregation lands in the RecordsReader path
+
+## Key Assumptions to Validate
+
+| Tier | Assumption | How to validate |
+|------|------------|-----------------|
+| Must-be-true | A `GroupBy(...)` and a new `Having(...)` terminal can be added to `dal.QueryBuilder` without disrupting the existing `OrderBy`/`Where`/`Select*` terminals, and a new `Having() Condition` getter + `having` field fit `StructuredQuery`/`structuredQuery` cleanly. | Add them, build a grouped query, confirm `q.GroupBy()`/`q.Having()` round-trip and `String()` renders both; existing builder tests stay green. |
+| Must-be-true | The source-aware resolver (empty `Source()` → base; alias/name → source) can compute group-key tuples and feed aggregate inputs over both single-source rows and join rows. | Group a single-source set by one field and a join by a qualified field (with a name collision across sources); assert each group key and aggregate input resolves from the right source. |
+| Must-be-true | `validateColumns`/`projectRow` can be extended to evaluate `function` aggregate expressions per group and to enforce "every non-aggregate SELECT column appears in GROUP BY", without breaking the ungrouped projection path. | Project a grouped query mixing a group-key column and `CountAs`/`SumAs`; assert values; assert a non-grouped, non-aggregate column is rejected; rerun the existing projection suite unchanged. |
+| Should-be-true | `Having()` can reuse `dal.Condition` evaluated over the aggregated/aliased output row (same shape `matchesWhere` already consumes) rather than needing a new clause type. | Add a HAVING that filters on a `COUNT` alias; confirm groups are dropped post-aggregation and the condition evaluator needs no special-casing. |
+| Should-be-true | An empty `GroupBy()` preserves today's exact behavior for every existing query (no grouping, full or projected records as before). | Run the full dalgo2memory suite unchanged; only queries built with `GroupBy(...)` take the grouping path. |
+| Might-be-true | Consumers actually want aggregation executed by the in-memory adapter (tests, datatug previews) rather than only by real SQL backends. | Review DTQL/datatug for a concrete in-memory aggregation use before widening past the five existing aggregate functions. |
+
+
+## SpecScore Integration
+
+- **New Features this would create:** a `query-group-by-aggregation` Feature (builder `GroupBy`/`Having` + dalgo2memory grouping/aggregation execution) — exact split TBD at spec time.
+- **Existing Features affected:** query-column-projection (projection extended to evaluate `function` aggregate expressions under grouping), first-class-query-joins (grouping over the join path), qualified-orderby-resolution (group-key/aggregate resolution reuses its source-aware resolver).
+- **Dependencies:** builds directly on query-column-projection (Implemented); no in-flight blockers.
+
+## Open Questions
+
+Resolved during ideation (recorded here; carry into the Feature spec):
+
+- **HAVING type:** reuse `dal.Condition` — same type and evaluator as WHERE, applied post-grouping over the aggregated row. An operand may reference an aggregate by either the expression form (`SUM(f2) > 5`) or its SELECT alias (`F_2 > 5`); both resolve to the same per-group value, and an aggregate used only in HAVING is still computed over the group.
+- **SELECT-rule enforcement:** hard error — reject a grouped query whose SELECT has a non-aggregate column missing from GROUP BY, consistent with `validateColumns` today.
+- **COUNT:** add a star/row expression so `COUNT(*)` counts all rows in a group; `Count()` is an alias for `Count(*)`. Existing `CountAs(field, alias)` keeps skip-nulls field-count semantics.
+- **Null handling:** standard SQL — aggregates skip NULLs; all-null `SUM`/`AVG`/`MIN`/`MAX` return NULL; numeric inputs reuse the existing `number()` coercion.
+
+None outstanding.
+
+---
+*This document follows the https://specscore.md/idea-specification*

--- a/spec/plans/2026-06-05-query-group-by-aggregation.md
+++ b/spec/plans/2026-06-05-query-group-by-aggregation.md
@@ -1,0 +1,87 @@
+# Plan: GROUP BY with aggregation in the query builder, executed by dalgo2memory
+
+**Status:** Completed
+**Source Feature:** query-group-by-aggregation
+**Date:** 2026-06-05
+**Owner:** alex
+**Supersedes:** —
+
+## Summary
+
+Decomposes the `query-group-by-aggregation` Feature into eight linear tasks: three `dal` builder additions (`GroupBy`, `Having`, `COUNT(*)`), then the `dalgo2memory` grouping engine built up incrementally — single-source aggregation, the SELECT-grouping hard-error, `HAVING` evaluation, grouped ordering, and finally the join path. All twelve acceptance criteria are covered by a task; none are deferred.
+
+## Approach
+
+The Feature is a builder capability plus an executor that consumes it, so the order is build-the-input then consume-it, and the executor is grown one concern at a time to keep each task in one focused session. Tasks 1–3 add the `dal` surface (`GroupBy`, the new `Having` clause, and the `COUNT(*)` star expression) — pure builder/`String()` work with no execution semantics. Task 4 introduces the single-source grouping path in `dalgo2memory` (partition by group-key tuple, evaluate aggregates with SQL null-skipping) gated behind a non-empty `GroupBy()`, which also establishes the empty-`GroupBy()` passthrough. Task 5 adds the up-front hard-error validation the grouping path needs. Task 6 adds `HAVING` evaluation (alias and aggregate-expression operand forms, including an aggregate used only in `HAVING`). Task 7 applies `ORDER BY`/`LIMIT`/`OFFSET` to the grouped rows. Task 8 routes the join executor through the same grouping pass. Task 4 depends on Tasks 1+3; Task 6 depends on Tasks 2+4; Tasks 5, 7, and 8 each depend on Task 4's grouping path.
+
+## Tasks
+
+### Task 1: GroupBy builder method on dal.QueryBuilder
+
+**Verifies:** query-group-by-aggregation#ac:group-by-recorded
+**Status:** done
+
+Add a chainable `GroupBy(expressions ...dal.Expression) dal.IQueryBuilder` to `QueryBuilder` and the `IQueryBuilder` interface, appending to `structuredQuery.groupBy` exactly as `OrderBy` appends to `orderBy`, so `GroupBy()` returns the expressions while a query on which `GroupBy` was never called reports an empty `GroupBy()`.
+
+### Task 2: Having clause — getter, field, builder, and String() rendering
+
+**Verifies:** query-group-by-aggregation#ac:having-recorded-and-rendered
+**Status:** done
+
+Add `Having() dal.Condition` to `StructuredQuery`, a `having Condition` field on `structuredQuery`, and a `Having(conditions ...dal.Condition) dal.IQueryBuilder` builder method that AND-combines multiple conditions like `Where`; render the `HAVING` clause in `structuredQuery.String()` immediately after the `GROUP BY` block.
+
+### Task 3: COUNT(*) star expression and Count() builder
+
+**Verifies:** query-group-by-aggregation#ac:count-star-expressible
+**Status:** done
+
+Add a star/row `Expression` to the `dal` query model and a `Count()` builder defined as an alias for `Count(*)`, rendering as `COUNT(*)` in `String()`, while the existing `CountAs(field, alias)` keeps its field-count semantics.
+
+### Task 4: dalgo2memory single-source grouping and aggregate evaluation
+
+**Verifies:** query-group-by-aggregation#ac:single-source-grouping-with-aggregates, query-group-by-aggregation#ac:all-null-group-aggregates-null, query-group-by-aggregation#ac:empty-groupby-unchanged
+**Depends-On:** 1, 3
+**Status:** done
+
+When `q.GroupBy()` is non-empty, partition the WHERE-matched rows into groups keyed by the ordered group-key tuple (resolved via the shared per-source resolver) and emit one row per group, evaluating `SUM`/`COUNT`/`MIN`/`MAX`/`AVG`/`COUNT(*)` with standard SQL null handling (skip nulls; `AVG` divides by non-null count; all-null `SUM`/`AVG`/`MIN`/`MAX` yield `null`; `COUNT(*)` counts all rows) reusing the existing `number()` coercion; an empty `GroupBy()` bypasses the path entirely, leaving today's behavior unchanged.
+
+### Task 5: SELECT-grouping-rule hard-error validation
+
+**Verifies:** query-group-by-aggregation#ac:non-grouped-select-column-errors
+**Depends-On:** 4
+**Status:** done
+
+Before emitting any group row, reject a grouped query whose SELECT contains a column that is neither an aggregate function expression nor one of the group-by expressions, returning a descriptive error and no rows — consistent with the eager hard-reject `validateColumns` already applies.
+
+### Task 6: HAVING evaluation over aggregated group rows
+
+**Verifies:** query-group-by-aggregation#ac:having-filters-by-alias, query-group-by-aggregation#ac:having-filters-by-aggregate-expression, query-group-by-aggregation#ac:having-on-unselected-aggregate
+**Depends-On:** 2, 4
+**Status:** done
+
+When `q.Having()` is non-nil, evaluate it as a post-aggregation filter over each group's aggregated row and drop failing groups; resolve a `HAVING` operand by either the SELECT alias bound to an aggregate or the aggregate expression itself (both yielding the same per-group value), computing an aggregate referenced only in `HAVING` over the group without adding it to the output row.
+
+### Task 7: grouped ORDER BY / LIMIT / OFFSET
+
+**Verifies:** query-group-by-aggregation#ac:grouped-order-and-limit
+**Depends-On:** 4
+**Status:** done
+
+For a grouped query, apply `ORDER BY`, `LIMIT`, and `OFFSET` to the post-`HAVING` group rows rather than to the pre-grouping input rows, so ordering and limiting operate on the aggregated result set.
+
+### Task 8: grouping over the join path
+
+**Verifies:** query-group-by-aggregation#ac:join-grouping-qualified
+**Depends-On:** 4
+**Status:** done
+
+Route `executeJoinQuery` through the same grouping/aggregation pass so group keys and aggregate inputs can reference qualified sources (e.g. `u.country`), reusing the join's existing source-aware resolver, emitting one aggregated row per distinct group across the joined rows.
+
+## Open Questions
+
+- Exact name/shape of the star expression and the `Count()`/`CountAll` builder, and the `GroupBy`/`Having` method signatures — settled during implementation.
+- Output-key collision when two selected columns resolve to the same alias/name — the in-scope ACs use distinct keys; last-write-wins vs. error is settled during implementation, consistent with the same open question in `query-column-projection`.
+- `MIN`/`MAX` over non-numeric (string) values — the in-scope ACs aggregate numeric fields; non-numeric ordering semantics are deferred.
+
+---
+*This document follows the https://specscore.md/plan-specification*


### PR DESCRIPTION
## What

Adds **GROUP BY with aggregation** end-to-end: expressible in the `dal` query builder and executed by `dalgo2memory`, for both single-source and join queries. Follows the `query-column-projection` precedent (the grouping struct/getter/`String()` rendering already existed but were unreachable — no builder setter, and `dalgo2memory` ignored `GroupBy()` while rejecting aggregate columns).

Implements Feature `spec/features/query-group-by-aggregation` (Grade A) and plan `spec/plans/2026-06-05-query-group-by-aggregation.md` (8 tasks, all 12 ACs covered).

## `dal` builder
- `GroupBy(expressions ...Expression)` and `Having(conditions ...Condition)` chainable methods on `IQueryBuilder`/`QueryBuilder`.
- `Having() Condition` getter + `having` field on `StructuredQuery`; `String()` renders `HAVING` after `GROUP BY`. HAVING reuses `dal.Condition`, AND-combined like `Where`.
- `COUNT(*)` star expression + `Count()` builder (alias for `COUNT(*)`); `CountAs(field, alias)` keeps field-count (skip-nulls) semantics.
- Exported `AggregateFunc` interface so adapters can introspect aggregate name/args.

## `dalgo2memory` grouping engine (`group.go`)
Shared by the single-source and join paths:
- Partition WHERE-matched rows by the group-key tuple via the existing source-aware resolver; one aggregated row per group.
- `SUM`/`COUNT`/`MIN`/`MAX`/`AVG` + `COUNT(*)` with **standard SQL null handling** (skip nulls; all-null `SUM`/`AVG`/`MIN`/`MAX` → `nil`; `COUNT(*)` counts all rows), reusing the existing `number()` coercion.
- **Hard error** when a selected column is neither an aggregate nor a `GROUP BY` expression, before any row is emitted.
- **HAVING** as a post-aggregation filter; operands resolved by SELECT alias **or** aggregate expression (aggregates used only in HAVING are computed but not output).
- `ORDER BY`/`LIMIT`/`OFFSET` applied to the grouped rows.
- Empty `GroupBy()` bypasses the path — existing behavior unchanged.

## Tests / verification
- New table tests in `dal` (builder/`String()`/`COUNT(*)`) and `dalgo2memory` (single-source aggregation, all-null groups, join grouping, the SELECT-grouping error, HAVING by alias/expression/unselected-aggregate, grouped ORDER BY + LIMIT/OFFSET, plus every error branch).
- `dalgo2memory` remains at **100% statement coverage**.
- Full module `go test ./...`, `go vet`, `gofmt`, and `golangci-lint` all clean.

## Out of scope
DTQL serialization of GROUP BY (already rejected by `dtql`), SQL adapters (`dalgo2sql`/`dalgo2sqlite`), DISTINCT/ROLLUP/window functions, new aggregate functions, and the columnar recordset reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)