### PR TITLE
spec(query-group-by-aggregation): mark Feature Stable

### DIFF
--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -20,7 +20,7 @@ The Feature format follows [SpecScore](https://specscore.md/feature-specificatio
 | [query-joins](query-joins/README.md) | Approved | — |
 | [qualified-orderby-resolution](qualified-orderby-resolution/README.md) | Approved | — |
 | [query-column-projection](query-column-projection/README.md) | Stable | — |
-| [query-group-by-aggregation](query-group-by-aggregation/README.md) | Implementing | — |
+| [query-group-by-aggregation](query-group-by-aggregation/README.md) | Stable | — |
 
 ## Open Questions
 

--- a/spec/features/query-group-by-aggregation/README.md
+++ b/spec/features/query-group-by-aggregation/README.md
@@ -1,7 +1,7 @@
 # Feature: GROUP BY with aggregation in the query builder, executed by dalgo2memory
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-group-by-aggregation?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-group-by-aggregation?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-group-by-aggregation?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-group-by-aggregation?op=request-change) |
-**Status:** Implementing
+**Status:** Stable
 **Date:** 2026-06-05
 **Owner:** alex
 **Source Ideas:** query-group-by-aggregation

--- a/spec/ideas/README.md
+++ b/spec/ideas/README.md
@@ -15,7 +15,7 @@ The Idea format follows [SpecScore](https://specscore.md/idea-specification).
 | [first-class-query-joins](first-class-query-joins.md) | Specified | 2026-06-05 | alexander.trakhimenok | query-joins |
 | [qualified-orderby-resolution](qualified-orderby-resolution.md) | Specified | 2026-06-05 | alex | qualified-orderby-resolution |
 | [query-column-projection](query-column-projection.md) | Implemented | 2026-06-05 | alex | query-column-projection |
-| [query-group-by-aggregation](query-group-by-aggregation.md) | Implementing | 2026-06-05 | alex | query-group-by-aggregation |
+| [query-group-by-aggregation](query-group-by-aggregation.md) | Implemented | 2026-06-05 | alex | query-group-by-aggregation |
 | [recordops](recordops.md) | Approved | 2026-05-15 | alex | — |
 | [recordset-computed-columns](recordset-computed-columns.md) | Specified | 2026-06-02 | alex | recordset-computed-columns |
 | [transaction-message](transaction-message.md) | Approved | 2026-06-02 | alex | — |

--- a/spec/ideas/query-group-by-aggregation.md
+++ b/spec/ideas/query-group-by-aggregation.md
@@ -1,6 +1,6 @@
 # Idea: GROUP BY with aggregation in the query builder, executed by dalgo2memory
 
-**Status:** Implementing
+**Status:** Implemented
 **Date:** 2026-06-05
 **Owner:** alex
 **Promotes To:** query-group-by-aggregation


### PR DESCRIPTION
Transitions the `query-group-by-aggregation` Feature from **Implementing → Stable** now that the implementation landed in #60.

Done via `specscore feature change-status ... --to Stable`; the idea `Promotes To`/status links and spec indices were synced by the CLI. Spec tree lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)