### PR TITLE
feat(dalgo2memory): typed columns for the recordset reader

### DIFF
--- a/dalgo2memory/recordset.go
+++ b/dalgo2memory/recordset.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"sort"
 
 	"github.com/dal-go/dalgo/dal"
@@ -54,24 +55,57 @@ func buildRecordsetReader(ctx context.Context, q dal.StructuredQuery, reader dal
 	colNames := recordsetColumnNames(q, rows)
 	cols := make([]recordset.Column[any], len(colNames))
 	for i, name := range colNames {
-		// NewTypedColumn[any] yields an unwrapped any-column that stores nil
-		// directly; NewColumn[any] would wrap it and reject the nil default
-		// that NewRow appends (nil.(any) is false), leaving the column empty.
-		cols[i] = recordset.NewTypedColumn[any](name, nil)
+		cols[i] = inferColumn(name, rows)
 	}
 	rs := recordset.NewColumnarRecordset(recordsetName(q, options...), cols...)
 	for _, m := range rows {
 		row := rs.NewRow()
 		for _, name := range colNames {
 			if v, ok := m[name]; ok {
-				// An any-typed standard column accepts any value, so SetValue
-				// cannot fail here (the column always exists and is not
-				// computed).
+				// The column exists and is not computed; a typed column only
+				// exists when every row holds that exact type (see inferColumn),
+				// and an any-column accepts anything — so SetValue cannot fail.
 				_ = row.SetValueByName(name, v, rs)
 			}
 		}
 	}
 	return &columnarReader{rs: rs}, nil
+}
+
+// inferColumn picks a column type for a named field from its values across all
+// rows. It returns a typed column (float64/string/bool/int) only when every row
+// holds a present, non-nil value of one consistent kind; anything nullable,
+// absent, mixed, or of another kind falls back to an untyped (any) column so
+// nulls stay representable. The adapter is schemaless, so the type is inferred
+// from values rather than a declared schema.
+func inferColumn(name string, rows []map[string]any) recordset.Column[any] {
+	var t reflect.Type
+	for _, m := range rows {
+		v, ok := m[name]
+		if !ok || v == nil {
+			return recordset.NewTypedColumn[any](name, nil)
+		}
+		vt := reflect.TypeOf(v)
+		if t == nil {
+			t = vt
+		} else if t != vt {
+			return recordset.NewTypedColumn[any](name, nil)
+		}
+	}
+	switch {
+	case t == nil: // no rows
+		return recordset.NewTypedColumn[any](name, nil)
+	case t.Kind() == reflect.Float64:
+		return recordset.NewColumn[float64](name, 0)
+	case t.Kind() == reflect.String:
+		return recordset.NewColumn[string](name, "")
+	case t.Kind() == reflect.Bool:
+		return recordset.NewColumn[bool](name, false)
+	case t.Kind() == reflect.Int:
+		return recordset.NewColumn[int](name, 0)
+	default:
+		return recordset.NewTypedColumn[any](name, nil)
+	}
 }
 
 // recordToMap renders a result record's data as a map keyed by column name.

--- a/dalgo2memory/recordset_test.go
+++ b/dalgo2memory/recordset_test.go
@@ -70,6 +70,8 @@ func TestRecordset_GroupByAggregation(t *testing.T) {
 	rs := drainRecordset(t, db, ctx, q)
 	require.Equal(t, 2, rs.RowsCount())
 	require.Equal(t, []string{"category", "total"}, columnNames(rs))
+	require.Equal(t, reflect.TypeOf(""), rs.GetColumnByName("category").ValueType(), "category is a typed string column")
+	require.Equal(t, reflect.TypeOf(float64(0)), rs.GetColumnByName("total").ValueType(), "SUM is a typed float64 column")
 	byCat := map[string]any{}
 	for i := 0; i < rs.RowsCount(); i++ {
 		byCat[cellByName(t, rs, i, "category").(string)] = cellByName(t, rs, i, "total")
@@ -181,6 +183,38 @@ func TestRecordToMap(t *testing.T) {
 		_, err := recordToMap(withData(make(chan int)))
 		require.Error(t, err)
 	})
+}
+
+// inferColumn types a column from its values, falling back to any when the
+// values are nullable, absent, mixed, or of an unsupported kind.
+func TestInferColumn(t *testing.T) {
+	rows := func(vals ...any) []map[string]any {
+		out := make([]map[string]any, len(vals))
+		for i, v := range vals {
+			out[i] = map[string]any{"c": v}
+		}
+		return out
+	}
+	cases := []struct {
+		name string
+		rows []map[string]any
+		want reflect.Type
+	}{
+		{"float64", rows(1.0, 2.0), reflect.TypeOf(float64(0))},
+		{"string", rows("a", "b"), reflect.TypeOf("")},
+		{"bool", rows(true, false), reflect.TypeOf(false)},
+		{"int", rows(1, 2), reflect.TypeOf(int(0))},
+		{"nested unsupported kind", rows([]any{1}), nil},
+		{"mixed types", rows(1.0, "x"), nil},
+		{"nil value present", rows(1.0, nil), nil},
+		{"empty rows", []map[string]any{}, nil},
+		{"absent key", []map[string]any{{"other": 1.0}}, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, inferColumn("c", tc.rows).ValueType())
+		})
+	}
 }
 
 // buildRecordsetReader surfaces a reader error from the records pipeline.


### PR DESCRIPTION
Follow-up to #62. The recordset (columnar) read path built every column as untyped (`any`). This infers a column type from its values so consumers like DataTug get proper typing.

## Behavior

`inferColumn` types a column as `float64`/`string`/`bool`/`int` **only when every row holds a present, non-nil value of one consistent kind**. Anything nullable, absent, mixed, or of another kind (nested object/array) falls back to an `any` column so nulls stay representable.

The adapter is schemaless, so the type is inferred from the values rather than a declared schema. In practice (values are JSON-roundtripped):
- `SUM`/`AVG` and numeric fields → `float64`
- `COUNT(*)`/`COUNT(field)` → `int`
- group keys / string fields → `string`
- boolean fields → `bool`
- nullable, mixed, or nested → `any`

## Tests / verification

- Direct `TestInferColumn` table covering every branch (each scalar kind, nested/unsupported kind, mixed types, nil-present, empty rows, absent key).
- The GROUP BY recordset test now asserts `category` is a typed `string` column and `SUM` a typed `float64` column.
- `dalgo2memory` stays at **100%** coverage; `go test ./...`, vet, gofmt, golangci-lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)