### PR TITLE
feat(dalgo2memory): recordset reader + e2e GROUP BY/column-projection coverage

### DIFF
--- a/dalgo2memory/database.go
+++ b/dalgo2memory/database.go
@@ -75,8 +75,10 @@ func (db *database) ExecuteQueryToRecordsReader(ctx context.Context, query dal.Q
 	return session{db: db}.ExecuteQueryToRecordsReader(ctx, query)
 }
 
-func (db *database) ExecuteQueryToRecordsetReader(context.Context, dal.Query, ...recordset.Option) (dal.RecordsetReader, error) {
-	return nil, dal.ErrNotSupported
+func (db *database) ExecuteQueryToRecordsetReader(ctx context.Context, query dal.Query, options ...recordset.Option) (dal.RecordsetReader, error) {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+	return session{db: db}.ExecuteQueryToRecordsetReader(ctx, query, options...)
 }
 
 func (db *database) Set(ctx context.Context, record dal.Record) error {
@@ -325,10 +327,6 @@ func (s session) ExecuteQueryToRecordsReader(_ context.Context, query dal.Query)
 		records[i] = dal.NewRecordWithData(key, data).SetError(nil)
 	}
 	return dal.NewRecordsReader(records), nil
-}
-
-func (s session) ExecuteQueryToRecordsetReader(context.Context, dal.Query, ...recordset.Option) (dal.RecordsetReader, error) {
-	return nil, dal.ErrNotSupported
 }
 
 var _ dal.ReadwriteTransaction = (*session)(nil)

--- a/dalgo2memory/recordset.go
+++ b/dalgo2memory/recordset.go
@@ -1,0 +1,163 @@
+package dalgo2memory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/recordset"
+)
+
+// ExecuteQueryToRecordsetReader executes a structured query and exposes its
+// result as a columnar recordset — the read path DataTug uses for tabular
+// query results. It reuses the records pipeline (WHERE, GROUP BY, HAVING,
+// column projection, joins, ORDER BY, LIMIT/OFFSET all already applied there),
+// then pivots the resulting rows into columns.
+//
+// Columns are derived from the query's explicit SELECT columns when present
+// (projection and GROUP BY aggregation); otherwise from the sorted union of
+// keys across the result rows (e.g. SELECT *). Values are stored in untyped
+// (any) columns, matching the adapter's schemaless JSON storage. A non-
+// structured query is not supported.
+func (s session) ExecuteQueryToRecordsetReader(ctx context.Context, query dal.Query, options ...recordset.Option) (dal.RecordsetReader, error) {
+	q, ok := query.(dal.StructuredQuery)
+	if !ok {
+		return nil, dal.ErrNotSupported
+	}
+	reader, err := s.ExecuteQueryToRecordsReader(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	return buildRecordsetReader(ctx, q, reader, options...)
+}
+
+// buildRecordsetReader drains a RecordsReader and pivots its rows into a
+// columnar recordset reader. Split out so the read/convert error paths are
+// directly testable with an injected reader.
+func buildRecordsetReader(ctx context.Context, q dal.StructuredQuery, reader dal.RecordsReader, options ...recordset.Option) (dal.RecordsetReader, error) {
+	records, err := dal.ReadAllToRecords(ctx, reader)
+	if err != nil {
+		return nil, err
+	}
+
+	rows := make([]map[string]any, len(records))
+	for i, rec := range records {
+		m, err := recordToMap(rec)
+		if err != nil {
+			return nil, err
+		}
+		rows[i] = m
+	}
+
+	colNames := recordsetColumnNames(q, rows)
+	cols := make([]recordset.Column[any], len(colNames))
+	for i, name := range colNames {
+		// NewTypedColumn[any] yields an unwrapped any-column that stores nil
+		// directly; NewColumn[any] would wrap it and reject the nil default
+		// that NewRow appends (nil.(any) is false), leaving the column empty.
+		cols[i] = recordset.NewTypedColumn[any](name, nil)
+	}
+	rs := recordset.NewColumnarRecordset(recordsetName(q, options...), cols...)
+	for _, m := range rows {
+		row := rs.NewRow()
+		for _, name := range colNames {
+			if v, ok := m[name]; ok {
+				// An any-typed standard column accepts any value, so SetValue
+				// cannot fail here (the column always exists and is not
+				// computed).
+				_ = row.SetValueByName(name, v, rs)
+			}
+		}
+	}
+	return &columnarReader{rs: rs}, nil
+}
+
+// recordToMap renders a result record's data as a map keyed by column name.
+// Projected/aggregated records already carry a map; a keys-only record exposes
+// its key under "ID"; any other shape (e.g. a typed struct from a SELECT * with
+// IntoRecord) is converted via a JSON round-trip.
+func recordToMap(rec dal.Record) (map[string]any, error) {
+	switch d := rec.Data().(type) {
+	case map[string]any:
+		return d, nil
+	case *map[string]any:
+		if d == nil {
+			return map[string]any{}, nil
+		}
+		return *d, nil
+	case nil:
+		return map[string]any{"ID": fmt.Sprint(rec.Key().ID)}, nil
+	default:
+		b, err := json.Marshal(d)
+		if err != nil {
+			return nil, err
+		}
+		var m map[string]any
+		if err := json.Unmarshal(b, &m); err != nil {
+			return nil, err
+		}
+		if m == nil {
+			m = map[string]any{}
+		}
+		return m, nil
+	}
+}
+
+// recordsetColumnNames returns the ordered column names: the query's explicit
+// SELECT columns when present, otherwise the sorted union of keys across rows.
+func recordsetColumnNames(q dal.StructuredQuery, rows []map[string]any) []string {
+	if cols := q.Columns(); len(cols) > 0 {
+		names := make([]string, len(cols))
+		for i, c := range cols {
+			names[i] = columnOutKey(c)
+		}
+		return names
+	}
+	seen := make(map[string]bool)
+	for _, m := range rows {
+		for k := range m {
+			seen[k] = true
+		}
+	}
+	names := make([]string, 0, len(seen))
+	for k := range seen {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// recordsetName resolves the recordset name from the WithName option, falling
+// back to the query's base recordset name.
+func recordsetName(q dal.StructuredQuery, options ...recordset.Option) string {
+	if name := recordset.NewOptions(options...).Name(); name != "" {
+		return name
+	}
+	return q.From().Base().Name()
+}
+
+// columnarReader is a dal.RecordsetReader over a fully-built ColumnarRecordset:
+// the recordset is populated up front and Next walks its rows in order.
+type columnarReader struct {
+	rs  *recordset.ColumnarRecordset
+	pos int
+}
+
+var _ dal.RecordsetReader = (*columnarReader)(nil)
+
+func (r *columnarReader) Recordset() recordset.Recordset { return r.rs }
+
+func (r *columnarReader) Next() (recordset.Row, recordset.Recordset, error) {
+	if r.pos >= r.rs.RowsCount() {
+		return nil, r.rs, dal.ErrNoMoreRecords
+	}
+	row := r.rs.GetRow(r.pos)
+	r.pos++
+	return row, r.rs, nil
+}
+
+func (r *columnarReader) Cursor() (string, error) { return "", nil }
+
+func (r *columnarReader) Close() error { return nil }

--- a/dalgo2memory/recordset_test.go
+++ b/dalgo2memory/recordset_test.go
@@ -1,0 +1,232 @@
+package dalgo2memory
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/recordset"
+	"github.com/stretchr/testify/require"
+)
+
+// drainRecordset executes a query via the recordset reader, drives the reader
+// to exhaustion (covering Next/Close), and returns the resulting recordset.
+func drainRecordset(t *testing.T, db *database, ctx context.Context, q dal.Query, opts ...recordset.Option) recordset.Recordset {
+	t.Helper()
+	reader, err := db.ExecuteQueryToRecordsetReader(ctx, q, opts...)
+	require.NoError(t, err)
+	rs := reader.Recordset()
+	cur, err := reader.Cursor()
+	require.NoError(t, err)
+	require.Equal(t, "", cur)
+	for {
+		row, gotRS, e := reader.Next()
+		if errors.Is(e, dal.ErrNoMoreRecords) {
+			break
+		}
+		require.NoError(t, e)
+		require.NotNil(t, row)
+		require.Same(t, rs, gotRS)
+	}
+	require.NoError(t, reader.Close())
+	return rs
+}
+
+func cellByName(t *testing.T, rs recordset.Recordset, rowIdx int, name string) any {
+	t.Helper()
+	row := rs.GetRow(rowIdx)
+	require.NotNil(t, row)
+	v, err := row.GetValueByName(name, rs)
+	require.NoError(t, err)
+	return v
+}
+
+// Column projection through the recordset reader: columns come from the
+// explicit SELECT list (one aliased), in order.
+func TestRecordset_ColumnProjection(t *testing.T) {
+	db, ctx := seedPeople(t)
+	q := dal.From(dal.NewRootCollectionRef("people", "")).NewQuery().
+		SelectColumns(
+			dal.Column{Alias: "n", Expression: dal.Field("name")},
+			dal.Column{Expression: dal.Field("status")},
+		)
+	rs := drainRecordset(t, db, ctx, q)
+	require.Equal(t, 2, rs.RowsCount())
+	require.Equal(t, []string{"n", "status"}, columnNames(rs))
+	require.Equal(t, "people", rs.Name())
+}
+
+// GROUP BY aggregation through the recordset reader.
+func TestRecordset_GroupByAggregation(t *testing.T) {
+	db, ctx := seedSales(t)
+	q := dal.From(dal.NewRootCollectionRef("sales", "")).NewQuery().
+		GroupBy(dal.Field("category")).
+		SelectColumns(
+			dal.Column{Expression: dal.Field("category")},
+			dal.SumAs(dal.Field("amount"), "total"),
+		)
+	rs := drainRecordset(t, db, ctx, q)
+	require.Equal(t, 2, rs.RowsCount())
+	require.Equal(t, []string{"category", "total"}, columnNames(rs))
+	byCat := map[string]any{}
+	for i := 0; i < rs.RowsCount(); i++ {
+		byCat[cellByName(t, rs, i, "category").(string)] = cellByName(t, rs, i, "total")
+	}
+	require.EqualValues(t, 30, byCat["A"])
+	require.EqualValues(t, 5, byCat["B"])
+}
+
+// SELECT * (no explicit columns) derives columns from the sorted union of keys
+// across rows; a *map[string]any record body is dereferenced.
+func TestRecordset_SelectStar(t *testing.T) {
+	db, ctx := seedPeople(t)
+	q := dal.From(dal.NewRootCollectionRef("people", "")).NewQuery().
+		SelectIntoRecord(func() dal.Record {
+			return dal.NewRecordWithIncompleteKey("people", reflect.String, &map[string]any{})
+		})
+	rs := drainRecordset(t, db, ctx, q)
+	require.Equal(t, 2, rs.RowsCount())
+	require.Equal(t, []string{"id", "name", "status"}, columnNames(rs), "sorted union of keys")
+}
+
+// Keys-only query: each row exposes its key under an "ID" column.
+func TestRecordset_KeysOnly(t *testing.T) {
+	db, ctx := seedPeople(t)
+	q := dal.From(dal.NewRootCollectionRef("people", "")).NewQuery().
+		SelectKeysOnly(0)
+	rs := drainRecordset(t, db, ctx, q)
+	require.Equal(t, 2, rs.RowsCount())
+	require.Equal(t, []string{"ID"}, columnNames(rs))
+}
+
+// The recordset name comes from the WithName option when provided.
+func TestRecordset_NameOption(t *testing.T) {
+	db, ctx := seedSales(t)
+	q := dal.From(dal.NewRootCollectionRef("sales", "")).NewQuery().
+		GroupBy(dal.Field("category")).
+		SelectColumns(dal.Column{Expression: dal.Field("category")})
+	rs := drainRecordset(t, db, ctx, q, recordset.WithName("custom"))
+	require.Equal(t, "custom", rs.Name())
+}
+
+// A non-structured query is not supported by the recordset reader.
+func TestRecordset_NonStructuredUnsupported(t *testing.T) {
+	db := NewDB().(*database)
+	_, err := db.ExecuteQueryToRecordsetReader(context.Background(), notStructuredQuery{})
+	require.ErrorIs(t, err, dal.ErrNotSupported)
+}
+
+// An execution error from the underlying records pipeline surfaces.
+func TestRecordset_ExecutionError(t *testing.T) {
+	db, ctx := seedSales(t)
+	q := dal.From(dal.NewRootCollectionRef("sales", "")).NewQuery().
+		GroupBy(dal.Field("category")).
+		SelectColumns(
+			dal.Column{Expression: dal.Field("category")},
+			dal.Column{Expression: dal.Field("amount")}, // not aggregated, not grouped
+		)
+	_, err := db.ExecuteQueryToRecordsetReader(ctx, q)
+	require.ErrorContains(t, err, "neither an aggregate nor in GROUP BY")
+}
+
+// recordToMap covers every record-body shape.
+func TestRecordToMap(t *testing.T) {
+	key := dal.NewKeyWithID("c", "k1")
+
+	withData := func(data any) dal.Record {
+		return dal.NewRecordWithData(key, data).SetError(nil)
+	}
+
+	t.Run("map", func(t *testing.T) {
+		m, err := recordToMap(withData(map[string]any{"a": 1}))
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{"a": 1}, m)
+	})
+	t.Run("pointer to map", func(t *testing.T) {
+		m, err := recordToMap(withData(&map[string]any{"a": 2}))
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{"a": 2}, m)
+	})
+	t.Run("nil pointer to map", func(t *testing.T) {
+		m, err := recordToMap(withData((*map[string]any)(nil)))
+		require.NoError(t, err)
+		require.Empty(t, m)
+	})
+	t.Run("nil data exposes key as ID", func(t *testing.T) {
+		m, err := recordToMap(dal.NewRecord(key).SetError(nil))
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{"ID": "k1"}, m)
+	})
+	t.Run("struct via json round-trip", func(t *testing.T) {
+		m, err := recordToMap(withData(struct {
+			Name string
+			Age  int
+		}{"alice", 30}))
+		require.NoError(t, err)
+		require.Equal(t, "alice", m["Name"])
+		require.EqualValues(t, 30, m["Age"])
+	})
+	t.Run("nil pointer struct marshals to null", func(t *testing.T) {
+		m, err := recordToMap(withData((*struct{ Name string })(nil)))
+		require.NoError(t, err)
+		require.Empty(t, m)
+	})
+	t.Run("non-object json errors", func(t *testing.T) {
+		_, err := recordToMap(withData([]int{1, 2}))
+		require.Error(t, err)
+	})
+	t.Run("unmarshalable value errors", func(t *testing.T) {
+		_, err := recordToMap(withData(make(chan int)))
+		require.Error(t, err)
+	})
+}
+
+// buildRecordsetReader surfaces a reader error from the records pipeline.
+func TestBuildRecordsetReader_ReaderError(t *testing.T) {
+	q := dal.From(dal.NewRootCollectionRef("people", "")).NewQuery().
+		SelectColumns(dal.Column{Expression: dal.Field("name")})
+	_, err := buildRecordsetReader(context.Background(), q, errRecordsReader{}, nil...)
+	require.ErrorContains(t, err, "boom")
+}
+
+// buildRecordsetReader surfaces a record-to-map conversion error.
+func TestBuildRecordsetReader_RecordConversionError(t *testing.T) {
+	q := dal.From(dal.NewRootCollectionRef("people", "")).NewQuery().
+		SelectColumns(dal.Column{Expression: dal.Field("name")})
+	bad := dal.NewRecordWithData(dal.NewKeyWithID("people", "1"), make(chan int)).SetError(nil)
+	reader := dal.NewRecordsReader([]dal.Record{bad})
+	_, err := buildRecordsetReader(context.Background(), q, reader)
+	require.Error(t, err)
+}
+
+// errRecordsReader is a RecordsReader whose Next always fails.
+type errRecordsReader struct{}
+
+func (errRecordsReader) Next() (dal.Record, error) { return nil, errors.New("boom") }
+func (errRecordsReader) Cursor() (string, error)   { return "", nil }
+func (errRecordsReader) Close() error              { return nil }
+
+// columnNames lists a recordset's column names in order.
+func columnNames(rs recordset.Recordset) []string {
+	cols := rs.Columns()
+	names := make([]string, len(cols))
+	for i, c := range cols {
+		names[i] = c.Name()
+	}
+	return names
+}
+
+// notStructuredQuery is a dal.Query that is not a dal.StructuredQuery.
+type notStructuredQuery struct{}
+
+func (notStructuredQuery) String() string { return "not structured" }
+func (notStructuredQuery) Offset() int    { return 0 }
+func (notStructuredQuery) Limit() int     { return 0 }
+func (notStructuredQuery) GetRecordsReader(context.Context, dal.QueryExecutor) (dal.RecordsReader, error) {
+	return nil, dal.ErrNotSupported
+}
+func (notStructuredQuery) GetRecordsetReader(context.Context, dal.QueryExecutor) (dal.RecordsetReader, error) {
+	return nil, dal.ErrNotSupported
+}

--- a/end2end/README.md
+++ b/end2end/README.md
@@ -3,3 +3,27 @@
 End-to-end conformance tests for DALgo database adapters.
 
 Adapters should import `github.com/dal-go/dalgo/end2end` and call `end2end.TestDalgoDB` from their own integration tests.
+
+## Query capability reporting
+
+`TestDalgoDB(t, db, errQuerySupport, eventuallyConsistent)` gates the whole
+query suite on `errQuerySupport`: pass a non-nil error and every query test is
+skipped (for adapters with no query support at all).
+
+Beyond that coarse gate, individual query features are **capability-reported per
+query**. The suite exercises advanced shapes — column projection, `GROUP BY`
+aggregation with `HAVING`, and both the records and recordset read paths — and an
+adapter that does not implement a given shape is expected to return an error that
+wraps `dal.ErrNotSupported`. The shared tests detect this via
+`errors.Is(err, dal.ErrNotSupported)` and `t.Skip` that sub-test rather than
+failing. So returning `dal.ErrNotSupported` (not a silent wrong result) is the
+contract for an unsupported query feature; adapters opt into coverage simply by
+implementing the feature.
+
+Both read paths are covered for the same query:
+
+- **records reader** — `tx.ExecuteQueryToRecordsReader` /
+  `dal.ExecuteQueryAndReadAllToRecords`.
+- **recordset reader** — `tx.ExecuteQueryToRecordsetReader` /
+  `dal.ExecuteQueryAndReadAllToRecordset` (the columnar path used by tabular
+  consumers such as DataTug).

--- a/end2end/end2end_test.go
+++ b/end2end/end2end_test.go
@@ -190,6 +190,14 @@ func TestEndToEnd(t *testing.T) {
 			tx.EXPECT().GetRecordsReader(gomock.Any(), gomock.Any()).DoAndReturn(readCityIDs(models.CityIDsSortedByPopulation))
 		case "SELECT ID FROM Cities WHERE Country = 'IN'":
 			tx.EXPECT().GetRecordsReader(gomock.Any(), gomock.Any()).DoAndReturn(readCityIDs([]string{"Delhi_Delhi", "Maharashtra_Mumbai"}))
+		case "SELECT Name AS city, Country FROM Cities",
+			"SELECT Country, COUNT(*), SUM(Population) GROUP BY Country",
+			"SELECT Country, COUNT(*) GROUP BY Country HAVING COUNT(*) > 1":
+			// This mock DB does not implement column projection / GROUP BY, so
+			// both read paths report the capability as unsupported and the
+			// shared end2end subtests skip.
+			tx.EXPECT().GetRecordsReader(gomock.Any(), gomock.Any()).Return(nil, dal.ErrNotSupported).AnyTimes()
+			tx.EXPECT().GetRecordsetReader(gomock.Any(), gomock.Any()).Return(nil, dal.ErrNotSupported).AnyTimes()
 		case "verify_cleanupDelete":
 			tx.EXPECT().GetMulti(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, records []dal.Record) error {
 				for _, record := range records {

--- a/end2end/test_query.go
+++ b/end2end/test_query.go
@@ -182,6 +182,12 @@ func queryOperationsTest(ctx context.Context, t *testing.T, db dal.DB, eventuall
 
 		})
 	})
+	t.Run("SELECT Name AS city, Country FROM Cities", func(t *testing.T) {
+		queryColumnProjectionTest(ctx, t, db)
+	})
+	t.Run("SELECT Country, aggregates FROM Cities GROUP BY Country", func(t *testing.T) {
+		queryGroupByTest(ctx, t, db)
+	})
 }
 
 func deleteAllCities(ctx context.Context, db dal.DB) (err error) {

--- a/end2end/test_query_aggregation.go
+++ b/end2end/test_query_aggregation.go
@@ -3,7 +3,6 @@ package end2end
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/dal-go/dalgo/dal"
@@ -27,11 +26,8 @@ func readMapRecords(ctx context.Context, db dal.DB, q dal.Query, txMsg string) (
 		}
 		out = make([]map[string]any, len(records))
 		for i, rec := range records {
-			m, err := recordDataAsMap(rec)
-			if err != nil {
-				return err
-			}
-			out[i] = m
+			// Projected and aggregated records carry map data by contract.
+			out[i] = rec.Data().(map[string]any)
 		}
 		return nil
 	}, dal.TxWithMessage(txMsg))
@@ -49,19 +45,6 @@ func readRecordset(ctx context.Context, db dal.DB, q dal.Query, txMsg string) (r
 		return e
 	}, dal.TxWithMessage(txMsg))
 	return rs, err
-}
-
-// recordDataAsMap returns a projected/aggregated record's data as a map,
-// accepting either a map value or a pointer to one.
-func recordDataAsMap(rec dal.Record) (map[string]any, error) {
-	switch d := rec.Data().(type) {
-	case map[string]any:
-		return d, nil
-	case *map[string]any:
-		return *d, nil
-	default:
-		return nil, fmt.Errorf("expected map[string]any record data, got %T", rec.Data())
-	}
 }
 
 // indexByString groups rows by the string value of a given key (e.g. the

--- a/end2end/test_query_aggregation.go
+++ b/end2end/test_query_aggregation.go
@@ -1,0 +1,209 @@
+package end2end
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/end2end/models"
+	"github.com/dal-go/dalgo/recordset"
+	"github.com/stretchr/testify/require"
+)
+
+// readMapRecords executes a structured query via the RecordsReader path and
+// collects each record's data as a map (column projection and GROUP BY
+// aggregation return map-shaped records). An adapter that does not implement
+// such queries is expected to return dal.ErrNotSupported; the error is returned
+// so callers can detect it via errors.Is and t.Skip — the standard end2end
+// capability-reporting approach.
+func readMapRecords(ctx context.Context, db dal.DB, q dal.Query, txMsg string) ([]map[string]any, error) {
+	var out []map[string]any
+	err := db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
+		records, err := dal.ExecuteQueryAndReadAllToRecords(ctx, q, tx)
+		if err != nil {
+			return err
+		}
+		out = make([]map[string]any, len(records))
+		for i, rec := range records {
+			m, err := recordDataAsMap(rec)
+			if err != nil {
+				return err
+			}
+			out[i] = m
+		}
+		return nil
+	}, dal.TxWithMessage(txMsg))
+	return out, err
+}
+
+// readRecordset executes the same structured query via the RecordsetReader
+// path. The in-memory adapter returns dal.ErrNotSupported here; adapters that
+// implement columnar reads return a populated recordset.
+func readRecordset(ctx context.Context, db dal.DB, q dal.Query, txMsg string) (recordset.Recordset, error) {
+	var rs recordset.Recordset
+	err := db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
+		var e error
+		rs, e = dal.ExecuteQueryAndReadAllToRecordset(ctx, q, tx)
+		return e
+	}, dal.TxWithMessage(txMsg))
+	return rs, err
+}
+
+// recordDataAsMap returns a projected/aggregated record's data as a map,
+// accepting either a map value or a pointer to one.
+func recordDataAsMap(rec dal.Record) (map[string]any, error) {
+	switch d := rec.Data().(type) {
+	case map[string]any:
+		return d, nil
+	case *map[string]any:
+		return *d, nil
+	default:
+		return nil, fmt.Errorf("expected map[string]any record data, got %T", rec.Data())
+	}
+}
+
+// indexByString groups rows by the string value of a given key (e.g. the
+// GROUP BY column), for order-independent assertions.
+func indexByString(t *testing.T, rows []map[string]any, key string) map[string]map[string]any {
+	t.Helper()
+	out := make(map[string]map[string]any, len(rows))
+	for _, r := range rows {
+		k, ok := r[key].(string)
+		require.Truef(t, ok, "row %v missing string key %q", r, key)
+		out[k] = r
+	}
+	return out
+}
+
+// assertRecordsetRowCount runs a query through the RecordsetReader path and
+// asserts the row count, skipping when the adapter reports the columnar read is
+// unsupported. This exercises the second of dalgo's two read paths (records vs
+// recordsets) for the same query.
+func assertRecordsetRowCount(ctx context.Context, t *testing.T, db dal.DB, q dal.Query, txMsg string, wantRows int) {
+	t.Helper()
+	rs, err := readRecordset(ctx, db, q, txMsg)
+	if errors.Is(err, dal.ErrNotSupported) {
+		t.Skip("recordset reader not supported by adapter:", err)
+		return
+	}
+	require.NoError(t, err)
+	require.NotNil(t, rs)
+	require.Equal(t, wantRows, rs.RowsCount())
+}
+
+// queryColumnProjectionTest exercises SELECT of a subset of columns (one
+// aliased) over both read paths. Skips a path when the adapter reports it is
+// unsupported.
+func queryColumnProjectionTest(ctx context.Context, t *testing.T, db dal.DB) {
+	const txMsg = "SELECT Name AS city, Country FROM Cities"
+	newQuery := func() dal.Query {
+		return dal.From(dal.NewRootCollectionRef(models.CitiesCollection, "")).NewQuery().
+			SelectColumns(
+				dal.Column{Alias: "city", Expression: dal.Field("Name")},
+				dal.Column{Expression: dal.Field("Country")},
+			)
+	}
+
+	t.Run("records reader", func(t *testing.T) {
+		rows, err := readMapRecords(ctx, db, newQuery(), txMsg)
+		if errors.Is(err, dal.ErrNotSupported) {
+			t.Skip("column projection not supported by adapter:", err)
+			return
+		}
+		require.NoError(t, err)
+		require.Len(t, rows, len(models.Cities))
+		for _, r := range rows {
+			require.Len(t, r, 2, "exactly the two selected columns")
+			require.Contains(t, r, "city", "aliased Name column")
+			require.Contains(t, r, "Country")
+			require.NotContains(t, r, "Name", "unaliased original field must not appear")
+			require.NotContains(t, r, "Population", "unselected field must not appear")
+		}
+	})
+
+	t.Run("recordset reader", func(t *testing.T) {
+		assertRecordsetRowCount(ctx, t, db, newQuery(), txMsg, len(models.Cities))
+	})
+}
+
+// queryGroupByTest exercises GROUP BY with COUNT(*)/SUM aggregates plus a
+// HAVING filter, over both read paths. Skips a path when the adapter reports it
+// is unsupported.
+//
+// The dataset has two cities each in IN (Delhi, Mumbai) and CN (Shanghai,
+// Beijing) and one in each of JP, BR, EG, BD, PK, TR — eight distinct
+// countries across ten cities.
+func queryGroupByTest(ctx context.Context, t *testing.T, db dal.DB) {
+	coll := dal.NewRootCollectionRef(models.CitiesCollection, "")
+
+	t.Run("COUNT and SUM per Country", func(t *testing.T) {
+		const txMsg = "SELECT Country, COUNT(*), SUM(Population) GROUP BY Country"
+		newQuery := func() dal.Query {
+			countAll := dal.Count()
+			countAll.Alias = "cities"
+			return dal.From(coll).NewQuery().
+				GroupBy(dal.Field("Country")).
+				SelectColumns(
+					dal.Column{Expression: dal.Field("Country")},
+					countAll,
+					dal.SumAs(dal.Field("Population"), "population"),
+				)
+		}
+
+		t.Run("records reader", func(t *testing.T) {
+			rows, err := readMapRecords(ctx, db, newQuery(), txMsg)
+			if errors.Is(err, dal.ErrNotSupported) {
+				t.Skip("GROUP BY not supported by adapter:", err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, rows, 8, "eight distinct countries")
+			byCountry := indexByString(t, rows, "Country")
+			require.EqualValues(t, 2, byCountry["IN"]["cities"], "India has Delhi and Mumbai")
+			require.EqualValues(t, 2, byCountry["CN"]["cities"], "China has Shanghai and Beijing")
+			require.EqualValues(t, 1, byCountry["JP"]["cities"])
+			// Delhi 30290936 + Mumbai 21344117.
+			require.EqualValues(t, 51635053, byCountry["IN"]["population"])
+		})
+
+		t.Run("recordset reader", func(t *testing.T) {
+			assertRecordsetRowCount(ctx, t, db, newQuery(), txMsg, 8)
+		})
+	})
+
+	t.Run("HAVING COUNT(*) > 1", func(t *testing.T) {
+		const txMsg = "SELECT Country, COUNT(*) GROUP BY Country HAVING COUNT(*) > 1"
+		newQuery := func() dal.Query {
+			countAll := dal.Count()
+			countAll.Alias = "cities"
+			return dal.From(coll).NewQuery().
+				GroupBy(dal.Field("Country")).
+				Having(dal.NewComparison(dal.Count().Expression, dal.GreaterThen, dal.NewConstant(1))).
+				SelectColumns(
+					dal.Column{Expression: dal.Field("Country")},
+					countAll,
+				)
+		}
+
+		t.Run("records reader", func(t *testing.T) {
+			rows, err := readMapRecords(ctx, db, newQuery(), txMsg)
+			if errors.Is(err, dal.ErrNotSupported) {
+				t.Skip("GROUP BY/HAVING not supported by adapter:", err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, rows, 2, "only IN and CN have more than one city")
+			byCountry := indexByString(t, rows, "Country")
+			require.Contains(t, byCountry, "IN")
+			require.Contains(t, byCountry, "CN")
+			require.EqualValues(t, 2, byCountry["IN"]["cities"])
+			require.EqualValues(t, 2, byCountry["CN"]["cities"])
+		})
+
+		t.Run("recordset reader", func(t *testing.T) {
+			assertRecordsetRowCount(ctx, t, db, newQuery(), txMsg, 2)
+		})
+	})
+}


### PR DESCRIPTION
## Why

Two gaps surfaced after the GROUP BY feature (#60):
1. The shared `end2end` conformance suite didn't exercise **column projection** or **GROUP BY** at all.
2. `dalgo2memory.ExecuteQueryToRecordsetReader` returned `ErrNotSupported` — but the **recordset (columnar) read path is crucial for DataTug**.

## Recordset reader (`dalgo2memory`)

Implements `ExecuteQueryToRecordsetReader` on `*database` and `session`, replacing the stub. It **reuses the records pipeline** (WHERE, GROUP BY, HAVING, projection, joins, ORDER BY, LIMIT/OFFSET already applied there) and pivots the rows into a columnar `recordset`:

- Columns from the query's explicit SELECT columns when present (projection / aggregation), else the sorted union of row keys (`SELECT *`).
- Untyped (`any`) columns, matching the adapter's schemaless JSON storage.
- Keys-only rows expose the key under `ID`; struct bodies convert via a JSON round-trip.
- `dalgo2memory` stays at **100% statement coverage**.

## end2end shared suite

- New **column-projection** and **GROUP BY (COUNT(\*)/SUM + HAVING)** conformance tests, each run over **both** read paths — records reader and recordset reader.
- Follows the **capability-reporting** convention: a query shape an adapter doesn't implement returns `dal.ErrNotSupported`, and the sub-test skips via `errors.Is` rather than failing. Adapters opt into coverage by implementing the feature. (No behavior change forced on external adapters.)
- Mock-based `TestEndToEnd` updated to report the new shapes as unsupported.
- Capability-reporting approach documented in `end2end/README.md`.

## Verification

`go test ./...`, `go vet`, `gofmt`, `golangci-lint` all clean; `dalgo2memory` at 100% coverage. Against the in-memory adapter both read paths assert real results; the mock adapter skips them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)