### PR TITLE
feat(dalgo2memory): optional schema with typed records and field guards

### DIFF
--- a/dalgo2memory/database.go
+++ b/dalgo2memory/database.go
@@ -14,10 +14,14 @@ import (
 )
 
 // NewDB creates an in-memory DALgo database.
-func NewDB() dal.DB {
-	return &database{
+func NewDB(options ...Option) dal.DB {
+	db := &database{
 		collections: make(map[string]map[string][]byte),
 	}
+	for _, option := range options {
+		option(db)
+	}
+	return db
 }
 
 type database struct {
@@ -25,6 +29,7 @@ type database struct {
 
 	mu          sync.RWMutex
 	collections map[string]map[string][]byte
+	schema      *memorySchema
 }
 
 func (db *database) ID() string {
@@ -155,6 +160,10 @@ func (s session) Exists(_ context.Context, key *dal.Key) (bool, error) {
 }
 
 func (s session) Get(_ context.Context, record dal.Record) error {
+	if err := s.db.guardCollection(record.Key().Collection()); err != nil {
+		record.SetError(err)
+		return err
+	}
 	b, ok := s.getBytes(record.Key())
 	if !ok {
 		err := dal.NewErrNotFoundByKey(record.Key(), nil)
@@ -224,6 +233,9 @@ func (s session) Update(ctx context.Context, key *dal.Key, updates []update.Upda
 }
 
 func (s session) UpdateRecord(_ context.Context, record dal.Record, updates []update.Update, _ ...dal.Precondition) error {
+	if err := s.db.guardCollection(record.Key().Collection()); err != nil {
+		return err
+	}
 	b, ok := s.getBytes(record.Key())
 	if !ok {
 		return dal.NewErrNotFoundByKey(record.Key(), nil)
@@ -239,6 +251,9 @@ func (s session) UpdateRecord(_ context.Context, record dal.Record, updates []up
 	}
 	next, err := json.Marshal(data)
 	if err != nil {
+		return err
+	}
+	if err := s.db.guardFields(record.Key().Collection(), next); err != nil {
 		return err
 	}
 	s.collection(record.Key())[keyID(record.Key())] = next
@@ -264,6 +279,10 @@ func (s session) ExecuteQueryToRecordsReader(_ context.Context, query dal.Query)
 	}
 	base := q.From().Base()
 	collectionName := base.Name()
+	factory, err := s.db.recordFactory(collectionName)
+	if err != nil {
+		return nil, err
+	}
 	collection := s.db.collections[collectionName]
 	if len(collection) == 0 {
 		return dal.NewRecordsReader([]dal.Record{}), nil
@@ -316,6 +335,14 @@ func (s session) ExecuteQueryToRecordsReader(_ context.Context, query dal.Query)
 			continue
 		}
 		template := q.IntoRecord()
+		if template == nil && factory != nil {
+			data := factory()
+			if err := json.Unmarshal(row.raw, data); err != nil {
+				return nil, err
+			}
+			records[i] = dal.NewRecordWithData(key, data).SetError(nil)
+			continue
+		}
 		if template == nil {
 			records[i] = dal.NewRecord(key).SetError(nil)
 			continue
@@ -338,6 +365,11 @@ type memoryRow struct {
 }
 
 func (s session) save(record dal.Record, overwrite bool) error {
+	collectionName := record.Key().Collection()
+	if err := s.db.guardCollection(collectionName); err != nil {
+		record.SetError(err)
+		return err
+	}
 	id := keyID(record.Key())
 	collection := s.collection(record.Key())
 	if !overwrite {
@@ -348,6 +380,10 @@ func (s session) save(record dal.Record, overwrite bool) error {
 	record.SetError(nil)
 	b, err := json.Marshal(record.Data())
 	if err != nil {
+		record.SetError(err)
+		return err
+	}
+	if err := s.db.guardFields(collectionName, b); err != nil {
 		record.SetError(err)
 		return err
 	}

--- a/dalgo2memory/database.go
+++ b/dalgo2memory/database.go
@@ -19,7 +19,9 @@ func NewDB(options ...Option) dal.DB {
 		collections: make(map[string]map[string][]byte),
 	}
 	for _, option := range options {
-		option(db)
+		if option != nil {
+			option(db)
+		}
 	}
 	return db
 }

--- a/dalgo2memory/database.go
+++ b/dalgo2memory/database.go
@@ -233,7 +233,9 @@ func (s session) Update(ctx context.Context, key *dal.Key, updates []update.Upda
 }
 
 func (s session) UpdateRecord(_ context.Context, record dal.Record, updates []update.Update, _ ...dal.Precondition) error {
-	if err := s.db.guardCollection(record.Key().Collection()); err != nil {
+	collectionName := record.Key().Collection()
+	factory, err := s.db.recordFactory(collectionName)
+	if err != nil {
 		return err
 	}
 	b, ok := s.getBytes(record.Key())
@@ -253,8 +255,10 @@ func (s session) UpdateRecord(_ context.Context, record dal.Record, updates []up
 	if err != nil {
 		return err
 	}
-	if err := s.db.guardFields(record.Key().Collection(), next); err != nil {
-		return err
+	if factory != nil {
+		if err := checkUnknownFields(collectionName, factory, next); err != nil {
+			return err
+		}
 	}
 	s.collection(record.Key())[keyID(record.Key())] = next
 	return nil
@@ -366,7 +370,8 @@ type memoryRow struct {
 
 func (s session) save(record dal.Record, overwrite bool) error {
 	collectionName := record.Key().Collection()
-	if err := s.db.guardCollection(collectionName); err != nil {
+	factory, err := s.db.recordFactory(collectionName)
+	if err != nil {
 		record.SetError(err)
 		return err
 	}
@@ -383,9 +388,11 @@ func (s session) save(record dal.Record, overwrite bool) error {
 		record.SetError(err)
 		return err
 	}
-	if err := s.db.guardFields(collectionName, b); err != nil {
-		record.SetError(err)
-		return err
+	if factory != nil {
+		if err := checkUnknownFields(collectionName, factory, b); err != nil {
+			record.SetError(err)
+			return err
+		}
 	}
 	collection[id] = b
 	record.SetError(nil)

--- a/dalgo2memory/schema.go
+++ b/dalgo2memory/schema.go
@@ -82,18 +82,10 @@ func (db *database) guardCollection(collection string) error {
 	return err
 }
 
-// guardFields validates that the marshaled record data contains no fields that
-// are undefined in the collection's schema type. It also enforces the collection
-// guard. It is a no-op when no schema is registered or the collection is an
-// allowed undefined collection.
-func (db *database) guardFields(collection string, marshaled []byte) error {
-	factory, err := db.recordFactory(collection)
-	if err != nil {
-		return err
-	}
-	if factory == nil {
-		return nil
-	}
+// checkUnknownFields validates that the marshaled record data contains no fields
+// that are undefined in the collection's schema type. Callers pass the factory
+// already resolved via recordFactory, and only call this when factory is not nil.
+func checkUnknownFields(collection string, factory func() any, marshaled []byte) error {
 	decoder := json.NewDecoder(bytes.NewReader(marshaled))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(factory()); err != nil {

--- a/dalgo2memory/schema.go
+++ b/dalgo2memory/schema.go
@@ -1,0 +1,103 @@
+package dalgo2memory
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// Option configures an in-memory database created by NewDB.
+type Option func(*database)
+
+// collectionDef describes a single collection in an in-memory schema.
+// It is produced by WithCollection and consumed by WithSchema.
+type collectionDef struct {
+	name      string
+	newRecord func() any
+}
+
+// WithCollection registers a collection backed by the concrete record type T.
+//
+// If newRecord is nil, a zero value (new(T)) is used to materialize each record
+// read by a query. Provide a factory to populate default field values instead.
+func WithCollection[T any](name string, newRecord func() *T) collectionDef {
+	factory := func() any {
+		if newRecord != nil {
+			return newRecord()
+		}
+		return new(T)
+	}
+	return collectionDef{name: name, newRecord: factory}
+}
+
+// WithSchema registers per-collection record types so that queries return records
+// populated into the concrete Go type of the collection.
+//
+// allowUndefinedCollections controls what happens when a query targets a collection
+// that is not part of the schema: when false (the default intent) such a query
+// returns an error; when true it falls back to the schemaless behavior
+// (map[string]any / keys-only records).
+func WithSchema(allowUndefinedCollections bool, collections ...collectionDef) Option {
+	return func(db *database) {
+		factories := make(map[string]func() any, len(collections))
+		for _, c := range collections {
+			factories[c.name] = c.newRecord
+		}
+		db.schema = &memorySchema{
+			collections:    factories,
+			allowUndefined: allowUndefinedCollections,
+		}
+	}
+}
+
+// memorySchema holds the registered record factories for the in-memory database.
+type memorySchema struct {
+	collections    map[string]func() any
+	allowUndefined bool
+}
+
+// recordFactory returns the factory for a collection.
+//
+// It returns (nil, nil) when no schema is registered, or when the collection is
+// undefined but undefined collections are allowed. It returns an error when a
+// schema is registered, the collection is undefined, and undefined collections
+// are not allowed.
+func (db *database) recordFactory(collection string) (func() any, error) {
+	if db.schema == nil {
+		return nil, nil
+	}
+	if factory, ok := db.schema.collections[collection]; ok {
+		return factory, nil
+	}
+	if db.schema.allowUndefined {
+		return nil, nil
+	}
+	return nil, fmt.Errorf("collection %q is not defined in the schema", collection)
+}
+
+// guardCollection returns an error if a schema is registered and the collection
+// is undefined while undefined collections are not allowed.
+func (db *database) guardCollection(collection string) error {
+	_, err := db.recordFactory(collection)
+	return err
+}
+
+// guardFields validates that the marshaled record data contains no fields that
+// are undefined in the collection's schema type. It also enforces the collection
+// guard. It is a no-op when no schema is registered or the collection is an
+// allowed undefined collection.
+func (db *database) guardFields(collection string, marshaled []byte) error {
+	factory, err := db.recordFactory(collection)
+	if err != nil {
+		return err
+	}
+	if factory == nil {
+		return nil
+	}
+	decoder := json.NewDecoder(bytes.NewReader(marshaled))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(factory()); err != nil {
+		return fmt.Errorf("record for collection %q has fields not defined in the schema: %w", collection, err)
+	}
+	return nil
+}

--- a/dalgo2memory/schema.go
+++ b/dalgo2memory/schema.go
@@ -89,7 +89,7 @@ func checkUnknownFields(collection string, factory func() any, marshaled []byte)
 	decoder := json.NewDecoder(bytes.NewReader(marshaled))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(factory()); err != nil {
-		return fmt.Errorf("record for collection %q has fields not defined in the schema: %w", collection, err)
+		return fmt.Errorf("record for collection %q does not conform to the schema: %w", collection, err)
 	}
 	return nil
 }

--- a/dalgo2memory/schema_test.go
+++ b/dalgo2memory/schema_test.go
@@ -28,6 +28,12 @@ func readAll(t *testing.T, reader dal.RecordsReader) []dal.Record {
 	}
 }
 
+func TestNewDBIgnoresNilOption(t *testing.T) {
+	db := NewDB(nil, WithSchema(false, WithCollection[user]("users", nil)), nil).(*database)
+	require.NotNil(t, db.schema)
+	require.Contains(t, db.schema.collections, "users")
+}
+
 func TestSchemaTypedQueryResults(t *testing.T) {
 	ctx := context.Background()
 	db := NewDB(WithSchema(false,

--- a/dalgo2memory/schema_test.go
+++ b/dalgo2memory/schema_test.go
@@ -1,0 +1,176 @@
+package dalgo2memory
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/update"
+	"github.com/stretchr/testify/require"
+)
+
+type user struct {
+	Name string
+	Role string
+}
+
+func readAll(t *testing.T, reader dal.RecordsReader) []dal.Record {
+	t.Helper()
+	var records []dal.Record
+	for {
+		record, err := reader.Next()
+		if err != nil {
+			require.ErrorIs(t, err, dal.ErrNoMoreRecords)
+			return records
+		}
+		records = append(records, record)
+	}
+}
+
+func TestSchemaTypedQueryResults(t *testing.T) {
+	ctx := context.Background()
+	db := NewDB(WithSchema(false,
+		WithCollection[user]("users", func() *user { return &user{Role: "member"} }),
+		WithCollection[thing]("things", nil),
+	)).(*database)
+
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("users", "u1"), &user{Name: "Alice", Role: "admin"})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("users", "u2"), &user{Name: "Bob"})))
+
+	q := dal.From(dal.NewRootCollectionRef("users", "")).NewQuery().SelectKeysOnly(reflect.String)
+	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+	require.NoError(t, err)
+
+	records := readAll(t, reader)
+	require.Len(t, records, 2)
+	for _, record := range records {
+		data, ok := record.Data().(*user)
+		require.True(t, ok, "record data should be of the registered concrete type *user")
+		require.NotEmpty(t, data.Name)
+		// Bob was stored without a Role; the JSON round-trip leaves it empty,
+		// confirming stored data wins over factory defaults.
+		if data.Name == "Bob" {
+			require.Empty(t, data.Role)
+		}
+	}
+}
+
+func TestSchemaNilFactoryUsesZeroValue(t *testing.T) {
+	ctx := context.Background()
+	db := NewDB(WithSchema(false,
+		WithCollection[thing]("things", nil),
+	)).(*database)
+
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("things", "t1"), &thing{Name: "x", Count: 7})))
+
+	q := dal.From(dal.NewRootCollectionRef("things", "")).NewQuery().SelectKeysOnly(reflect.String)
+	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+	require.NoError(t, err)
+
+	records := readAll(t, reader)
+	require.Len(t, records, 1)
+	data, ok := records[0].Data().(*thing)
+	require.True(t, ok)
+	require.Equal(t, "x", data.Name)
+	require.Equal(t, 7, data.Count)
+}
+
+func TestSchemaUndefinedCollectionErrors(t *testing.T) {
+	ctx := context.Background()
+	db := NewDB(WithSchema(false,
+		WithCollection[user]("users", nil),
+	)).(*database)
+	key := dal.NewKeyWithID("orphans", "o1")
+
+	// All write/read operations on an undefined collection are rejected.
+	require.Error(t, db.Set(ctx, dal.NewRecordWithData(key, &thing{Name: "x"})))
+	require.Error(t, db.Insert(ctx, dal.NewRecordWithData(key, &thing{Name: "x"})))
+	require.Error(t, db.Get(ctx, dal.NewRecordWithData(key, &thing{})))
+	require.Error(t, db.Update(ctx, key, []update.Update{update.ByFieldName("Name", "x")}))
+
+	// Nothing was written despite the Set/Insert attempts.
+	require.Empty(t, db.collections["orphans"])
+
+	// Queries against an undefined collection error too.
+	q := dal.From(dal.NewRootCollectionRef("orphans", "")).NewQuery().SelectKeysOnly(reflect.String)
+	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+	require.Nil(t, reader)
+	require.Error(t, err)
+}
+
+func TestSchemaRejectsUndefinedFieldsOnWrite(t *testing.T) {
+	ctx := context.Background()
+	db := NewDB(WithSchema(false,
+		WithCollection[user]("users", nil),
+	)).(*database)
+	key := dal.NewKeyWithID("users", "u1")
+
+	// A field that does not exist on the user type must be rejected.
+	bad := dal.NewRecordWithData(key, map[string]any{"Name": "Alice", "Unknown": 1})
+	require.Error(t, db.Set(ctx, bad))
+	require.Error(t, db.Insert(ctx, bad))
+	require.Empty(t, db.collections["users"])
+
+	// A payload that only uses defined fields is accepted.
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, map[string]any{"Name": "Alice", "Role": "admin"})))
+
+	// Updating an undefined field is rejected; the stored record is unchanged.
+	require.Error(t, db.Update(ctx, key, []update.Update{update.ByFieldName("Unknown", 1)}))
+	var got user
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(key, &got)))
+	require.Equal(t, user{Name: "Alice", Role: "admin"}, got)
+
+	// Updating a defined field succeeds.
+	require.NoError(t, db.Update(ctx, key, []update.Update{update.ByFieldName("Role", "member")}))
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(key, &got)))
+	require.Equal(t, "member", got.Role)
+}
+
+func TestSchemaAllowUndefinedFallsBack(t *testing.T) {
+	ctx := context.Background()
+	db := NewDB(WithSchema(true,
+		WithCollection[user]("users", nil),
+	)).(*database)
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("orphans", "o1"), &thing{Name: "x"})))
+
+	q := dal.From(dal.NewRootCollectionRef("orphans", "")).NewQuery().SelectKeysOnly(reflect.String)
+	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+	require.NoError(t, err)
+	records := readAll(t, reader)
+	require.Len(t, records, 1)
+	// No factory for an undefined collection => keys-only record (nil data).
+	require.Nil(t, records[0].Data())
+}
+
+func TestSchemaIntoRecordTakesPrecedence(t *testing.T) {
+	ctx := context.Background()
+	db := NewDB(WithSchema(false,
+		WithCollection[user]("users", nil),
+	)).(*database)
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("users", "u1"), &user{Name: "Alice"})))
+
+	q := dal.From(dal.NewRootCollectionRef("users", "")).NewQuery().SelectIntoRecord(func() dal.Record {
+		return dal.NewRecordWithIncompleteKey("users", reflect.String, &map[string]any{})
+	})
+	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+	require.NoError(t, err)
+	records := readAll(t, reader)
+	require.Len(t, records, 1)
+	_, isUser := records[0].Data().(*user)
+	require.False(t, isUser, "explicit SelectIntoRecord should override the schema factory")
+}
+
+func TestNoSchemaUnaffected(t *testing.T) {
+	ctx := context.Background()
+	db := NewDB().(*database)
+	require.Nil(t, db.schema)
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("users", "u1"), &user{Name: "Alice"})))
+
+	q := dal.From(dal.NewRootCollectionRef("users", "")).NewQuery().SelectKeysOnly(reflect.String)
+	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+	require.NoError(t, err)
+	records := readAll(t, reader)
+	require.Len(t, records, 1)
+	require.Nil(t, records[0].Data())
+}

--- a/dalgo2memory/schema_test.go
+++ b/dalgo2memory/schema_test.go
@@ -127,6 +127,21 @@ func TestSchemaRejectsUndefinedFieldsOnWrite(t *testing.T) {
 	require.Equal(t, "member", got.Role)
 }
 
+func TestSchemaQueryMalformedStoredData(t *testing.T) {
+	ctx := context.Background()
+	db := NewDB(WithSchema(false,
+		WithCollection[thing]("things", nil),
+	)).(*database)
+	key := dal.NewKeyWithID("things", "bad")
+	// Decodes fine into map[string]any, but Count("x") fails to decode into thing.
+	db.collections["things"] = map[string][]byte{keyID(key): []byte(`{"Count":"x"}`)}
+
+	q := dal.From(dal.NewRootCollectionRef("things", "")).NewQuery().SelectKeysOnly(reflect.String)
+	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+	require.Nil(t, reader)
+	require.Error(t, err)
+}
+
 func TestSchemaAllowUndefinedFallsBack(t *testing.T) {
 	ctx := context.Background()
 	db := NewDB(WithSchema(true,


### PR DESCRIPTION
## Summary

Adds an optional schema to the in-memory adapter so a collection can be bound to a concrete Go record type (or a factory that supplies default values). When a schema is registered the adapter enforces it; with no schema it behaves exactly as before.

```go
db := dalgo2memory.NewDB(
    dalgo2memory.WithSchema(false, // allowUndefinedCollections
        dalgo2memory.WithCollection[User]("users", func() *User { return &User{Role: "member"} }),
        dalgo2memory.WithCollection[Company]("companies", nil), // nil -> new(Company)
    ),
)
```

## Behavior

- **Typed query results** — query reads materialize records into the registered concrete type via a JSON round-trip (stored data wins over factory defaults). Explicit `SelectIntoRecord(...)` still takes precedence per-query.
- **Collection guard** — `Get`/`Set`/`Insert`/`Update` and queries on a collection not in the schema error, unless `allowUndefinedCollections` is `true` (then legacy schemaless behavior).
- **Field guard** — writes (`Set`/`Insert`/`Update`) reject fields not defined on the collection's type via `json.Decoder.DisallowUnknownFields()`, for both struct and `map[string]any` payloads. Nothing is written on rejection.

## Compatibility

`NewDB` gains variadic options and stays fully backward-compatible — all existing `NewDB()` call sites are unaffected.

## Scope notes

- `Delete`/`Exists` are not guarded (deleting/checking a missing collection is already a harmless no-op).
- `WithCollection[map[string]any](...)` registers a type with no fixed fields, so field validation is a pass-through for that collection by design.

## Tests

New `dalgo2memory/schema_test.go` covers: typed results, nil-factory zero value, undefined-collection errors across all guarded ops, undefined-field rejection on write/update, `SelectIntoRecord` precedence, and the no-schema baseline. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)