### PR TITLE
feat(dalgo2memory): pluggable storage engines (seam, serialized, columnar, mixed-mode maps)

### DIFF
--- a/dalgo2memory/columnar.go
+++ b/dalgo2memory/columnar.go
@@ -1,0 +1,584 @@
+package dalgo2memory
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/dal-go/dalgo/dal"
+)
+
+// compactionThreshold is the dead-slot fraction that triggers compaction. When
+// dead/(live+dead) reaches this fraction (and at least one slot exists),
+// maybeCompact reclaims the dead slots under the global write lock.
+const compactionThreshold = 0.5
+
+// column is one column of a columnar collection: the JSON field name it stores,
+// a slice typed to the field's Go element type (or []any for an interface /
+// heterogeneous field), a flag marking reference-bearing element types (which
+// are deep-copied on write when faithful), the strategy backing it, and a back
+// reference to the engine for liveness checks.
+type column struct {
+	name        string        // JSON object key (the field view / query key)
+	goField     string        // the Go struct field name (for opt-out direct copy)
+	values      reflect.Value // a slice of elemType, indexed by slot
+	elemType    reflect.Type
+	refBearing  bool
+	strategy    ColumnStrategy
+	defaultStgy *typedSliceStrategy // non-nil when strategy is the default
+	engine      *columnarEngine
+}
+
+// columnarEngine stores a typed collection column-wise over a stable per-row
+// slot model with tombstone deletes and bulk compaction. It implements the
+// storageEngine seam and is selected per collection via WithColumnarStorage.
+//
+// All access is serialized by the database's single global write lock (db.mu),
+// so the engine itself holds no lock.
+type columnarEngine struct {
+	collection string
+	factory    func() any
+	recordType reflect.Type // the struct type T (factory returns *T)
+
+	columns   []*column
+	byName    map[string]*column
+	idToSlot  map[string]int
+	slotToID  []string                  // slotToID[slot] == "" when the slot is dead
+	live      []bool                    // live[slot] reports whether the slot holds a record
+	freeList  []int                     // dead slots available for reuse
+	deadCount int                       // number of dead (tombstoned) slots
+	refBreak  bool                      // faithful (deep-copy ref-bearing columns) when true
+	stgyByCol map[string]ColumnStrategy // explicit per-column strategies
+
+	// initErr is set when the factory could not build a typed columnar engine
+	// (schemaless/non-struct selection); every operation reports it.
+	initErr error
+}
+
+var _ storageEngine = (*columnarEngine)(nil)
+
+// columnarConfig is the resolved configuration produced by WithColumnarStorage:
+// the per-column strategies and the optional per-collection ref-breaking
+// override (nil means "inherit the schema-wide default").
+type columnarConfig struct {
+	strategies   map[string]ColumnStrategy
+	refBreakOver *bool
+}
+
+// newColumnarEngineFactory builds an engineFactory that constructs a columnar
+// engine for a typed collection. Selecting columnar storage for a schemaless or
+// non-struct collection yields an engine whose operations all fail with a
+// descriptive error (REQ:columnar-selection).
+func newColumnarEngineFactory(cfg columnarConfig) engineFactory {
+	return func(collection string, factory func() any, schemaRefBreaking bool) storageEngine {
+		refBreak := schemaRefBreaking
+		if cfg.refBreakOver != nil {
+			refBreak = *cfg.refBreakOver
+		}
+		recordType, err := structTypeOf(factory)
+		if err != nil {
+			return &columnarEngine{
+				collection: collection,
+				factory:    factory,
+				initErr:    fmt.Errorf("columnar storage for collection %q requires a schema-registered typed collection: %w", collection, err),
+			}
+		}
+		eng := &columnarEngine{
+			collection: collection,
+			factory:    factory,
+			recordType: recordType,
+			byName:     make(map[string]*column),
+			idToSlot:   make(map[string]int),
+			refBreak:   refBreak,
+			stgyByCol:  cfg.strategies,
+		}
+		eng.buildColumns()
+		return eng
+	}
+}
+
+// structTypeOf returns the struct type T given a factory returning *T (or T).
+// It errors when the factory is nil or the resolved type is not a struct.
+func structTypeOf(factory func() any) (reflect.Type, error) {
+	if factory == nil {
+		return nil, fmt.Errorf("collection has no registered record type")
+	}
+	t := reflect.TypeOf(factory())
+	for t != nil && t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t == nil || t.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("registered record type is not a struct")
+	}
+	return t, nil
+}
+
+// buildColumns derives one column per JSON-serializable field of the record
+// type, typed to the field's Go type (or []any for interface fields), and wires
+// each column's strategy (explicit when supplied, else the default typed-slice
+// strategy).
+func (e *columnarEngine) buildColumns() {
+	for i := 0; i < e.recordType.NumField(); i++ {
+		field := e.recordType.Field(i)
+		name, ok := jsonFieldName(field)
+		if !ok {
+			continue
+		}
+		elemType := field.Type
+		if elemType.Kind() == reflect.Interface {
+			elemType = anyType
+		}
+		col := &column{
+			name:       name,
+			goField:    field.Name,
+			values:     reflect.MakeSlice(reflect.SliceOf(elemType), 0, 0),
+			elemType:   elemType,
+			refBearing: isRefBearing(field.Type),
+			engine:     e,
+		}
+		if stgy, ok := e.stgyByCol[name]; ok && stgy != nil {
+			col.strategy = stgy
+		} else {
+			def := newTypedSliceStrategy(col)
+			col.strategy = def
+			col.defaultStgy = def
+		}
+		e.columns = append(e.columns, col)
+		e.byName[name] = col
+	}
+}
+
+var anyType = reflect.TypeOf((*any)(nil)).Elem()
+
+// jsonFieldName reports the JSON object key a struct field marshals to (so the
+// columnar field view keys match the Serialized engine's json.Unmarshal keys),
+// and whether the field is serialized at all (exported, not json:"-").
+func jsonFieldName(field reflect.StructField) (string, bool) {
+	if field.PkgPath != "" { // unexported
+		return "", false
+	}
+	tag, ok := field.Tag.Lookup("json")
+	if !ok {
+		return field.Name, true
+	}
+	name, _, _ := strings.Cut(tag, ",")
+	switch name {
+	case "-":
+		return "", false
+	case "":
+		return field.Name, true
+	default:
+		return name, true
+	}
+}
+
+// isRefBearing reports whether a field type can share references with the
+// caller's value (slice, map, pointer, interface, or a struct/array containing
+// one). Such columns are deep-copied via a JSON round-trip on write when the
+// collection is faithful.
+func isRefBearing(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Slice, reflect.Map, reflect.Pointer, reflect.Interface, reflect.Chan, reflect.Func, reflect.UnsafePointer:
+		return true
+	case reflect.Array:
+		return isRefBearing(t.Elem())
+	case reflect.Struct:
+		for i := 0; i < t.NumField(); i++ {
+			if t.Field(i).PkgPath == "" && isRefBearing(t.Field(i).Type) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+func (e *columnarEngine) exists(id string) bool {
+	if e.initErr != nil {
+		return false
+	}
+	slot, ok := e.idToSlot[id]
+	return ok && e.live[slot]
+}
+
+func (e *columnarEngine) store(id string, record dal.Record, overwrite bool) error {
+	if e.initErr != nil {
+		return e.initErr
+	}
+	if !overwrite {
+		if slot, ok := e.idToSlot[id]; ok && e.live[slot] {
+			return fmt.Errorf("record already exists: %s", record.Key())
+		}
+	}
+	values, err := e.decodeFields(record.Data())
+	if err != nil {
+		return err
+	}
+	slot := e.allocSlot(id)
+	e.writeSlot(slot, values)
+	return nil
+}
+
+func (e *columnarEngine) load(id string, record dal.Record) error {
+	if e.initErr != nil {
+		return e.initErr
+	}
+	slot, ok := e.idToSlot[id]
+	if !ok || !e.live[slot] {
+		return dal.NewErrNotFoundByKey(record.Key(), nil)
+	}
+	return e.materializeSlot(slot, record.Data())
+}
+
+func (e *columnarEngine) delete(id string) {
+	if e.initErr != nil {
+		return
+	}
+	slot, ok := e.idToSlot[id]
+	if !ok || !e.live[slot] {
+		return
+	}
+	e.freeSlot(slot)
+	delete(e.idToSlot, id)
+	e.maybeCompact()
+}
+
+func (e *columnarEngine) update(id string, updates map[string]any) error {
+	if e.initErr != nil {
+		return e.initErr
+	}
+	slot, ok := e.idToSlot[id]
+	if !ok || !e.live[slot] {
+		return dal.NewErrNotFoundByKey(dal.NewKeyWithID(e.collection, id), nil)
+	}
+	current, err := e.rowData(slot)
+	if err != nil {
+		return err
+	}
+	for fieldName, value := range updates {
+		if _, ok := e.byName[fieldName]; !ok {
+			return fmt.Errorf("record for collection %q does not conform to the schema: unknown field %q", e.collection, fieldName)
+		}
+		current[fieldName] = value
+	}
+	values, err := e.decodeFields(current)
+	if err != nil {
+		return err
+	}
+	e.writeSlot(slot, values)
+	return nil
+}
+
+func (e *columnarEngine) rows() ([]engineRow, error) {
+	if e.initErr != nil {
+		return nil, e.initErr
+	}
+	ids := make([]string, 0, len(e.idToSlot))
+	for id := range e.idToSlot {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return e.buildRows(ids)
+}
+
+// buildRows reassembles the given (sorted) ids into engineRows, each carrying
+// the JSON-normalized field view and a materialize callback bound to the row's
+// current slot.
+func (e *columnarEngine) buildRows(ids []string) ([]engineRow, error) {
+	rows := make([]engineRow, 0, len(ids))
+	for _, id := range ids {
+		slot := e.idToSlot[id]
+		data, err := e.rowData(slot)
+		if err != nil {
+			return nil, err
+		}
+		s := slot
+		rows = append(rows, engineRow{
+			id:          id,
+			data:        data,
+			materialize: func(target any) error { return e.materializeSlot(s, target) },
+		})
+	}
+	return rows, nil
+}
+
+// candidateRows implements the equality-WHERE acceleration the query path uses:
+// for the single supported field==value predicate it consults the target
+// column's strategy. When the strategy returns a slot set (ok=true), only those
+// live slots are reassembled; "no opinion" returns ok=false and the caller
+// scans all rows. The caller re-applies matchesWhere to the returned rows, so
+// the result is identical to a full scan regardless of the strategy.
+func (e *columnarEngine) candidateRows(condition dal.Condition) ([]engineRow, bool, error) {
+	if e.initErr != nil {
+		return nil, false, e.initErr
+	}
+	slots, ok := e.candidateSlots(condition)
+	if !ok {
+		return nil, false, nil
+	}
+	ids := make([]string, 0, len(slots))
+	for slot := range slots {
+		if slot >= 0 && slot < len(e.live) && e.live[slot] {
+			ids = append(ids, e.slotToID[slot])
+		}
+	}
+	sort.Strings(ids)
+	rows, err := e.buildRows(ids)
+	if err != nil {
+		return nil, false, err
+	}
+	return rows, true, nil
+}
+
+// candidateSlots returns the live slots a single equality predicate selects via
+// the target column's strategy, with ok=true; ok=false means "no opinion"
+// (caller scans). It is only consulted for the single field==value predicate
+// the adapter supports; any other condition shape yields no opinion.
+func (e *columnarEngine) candidateSlots(condition dal.Condition) (SlotSet, bool) {
+	comparison, ok := condition.(dal.Comparison)
+	if !ok || comparison.Operator != dal.Equal {
+		return nil, false
+	}
+	field, ok := comparison.Left.(dal.FieldRef)
+	if !ok {
+		return nil, false
+	}
+	constant, ok := comparison.Right.(dal.Constant)
+	if !ok {
+		return nil, false
+	}
+	col, ok := e.byName[field.Name()]
+	if !ok {
+		return nil, false
+	}
+	return col.strategy.EqualSlots(constant.Value)
+}
+
+// allocSlot reserves a slot for id: it reuses a free (tombstoned) slot when one
+// is available, otherwise appends a new slot to every column. The id's slot is
+// recorded and stays stable until deletion or compaction.
+func (e *columnarEngine) allocSlot(id string) int {
+	if slot, ok := e.idToSlot[id]; ok && e.live[slot] {
+		return slot
+	}
+	if n := len(e.freeList); n > 0 {
+		slot := e.freeList[n-1]
+		e.freeList = e.freeList[:n-1]
+		e.deadCount--
+		e.live[slot] = true
+		e.slotToID[slot] = id
+		e.idToSlot[id] = slot
+		return slot
+	}
+	slot := len(e.live)
+	for _, col := range e.columns {
+		col.values = reflect.Append(col.values, reflect.Zero(col.elemType))
+	}
+	e.live = append(e.live, true)
+	e.slotToID = append(e.slotToID, id)
+	e.idToSlot[id] = slot
+	return slot
+}
+
+// writeSlot stores already-decoded per-column values at slot and updates each
+// column's strategy write side.
+func (e *columnarEngine) writeSlot(slot int, values []reflect.Value) {
+	for i, col := range e.columns {
+		col.values.Index(slot).Set(values[i])
+		col.strategy.SetValue(slot, values[i].Interface())
+	}
+}
+
+// freeSlot tombstones a slot: it marks it dead, zeroes its column cells, clears
+// each strategy, and pushes it to the free list for reuse.
+func (e *columnarEngine) freeSlot(slot int) {
+	for _, col := range e.columns {
+		col.values.Index(slot).Set(reflect.Zero(col.elemType))
+		col.strategy.ClearValue(slot)
+	}
+	e.live[slot] = false
+	e.slotToID[slot] = ""
+	e.freeList = append(e.freeList, slot)
+	e.deadCount++
+}
+
+// decodeFields converts a record's data (a struct, pointer, or map[string]any)
+// into one reflect.Value per column, typed to the column's element type.
+//
+// The record is first marshaled (rejecting non-serializable values) and
+// unmarshaled into a normalized map, matching the Serialized engine's
+// validation and reassembly view; an unknown field is rejected there. Scalar
+// columns are then decoded from the normalized value. A reference-bearing
+// column is deep-copied via the round-trip when the collection is faithful;
+// when the opt-out is set and the source is a live struct, the caller's field
+// value is stored by direct reflection copy (sharing references). Fields absent
+// from the data decode to the column's zero value.
+func (e *columnarEngine) decodeFields(data any) ([]reflect.Value, error) {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	var asMap map[string]any
+	if err := json.Unmarshal(b, &asMap); err != nil {
+		return nil, err
+	}
+	for key := range asMap {
+		if _, ok := e.byName[key]; !ok {
+			return nil, fmt.Errorf("record for collection %q does not conform to the schema: unknown field %q", e.collection, key)
+		}
+	}
+	src := structValue(data)
+	values := make([]reflect.Value, len(e.columns))
+	for i, col := range e.columns {
+		dst := reflect.New(col.elemType)
+		if !e.refBreak && col.refBearing && src.IsValid() {
+			if field := src.FieldByName(col.goField); field.IsValid() && field.Type() == col.elemType {
+				dst.Elem().Set(field)
+				values[i] = dst.Elem()
+				continue
+			}
+		}
+		raw, present := asMap[col.name]
+		if present {
+			if err := assignInto(dst, raw, col); err != nil {
+				return nil, err
+			}
+		}
+		values[i] = dst.Elem()
+	}
+	return values, nil
+}
+
+// structValue returns the underlying struct reflect.Value of a record's data
+// (dereferencing a pointer), or an invalid Value when the data is not a struct
+// (e.g. a map[string]any write), in which case the opt-out direct copy does not
+// apply and the round-trip path is used.
+func structValue(data any) reflect.Value {
+	v := reflect.ValueOf(data)
+	for v.IsValid() && v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	if v.IsValid() && v.Kind() == reflect.Struct {
+		return v
+	}
+	return reflect.Value{}
+}
+
+// assignInto decodes a JSON-normalized value into a freshly allocated cell of
+// the column's element type. The []any fallback keeps the raw normalized value;
+// any other type is decoded via json.Unmarshal into the typed cell.
+func assignInto(dst reflect.Value, raw any, col *column) error {
+	if col.elemType == anyType {
+		if raw != nil {
+			dst.Elem().Set(reflect.ValueOf(raw))
+		}
+		return nil
+	}
+	// raw is a value decoded from JSON (see decodeFields), so it always
+	// re-marshals; only the decode into the typed cell can fail (type mismatch).
+	b, _ := json.Marshal(raw)
+	if err := json.Unmarshal(b, dst.Interface()); err != nil {
+		return err
+	}
+	return nil
+}
+
+// rowData builds the JSON-normalized map[string]any field view for a slot by
+// marshaling each column cell, matching the Serialized engine's view exactly
+// (numbers as float64, nested as map[string]any), so the shared query pipeline
+// produces identical results.
+func (e *columnarEngine) rowData(slot int) (map[string]any, error) {
+	cells := make(map[string]any, len(e.columns))
+	for _, col := range e.columns {
+		cells[col.name] = col.values.Index(slot).Interface()
+	}
+	b, err := json.Marshal(cells)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]any
+	// b is the marshaling of a map, so it is a JSON object that always decodes
+	// back into map[string]any.
+	_ = json.Unmarshal(b, &out)
+	return out, nil
+}
+
+// materializeSlot reassembles a slot into a typed target by marshaling the
+// per-column cells into a JSON object and unmarshaling it into target, so the
+// result shares no references with stored data or other reads.
+func (e *columnarEngine) materializeSlot(slot int, target any) error {
+	obj := make(map[string]any, len(e.columns))
+	for _, col := range e.columns {
+		obj[col.name] = col.values.Index(slot).Interface()
+	}
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, target)
+}
+
+// maybeCompact compacts when the dead-slot fraction crosses the threshold,
+// reclaiming dead slots while preserving every live record. It runs under the
+// global write lock; readers never observe partial state because no read can
+// interleave with it.
+func (e *columnarEngine) maybeCompact() {
+	total := len(e.live)
+	if total == 0 || e.deadCount == 0 {
+		return
+	}
+	if float64(e.deadCount)/float64(total) < compactionThreshold {
+		return
+	}
+	e.compact()
+}
+
+// compact rebuilds the column slices and slot mapping with only live records,
+// in ascending current-slot order, then rebuilds each column's strategy from
+// the compacted slices.
+func (e *columnarEngine) compact() {
+	liveSlots := make([]int, 0, len(e.live)-e.deadCount)
+	for slot, isLive := range e.live {
+		if isLive {
+			liveSlots = append(liveSlots, slot)
+		}
+	}
+	newLen := len(liveSlots)
+	for _, col := range e.columns {
+		next := reflect.MakeSlice(col.values.Type(), newLen, newLen)
+		for newSlot, oldSlot := range liveSlots {
+			next.Index(newSlot).Set(col.values.Index(oldSlot))
+		}
+		col.values = next
+	}
+	newSlotToID := make([]string, newLen)
+	newLive := make([]bool, newLen)
+	for newSlot, oldSlot := range liveSlots {
+		id := e.slotToID[oldSlot]
+		newSlotToID[newSlot] = id
+		newLive[newSlot] = true
+		e.idToSlot[id] = newSlot
+	}
+	e.slotToID = newSlotToID
+	e.live = newLive
+	e.freeList = e.freeList[:0]
+	e.deadCount = 0
+	e.rebuildStrategies()
+}
+
+// rebuildStrategies re-syncs each column's strategy with the compacted slices:
+// the default strategy reads the live slices directly (nothing to do), while an
+// explicit external strategy is notified via its write side per live slot.
+func (e *columnarEngine) rebuildStrategies() {
+	for _, col := range e.columns {
+		if col.defaultStgy != nil {
+			continue
+		}
+		for slot := 0; slot < col.values.Len(); slot++ {
+			col.strategy.SetValue(slot, col.values.Index(slot).Interface())
+		}
+	}
+}

--- a/dalgo2memory/columnar.go
+++ b/dalgo2memory/columnar.go
@@ -52,6 +52,13 @@ type columnarEngine struct {
 	refBreak  bool                      // faithful (deep-copy ref-bearing columns) when true
 	stgyByCol map[string]ColumnStrategy // explicit per-column strategies
 
+	// mapBacked reports a mixed-mode map[string]any collection: columns come
+	// from declared options and undeclared fields are kept in leftover.
+	mapBacked bool
+	// leftover holds each row's undeclared fields, indexed by the same per-row
+	// slot as the column slices (nil for the struct path).
+	leftover []map[string]any
+
 	// initErr is set when the factory could not build a typed columnar engine
 	// (schemaless/non-struct selection); every operation reports it.
 	initErr error
@@ -60,11 +67,23 @@ type columnarEngine struct {
 var _ storageEngine = (*columnarEngine)(nil)
 
 // columnarConfig is the resolved configuration produced by WithColumnarStorage:
-// the per-column strategies and the optional per-collection ref-breaking
-// override (nil means "inherit the schema-wide default").
+// the per-column strategies, the optional per-collection ref-breaking override
+// (nil means "inherit the schema-wide default"), and the columns explicitly
+// declared for a map-backed (map[string]any) collection.
 type columnarConfig struct {
 	strategies   map[string]ColumnStrategy
 	refBreakOver *bool
+	declared     []declaredColumn
+}
+
+// declaredColumn names a column explicitly declared (via WithDeclaredColumn) for
+// a map-backed columnar collection, together with the Go element type its typed
+// slice holds. Declared columns are the column set for a map[string]any
+// collection; on a struct collection they are accepted but redundant (the struct
+// path reflects over the record type instead).
+type declaredColumn struct {
+	name     string
+	elemType reflect.Type
 }
 
 // newColumnarEngineFactory builds an engineFactory that constructs a columnar
@@ -79,6 +98,9 @@ func newColumnarEngineFactory(cfg columnarConfig) engineFactory {
 		}
 		recordType, err := structTypeOf(factory)
 		if err != nil {
+			if isMapBackedFactory(factory) {
+				return newMapBackedEngine(collection, factory, refBreak, cfg)
+			}
 			return &columnarEngine{
 				collection: collection,
 				factory:    factory,
@@ -97,6 +119,47 @@ func newColumnarEngineFactory(cfg columnarConfig) engineFactory {
 		eng.buildColumns()
 		return eng
 	}
+}
+
+// isMapBackedFactory reports whether the collection's record type is
+// map[string]any (a schemaless mixed-mode collection), as opposed to a struct
+// or any other type.
+func isMapBackedFactory(factory func() any) bool {
+	if factory == nil {
+		return false
+	}
+	t := reflect.TypeOf(factory())
+	for t != nil && t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	return t != nil && t == mapStringAnyType
+}
+
+var mapStringAnyType = reflect.TypeOf(map[string]any{})
+
+// newMapBackedEngine builds a mixed-mode columnar engine for a map[string]any
+// collection from its explicitly declared columns. With no declared column the
+// engine cannot infer its columns, so every operation reports a descriptive
+// error (REQ:mixed-mode-selection).
+func newMapBackedEngine(collection string, factory func() any, refBreak bool, cfg columnarConfig) *columnarEngine {
+	if len(cfg.declared) == 0 {
+		return &columnarEngine{
+			collection: collection,
+			factory:    factory,
+			initErr:    fmt.Errorf("columnar storage for map-backed collection %q requires at least one declared column (WithDeclaredColumn)", collection),
+		}
+	}
+	eng := &columnarEngine{
+		collection: collection,
+		factory:    factory,
+		byName:     make(map[string]*column),
+		idToSlot:   make(map[string]int),
+		refBreak:   refBreak,
+		stgyByCol:  cfg.strategies,
+		mapBacked:  true,
+	}
+	eng.buildDeclaredColumns(cfg.declared)
+	return eng
 }
 
 // structTypeOf returns the struct type T given a factory returning *T (or T).
@@ -147,6 +210,41 @@ func (e *columnarEngine) buildColumns() {
 		}
 		e.columns = append(e.columns, col)
 		e.byName[name] = col
+	}
+}
+
+// buildDeclaredColumns derives one typed column per declared column for a
+// map-backed collection, in declaration order. A column's element type is the
+// declared Go type (or []any when an interface type is declared), and its
+// strategy is the explicit one when supplied, else the default typed-slice
+// strategy. When the same name is declared more than once, the last declaration
+// wins (its element type replaces the earlier one).
+func (e *columnarEngine) buildDeclaredColumns(declared []declaredColumn) {
+	for _, dc := range declared {
+		elemType := dc.elemType
+		if elemType.Kind() == reflect.Interface {
+			elemType = anyType
+		}
+		col := &column{
+			name:       dc.name,
+			values:     reflect.MakeSlice(reflect.SliceOf(elemType), 0, 0),
+			elemType:   elemType,
+			refBearing: isRefBearing(dc.elemType),
+			engine:     e,
+		}
+		if stgy, ok := e.stgyByCol[dc.name]; ok && stgy != nil {
+			col.strategy = stgy
+		} else {
+			def := newTypedSliceStrategy(col)
+			col.strategy = def
+			col.defaultStgy = def
+		}
+		if existing, ok := e.byName[dc.name]; ok {
+			*existing = *col // last-declaration-wins: replace in place, keep order
+			continue
+		}
+		e.columns = append(e.columns, col)
+		e.byName[dc.name] = col
 	}
 }
 
@@ -213,12 +311,12 @@ func (e *columnarEngine) store(id string, record dal.Record, overwrite bool) err
 			return fmt.Errorf("record already exists: %s", record.Key())
 		}
 	}
-	values, err := e.decodeFields(record.Data())
+	values, leftover, err := e.prepareWrite(record.Data())
 	if err != nil {
 		return err
 	}
 	slot := e.allocSlot(id)
-	e.writeSlot(slot, values)
+	e.writeSlot(slot, values, leftover)
 	return nil
 }
 
@@ -259,16 +357,18 @@ func (e *columnarEngine) update(id string, updates map[string]any) error {
 		return err
 	}
 	for fieldName, value := range updates {
-		if _, ok := e.byName[fieldName]; !ok {
+		// On the struct path an unknown field is rejected; on the map-backed
+		// path an undeclared field is a valid leftover field.
+		if _, ok := e.byName[fieldName]; !ok && !e.mapBacked {
 			return fmt.Errorf("record for collection %q does not conform to the schema: unknown field %q", e.collection, fieldName)
 		}
 		current[fieldName] = value
 	}
-	values, err := e.decodeFields(current)
+	values, leftover, err := e.prepareWrite(current)
 	if err != nil {
 		return err
 	}
-	e.writeSlot(slot, values)
+	e.writeSlot(slot, values, leftover)
 	return nil
 }
 
@@ -377,32 +477,94 @@ func (e *columnarEngine) allocSlot(id string) int {
 	for _, col := range e.columns {
 		col.values = reflect.Append(col.values, reflect.Zero(col.elemType))
 	}
+	if e.mapBacked {
+		e.leftover = append(e.leftover, nil)
+	}
 	e.live = append(e.live, true)
 	e.slotToID = append(e.slotToID, id)
 	e.idToSlot[id] = slot
 	return slot
 }
 
-// writeSlot stores already-decoded per-column values at slot and updates each
-// column's strategy write side.
-func (e *columnarEngine) writeSlot(slot int, values []reflect.Value) {
+// writeSlot stores already-decoded per-column values at slot, updates each
+// column's strategy write side, and (on the map-backed path) stores the row's
+// leftover map of undeclared fields at the same slot.
+func (e *columnarEngine) writeSlot(slot int, values []reflect.Value, leftover map[string]any) {
 	for i, col := range e.columns {
 		col.values.Index(slot).Set(values[i])
 		col.strategy.SetValue(slot, values[i].Interface())
 	}
+	if e.mapBacked {
+		e.leftover[slot] = leftover
+	}
 }
 
 // freeSlot tombstones a slot: it marks it dead, zeroes its column cells, clears
-// each strategy, and pushes it to the free list for reuse.
+// each strategy, drops its leftover map (map-backed), and pushes it to the free
+// list for reuse.
 func (e *columnarEngine) freeSlot(slot int) {
 	for _, col := range e.columns {
 		col.values.Index(slot).Set(reflect.Zero(col.elemType))
 		col.strategy.ClearValue(slot)
 	}
+	if e.mapBacked {
+		e.leftover[slot] = nil
+	}
 	e.live[slot] = false
 	e.slotToID[slot] = ""
 	e.freeList = append(e.freeList, slot)
 	e.deadCount++
+}
+
+// prepareWrite decodes a record's data into per-column values and, on the
+// map-backed path, the leftover map of undeclared fields. On the struct path the
+// leftover return is nil. Decoding happens before any slot is reserved, so a
+// decode error (non-serializable value, unknown field on the struct path, or a
+// declared value that cannot be stored as its column type) leaves nothing stored
+// for the record.
+func (e *columnarEngine) prepareWrite(data any) ([]reflect.Value, map[string]any, error) {
+	if e.mapBacked {
+		return e.decodeMapFields(data)
+	}
+	values, err := e.decodeFields(data)
+	return values, nil, err
+}
+
+// decodeMapFields decodes a map-backed record: each declared column's value is
+// decoded into its typed cell (a clearly-incompatible value is a descriptive
+// error) and removed from the leftover, while every undeclared field is
+// deep-copied (JSON round-trip, faithful default) into the leftover map at the
+// row's slot. A record with only declared fields yields a nil leftover.
+func (e *columnarEngine) decodeMapFields(data any) ([]reflect.Value, map[string]any, error) {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return nil, nil, err
+	}
+	var asMap map[string]any
+	if err := json.Unmarshal(b, &asMap); err != nil {
+		return nil, nil, err
+	}
+	values := make([]reflect.Value, len(e.columns))
+	for i, col := range e.columns {
+		dst := reflect.New(col.elemType)
+		if raw, present := asMap[col.name]; present {
+			if err := assignInto(dst, raw, col); err != nil {
+				return nil, nil, fmt.Errorf("declared column %q of collection %q: %w", col.name, e.collection, err)
+			}
+		}
+		values[i] = dst.Elem()
+	}
+	var leftover map[string]any
+	for key, raw := range asMap {
+		if _, declared := e.byName[key]; declared {
+			continue // declared keys live in typed columns, not in leftover
+		}
+		if leftover == nil {
+			leftover = make(map[string]any)
+		}
+		leftover[key] = raw // raw is the JSON-decoded value: already ref-isolated
+	}
+	return values, leftover, nil
 }
 
 // decodeFields converts a record's data (a struct, pointer, or map[string]any)
@@ -491,7 +653,10 @@ func assignInto(dst reflect.Value, raw any, col *column) error {
 // (numbers as float64, nested as map[string]any), so the shared query pipeline
 // produces identical results.
 func (e *columnarEngine) rowData(slot int) (map[string]any, error) {
-	cells := make(map[string]any, len(e.columns))
+	cells := make(map[string]any, len(e.columns)+len(e.leftoverAt(slot)))
+	for key, value := range e.leftoverAt(slot) {
+		cells[key] = value
+	}
 	for _, col := range e.columns {
 		cells[col.name] = col.values.Index(slot).Interface()
 	}
@@ -510,7 +675,10 @@ func (e *columnarEngine) rowData(slot int) (map[string]any, error) {
 // per-column cells into a JSON object and unmarshaling it into target, so the
 // result shares no references with stored data or other reads.
 func (e *columnarEngine) materializeSlot(slot int, target any) error {
-	obj := make(map[string]any, len(e.columns))
+	obj := make(map[string]any, len(e.columns)+len(e.leftoverAt(slot)))
+	for key, value := range e.leftoverAt(slot) {
+		obj[key] = value
+	}
 	for _, col := range e.columns {
 		obj[col.name] = col.values.Index(slot).Interface()
 	}
@@ -519,6 +687,16 @@ func (e *columnarEngine) materializeSlot(slot int, target any) error {
 		return err
 	}
 	return json.Unmarshal(b, target)
+}
+
+// leftoverAt returns the slot's leftover map of undeclared fields on the
+// map-backed path, or nil on the struct path (and for an empty leftover). Ranging
+// over a nil map is a no-op, so callers merge it unconditionally.
+func (e *columnarEngine) leftoverAt(slot int) map[string]any {
+	if !e.mapBacked {
+		return nil
+	}
+	return e.leftover[slot]
 }
 
 // maybeCompact compacts when the dead-slot fraction crosses the threshold,
@@ -554,6 +732,13 @@ func (e *columnarEngine) compact() {
 		}
 		col.values = next
 	}
+	var newLeftover []map[string]any
+	if e.mapBacked {
+		newLeftover = make([]map[string]any, newLen)
+		for newSlot, oldSlot := range liveSlots {
+			newLeftover[newSlot] = e.leftover[oldSlot]
+		}
+	}
 	newSlotToID := make([]string, newLen)
 	newLive := make([]bool, newLen)
 	for newSlot, oldSlot := range liveSlots {
@@ -562,6 +747,7 @@ func (e *columnarEngine) compact() {
 		newLive[newSlot] = true
 		e.idToSlot[id] = newSlot
 	}
+	e.leftover = newLeftover
 	e.slotToID = newSlotToID
 	e.live = newLive
 	e.freeList = e.freeList[:0]

--- a/dalgo2memory/columnar_coverage_test.go
+++ b/dalgo2memory/columnar_coverage_test.go
@@ -1,0 +1,337 @@
+package dalgo2memory
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/update"
+	"github.com/stretchr/testify/require"
+)
+
+// tagged exercises jsonFieldName's tag handling: a renamed field, an
+// option-only tag (",omitempty" -> field name), and a skipped field
+// (json:"-"). It also carries reference-bearing types for isRefBearing.
+type tagged struct {
+	Renamed    string         `json:"renamed"`
+	OnlyOpts   int            `json:",omitempty"`
+	Skipped    string         `json:"-"`
+	unexported int            //nolint:unused // proves unexported fields get no column
+	Mapping    map[string]int `json:"mapping"`
+}
+
+// TestColumnar_BuildColumnsTagsAndRefTypes covers jsonFieldName (tag variants,
+// unexported skip) and the reference-bearing detection over a map field.
+func TestColumnar_BuildColumnsTagsAndRefTypes(t *testing.T) {
+	t.Parallel()
+	db := NewDB(WithSchema(false, WithCollection[tagged]("t", nil, WithColumnarStorage()))).(*database)
+	eng := db.engine("t").(*columnarEngine)
+
+	require.Contains(t, eng.byName, "renamed")
+	require.Contains(t, eng.byName, "OnlyOpts")
+	require.Contains(t, eng.byName, "mapping")
+	require.NotContains(t, eng.byName, "Skipped")
+	require.NotContains(t, eng.byName, "unexported")
+	require.True(t, eng.byName["mapping"].refBearing)
+	require.False(t, eng.byName["renamed"].refBearing)
+}
+
+// refShapes exercises isRefBearing's array, channel, and nested-struct cases,
+// and the "struct with no ref-bearing field" false branch.
+type refShapes struct {
+	ArrayOfSlices [2][]int
+	Plain         scalarsOnly
+}
+
+type scalarsOnly struct {
+	A int
+	B string
+}
+
+func TestColumnar_IsRefBearingShapes(t *testing.T) {
+	t.Parallel()
+	require.True(t, isRefBearing(reflect.TypeOf([2][]int{})))     // array of slices
+	require.True(t, isRefBearing(reflect.TypeOf(make(chan int)))) // channel
+	require.False(t, isRefBearing(reflect.TypeOf(scalarsOnly{}))) // struct, no refs
+	require.True(t, isRefBearing(reflect.TypeOf(refShapes{})))    // struct containing a ref
+	require.False(t, isRefBearing(reflect.TypeOf([3]int{})))      // array of scalars
+}
+
+// TestColumnar_StructTypeOfErrors covers structTypeOf's nil-factory and
+// non-struct branches.
+func TestColumnar_StructTypeOfErrors(t *testing.T) {
+	t.Parallel()
+	_, err := structTypeOf(nil)
+	require.Error(t, err)
+
+	_, err = structTypeOf(func() any { return new(int) })
+	require.Error(t, err)
+
+	typ, err := structTypeOf(func() any { return &user{} })
+	require.NoError(t, err)
+	require.Equal(t, reflect.TypeOf(user{}), typ)
+}
+
+// TestColumnar_ExplicitStrategyOption covers the WithColumnStrategy path in
+// buildColumns (an explicit strategy is installed and the default is not).
+func TestColumnar_ExplicitStrategyOption(t *testing.T) {
+	t.Parallel()
+	stgy := newRecordingStrategy(true, func(int) bool { return true })
+	db := NewDB(WithSchema(false,
+		WithCollection[user]("users", nil, WithColumnarStorage(WithColumnStrategy("Role", stgy))),
+	)).(*database)
+	eng := db.engine("users").(*columnarEngine)
+	require.Same(t, stgy, eng.byName["Role"].strategy)
+	require.Nil(t, eng.byName["Role"].defaultStgy)
+	require.NotNil(t, eng.byName["Name"].defaultStgy)
+}
+
+// TestColumnar_CandidateSlotsNonMatchingShapes covers candidateSlots' early
+// returns for condition shapes the strategy path does not handle.
+func TestColumnar_CandidateSlotsNonMatchingShapes(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := columnarItemDB(t)
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", "i1"), &item{Name: "a"})))
+	eng := db.collections["items"].(*columnarEngine)
+
+	// nil condition -> not a Comparison.
+	_, ok := eng.candidateSlots(nil)
+	require.False(t, ok)
+
+	// Non-equal operator.
+	_, ok = eng.candidateSlots(dal.Comparison{Operator: dal.GreaterThen,
+		Left: dal.NewFieldRef("", "Count"), Right: dal.NewConstant(1)})
+	require.False(t, ok)
+
+	// Left is not a FieldRef.
+	_, ok = eng.candidateSlots(dal.Comparison{Operator: dal.Equal,
+		Left: dal.NewConstant(1), Right: dal.NewConstant(1)})
+	require.False(t, ok)
+
+	// Right is not a Constant.
+	_, ok = eng.candidateSlots(dal.Comparison{Operator: dal.Equal,
+		Left: dal.NewFieldRef("", "Count"), Right: dal.NewFieldRef("", "Count")})
+	require.False(t, ok)
+
+	// Field references an unknown column.
+	_, ok = eng.candidateSlots(dal.Comparison{Operator: dal.Equal,
+		Left: dal.NewFieldRef("", "Missing"), Right: dal.NewConstant(1)})
+	require.False(t, ok)
+}
+
+// TestColumnar_ValuesEqualNonComparableQueried covers
+// valuesEqualForStrategy's guard against a non-comparable queried value.
+func TestColumnar_ValuesEqualNonComparableQueried(t *testing.T) {
+	t.Parallel()
+	require.False(t, valuesEqualForStrategy("x", []int{1}))
+	require.True(t, valuesEqualForStrategy("x", "x"))
+	require.False(t, valuesEqualForStrategy("x", nil))
+}
+
+// TestColumnar_MaybeCompactNoTrigger covers maybeCompact's early returns: no
+// slots, no dead slots, and a dead fraction below the threshold.
+func TestColumnar_MaybeCompactNoTrigger(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := columnarItemDB(t)
+	eng := db.engine("items").(*columnarEngine)
+
+	// No slots at all.
+	eng.maybeCompact()
+	require.Empty(t, eng.live)
+
+	// Three live, delete one: dead fraction 1/3 < 0.5, so no compaction.
+	for _, id := range []string{"a", "b", "c"} {
+		require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", id), &item{Name: id})))
+	}
+	require.NoError(t, db.Delete(ctx, dal.NewKeyWithID("items", "a")))
+	require.Equal(t, 1, eng.deadCount)
+	require.Len(t, eng.live, 3, "no compaction below threshold")
+
+	// deadCount == 0 early return.
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", "d"), &item{Name: "d"})))
+	require.Equal(t, 0, eng.deadCount)
+	eng.maybeCompact()
+	require.Len(t, eng.live, 3)
+}
+
+// TestColumnar_CompactRebuildsExternalStrategy covers compact()/rebuildStrategies
+// for an explicit (non-default) strategy: after compaction the strategy is
+// re-synced from the compacted slices.
+func TestColumnar_CompactRebuildsExternalStrategy(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := NewDB(WithSchema(false, WithCollection[queryRow]("q", nil, WithColumnarStorage()))).(*database)
+	eng := db.engine("q").(*columnarEngine)
+	stgy := newRecordingStrategy(true, func(slot int) bool { return slot < len(eng.live) && eng.live[slot] })
+	eng.byName["Group"].strategy = stgy
+	eng.byName["Group"].defaultStgy = nil
+	seedQueryRows(t, db, "q")
+
+	// Delete two of four (>= threshold) to force compaction.
+	require.NoError(t, db.Delete(ctx, dal.NewKeyWithID("q", "r2")))
+	require.NoError(t, db.Delete(ctx, dal.NewKeyWithID("q", "r4")))
+	require.Equal(t, 0, eng.deadCount, "compaction reclaimed dead slots")
+
+	// The external strategy, rebuilt from compacted slices, still answers
+	// correctly for the surviving rows.
+	slots, ok := stgy.EqualSlots("a")
+	require.True(t, ok)
+	require.Len(t, slots, 2) // r1 and r3 survive, both Group "a"
+}
+
+// TestColumnar_UpdateOnDefaultStrategyColumn covers update()'s read-modify-write
+// over an existing record, and the non-error decode path.
+func TestColumnar_UpdateRoundTrips(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := columnarItemDB(t)
+	key := dal.NewKeyWithID("items", "i1")
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, &item{Name: "a", Count: 1, Active: true})))
+	require.NoError(t, db.Update(ctx, key, []update.Update{update.ByFieldName("Count", 9)}))
+	var got item
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(key, &got)))
+	require.Equal(t, item{Name: "a", Count: 9, Active: true}, got)
+}
+
+// TestColumnar_NonSerializableWriteErrors covers decodeFields' marshal-error
+// branch (parity with the Serialized engine): a channel value is rejected.
+func TestColumnar_NonSerializableWriteErrors(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := columnarItemDB(t)
+	err := db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", "i1"),
+		map[string]any{"Extra": make(chan int)}))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "json")
+}
+
+// TestColumnar_RowMarshalErrorPaths covers the marshal/unmarshal error branches
+// of rowData, materializeSlot, and buildRows by poking a non-serializable value
+// into an []any column cell at a live slot.
+func TestColumnar_RowMarshalErrorPaths(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := columnarItemDB(t)
+	key := dal.NewKeyWithID("items", "i1")
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, &item{Name: "a"})))
+	eng := db.collections["items"].(*columnarEngine)
+	slot := eng.idToSlot["i1"]
+
+	// Force a non-serializable value into the []any "Extra" column cell.
+	eng.byName["Extra"].values.Index(slot).Set(reflect.ValueOf(any(make(chan int))))
+
+	_, err := eng.rowData(slot)
+	require.Error(t, err)
+
+	require.Error(t, eng.materializeSlot(slot, &item{}))
+
+	_, err = eng.rows()
+	require.Error(t, err)
+
+	// candidateRows surfaces the same reassembly error when it has an opinion.
+	_, _, err = eng.candidateRows(dal.Comparison{Operator: dal.Equal,
+		Left: dal.NewFieldRef("", "Name"), Right: dal.NewConstant("a")})
+	require.Error(t, err)
+
+	// load surfaces the reassembly error too.
+	require.Error(t, db.Get(ctx, dal.NewRecordWithData(key, &item{})))
+}
+
+// TestColumnar_MaterializeUnmarshalError covers materializeSlot's final
+// json.Unmarshal error branch: a stored string cell cannot decode into an int
+// target field.
+func TestColumnar_MaterializeUnmarshalError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := columnarItemDB(t)
+	key := dal.NewKeyWithID("items", "i1")
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, &item{Name: "a", Count: 3})))
+	eng := db.collections["items"].(*columnarEngine)
+	slot := eng.idToSlot["i1"]
+
+	// Put a string into the []any Extra column, then materialize into a target
+	// whose Extra is typed int — the unmarshal fails.
+	eng.byName["Extra"].values.Index(slot).Set(reflect.ValueOf(any("not-an-int")))
+	type intExtra struct {
+		Name  string
+		Count int
+		Extra int
+	}
+	require.Error(t, eng.materializeSlot(slot, &intExtra{}))
+}
+
+// TestColumnar_DecodeFieldsAssignError covers assignInto's json.Unmarshal error
+// path via update: assigning a string into an int column is rejected.
+func TestColumnar_DecodeFieldsAssignError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := columnarItemDB(t)
+	key := dal.NewKeyWithID("items", "i1")
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, &item{Name: "a", Count: 1})))
+	err := db.Update(ctx, key, []update.Update{update.ByFieldName("Count", "not-an-int")})
+	require.Error(t, err)
+}
+
+// TestColumnar_UpdateOnBrokenEngine covers update()'s initErr branch.
+func TestColumnar_UpdateOnBrokenEngine(t *testing.T) {
+	t.Parallel()
+	db := NewDB(WithSchema(false,
+		WithCollection[map[string]any]("blobs", nil, WithColumnarStorage()),
+	)).(*database)
+	eng := db.engine("blobs").(*columnarEngine)
+	require.Error(t, eng.update("x", map[string]any{"a": 1}))
+}
+
+// TestColumnar_DecodeFieldsNonObjectErrors covers decodeFields' unmarshal-to-map
+// error branch: a record whose data marshals to a JSON array, not an object.
+func TestColumnar_DecodeFieldsNonObjectErrors(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := columnarItemDB(t)
+	err := db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", "i1"), []int{1, 2, 3}))
+	require.Error(t, err)
+}
+
+// TestColumnar_UpdateRowDataError covers update()'s rowData error branch: a
+// non-serializable existing cell makes the read-modify-write read fail.
+func TestColumnar_UpdateRowDataError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := columnarItemDB(t)
+	key := dal.NewKeyWithID("items", "i1")
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, &item{Name: "a"})))
+	eng := db.collections["items"].(*columnarEngine)
+	slot := eng.idToSlot["i1"]
+	eng.byName["Extra"].values.Index(slot).Set(reflect.ValueOf(any(make(chan int))))
+
+	err := db.Update(ctx, key, []update.Update{update.ByFieldName("Name", "b")})
+	require.Error(t, err)
+}
+
+// TestColumnar_QueryReassemblyErrorPropagates covers loadCandidateRows' error
+// return: a non-serializable cell makes candidateRows fail during a query.
+func TestColumnar_QueryReassemblyErrorPropagates(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := columnarItemDB(t)
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", "i1"), &item{Name: "a"})))
+	eng := db.collections["items"].(*columnarEngine)
+	slot := eng.idToSlot["i1"]
+	eng.byName["Extra"].values.Index(slot).Set(reflect.ValueOf(any(make(chan int))))
+
+	q := dal.From(dal.NewRootCollectionRef("items", "")).NewQuery().
+		WhereField("Name", dal.Equal, "a").
+		SelectKeysOnly(reflect.String)
+	_, err := db.ExecuteQueryToRecordsReader(ctx, q)
+	require.Error(t, err)
+}
+
+// TestColumnar_InterfaceGuards documents the compile-time interface guards.
+func TestColumnar_InterfaceGuards(t *testing.T) {
+	t.Parallel()
+	var _ storageEngine = (*columnarEngine)(nil)
+	var _ ColumnStrategy = (*typedSliceStrategy)(nil)
+}

--- a/dalgo2memory/columnar_external_test.go
+++ b/dalgo2memory/columnar_external_test.go
@@ -1,0 +1,113 @@
+package dalgo2memory_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/dalgo2memory"
+	"github.com/stretchr/testify/require"
+)
+
+// externalUser is a typed record defined in the EXTERNAL test package, so this
+// test exercises only dalgo2memory's exported surface.
+type externalUser struct {
+	Name string
+	Role string
+}
+
+// externalStrategy is a ColumnStrategy implemented entirely outside the
+// dalgo2memory package, using only its exported ColumnStrategy interface and
+// SlotSet type. It models what an out-of-core package (e.g. a bitmap index)
+// would provide: an index kept in sync via the write side that answers equality
+// by returning matching slots. This proves dalgo2memory does not need to import
+// the strategy's package (REQ:external-strategy-pluggable).
+type externalStrategy struct {
+	bySlot map[int]any
+	calls  int
+}
+
+func newExternalStrategy() *externalStrategy {
+	return &externalStrategy{bySlot: map[int]any{}}
+}
+
+func (s *externalStrategy) SetValue(slot int, value any) { s.bySlot[slot] = value }
+
+func (s *externalStrategy) ClearValue(slot int) { delete(s.bySlot, slot) }
+
+func (s *externalStrategy) EqualSlots(value any) (dalgo2memory.SlotSet, bool) {
+	s.calls++
+	slots := make(dalgo2memory.SlotSet)
+	for slot, v := range s.bySlot {
+		if v == value {
+			slots[slot] = struct{}{}
+		}
+	}
+	return slots, true
+}
+
+// WithExternalRoleIndex mirrors a hypothetical bitmap4dalgo2memory.WithBitmapColumn:
+// an exported constructor returning a ColumnOption that plugs an external
+// strategy into WithColumnarStorage.
+func WithExternalRoleIndex(s *externalStrategy) dalgo2memory.ColumnOption {
+	return dalgo2memory.WithColumnStrategy("Role", s)
+}
+
+// TestExternalStrategyPluggable verifies
+// columnar-storage#ac:strategy-interface-exported: an external strategy supplied
+// via WithColumnarStorage is consulted by the query engine, with results
+// identical to a Serialized collection — and dalgo2memory never imports it.
+func TestExternalStrategyPluggable(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	stgy := newExternalStrategy()
+	colDB := dalgo2memory.NewDB(dalgo2memory.WithSchema(false,
+		dalgo2memory.WithCollection[externalUser]("users", nil,
+			dalgo2memory.WithColumnarStorage(WithExternalRoleIndex(stgy))),
+	))
+	serDB := dalgo2memory.NewDB(dalgo2memory.WithSchema(false,
+		dalgo2memory.WithCollection[externalUser]("users", nil),
+	))
+
+	seed := func(db dal.DB) {
+		err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+			records := []dal.Record{
+				dal.NewRecordWithData(dal.NewKeyWithID("users", "u1"), &externalUser{Name: "Alice", Role: "admin"}),
+				dal.NewRecordWithData(dal.NewKeyWithID("users", "u2"), &externalUser{Name: "Bob", Role: "member"}),
+				dal.NewRecordWithData(dal.NewKeyWithID("users", "u3"), &externalUser{Name: "Carol", Role: "admin"}),
+			}
+			return tx.SetMulti(ctx, records)
+		})
+		require.NoError(t, err)
+	}
+	seed(colDB)
+	seed(serDB)
+
+	build := func() dal.Query {
+		return dal.From(dal.NewRootCollectionRef("users", "")).NewQuery().
+			WhereField("Role", dal.Equal, "admin").
+			SelectKeysOnly(reflect.String)
+	}
+	colReader, err := colDB.ExecuteQueryToRecordsReader(ctx, build())
+	require.NoError(t, err)
+	serReader, err := serDB.ExecuteQueryToRecordsReader(ctx, build())
+	require.NoError(t, err)
+
+	require.Positive(t, stgy.calls, "the external strategy's read side was consulted")
+	require.Equal(t, idsOf(t, serReader), idsOf(t, colReader))
+}
+
+func idsOf(t *testing.T, reader dal.RecordsReader) []string {
+	t.Helper()
+	var ids []string
+	for {
+		record, err := reader.Next()
+		if err != nil {
+			require.ErrorIs(t, err, dal.ErrNoMoreRecords)
+			return ids
+		}
+		ids = append(ids, record.Key().ID.(string))
+	}
+}

--- a/dalgo2memory/columnar_mixed_test.go
+++ b/dalgo2memory/columnar_mixed_test.go
@@ -1,0 +1,495 @@
+package dalgo2memory
+
+import (
+	"context"
+	"reflect"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/update"
+	"github.com/stretchr/testify/require"
+)
+
+// mixedDB builds a map[string]any-backed columnar collection "m" with the given
+// column options (typically one or more WithDeclaredColumn plus an optional
+// strategy/ref-breaking override).
+func mixedDB(t *testing.T, opts ...ColumnOption) *database {
+	t.Helper()
+	db := NewDB(WithSchema(false,
+		WithCollection[map[string]any]("m", nil, WithColumnarStorage(opts...)),
+	)).(*database)
+	return db
+}
+
+// serMapDB builds a Serialized map[string]any-backed collection "m" for parity
+// comparisons.
+func serMapDB(t *testing.T) *database {
+	t.Helper()
+	db := NewDB(WithSchema(false,
+		WithCollection[map[string]any]("m", nil, WithSerializedStorage()),
+	)).(*database)
+	return db
+}
+
+func setMap(t *testing.T, db *database, id string, data map[string]any) {
+	t.Helper()
+	require.NoError(t, db.Set(context.Background(),
+		dal.NewRecordWithData(dal.NewKeyWithID("m", id), data)))
+}
+
+func getMap(t *testing.T, db *database, id string) map[string]any {
+	t.Helper()
+	got := map[string]any{}
+	require.NoError(t, db.Get(context.Background(),
+		dal.NewRecordWithData(dal.NewKeyWithID("m", id), &got)))
+	return got
+}
+
+// AC: mixed-mode-requires-declared-column.
+func TestMixed_RequiresDeclaredColumn(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// With a declared column the mixed-mode engine builds and works.
+	okDB := mixedDB(t, WithDeclaredColumn[int]("age"))
+	eng := okDB.engine("m").(*columnarEngine)
+	require.Nil(t, eng.initErr)
+	require.True(t, eng.mapBacked)
+	require.Contains(t, eng.byName, "age")
+	setMap(t, okDB, "u1", map[string]any{"age": 30, "name": "Alice"})
+	require.Equal(t, map[string]any{"age": float64(30), "name": "Alice"}, getMap(t, okDB, "u1"))
+
+	// With no declared column the selection fails with a descriptive error.
+	noColDB := mixedDB(t)
+	err := noColDB.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("m", "x"), map[string]any{"a": 1}))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "m")
+	require.ErrorContains(t, err, "declared column")
+
+	badEng := noColDB.engine("m").(*columnarEngine)
+	require.False(t, badEng.mapBacked)
+	require.NotNil(t, badEng.initErr)
+}
+
+// AC: declared-value-wrong-type-errors.
+func TestMixed_DeclaredValueWrongTypeErrors(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := mixedDB(t, WithDeclaredColumn[int]("age"))
+
+	err := db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("m", "u1"),
+		map[string]any{"age": "old", "name": "Alice"}))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "age")
+
+	// Nothing was stored for that id: neither dropped nor coerced.
+	eng := db.engine("m").(*columnarEngine)
+	require.NotContains(t, eng.idToSlot, "u1")
+	exists, existsErr := db.Exists(ctx, dal.NewKeyWithID("m", "u1"))
+	require.NoError(t, existsErr)
+	require.False(t, exists)
+}
+
+// AC: declared-field-removed-from-leftover.
+func TestMixed_DeclaredFieldRemovedFromLeftover(t *testing.T) {
+	t.Parallel()
+	db := mixedDB(t, WithDeclaredColumn[int]("age"))
+	setMap(t, db, "u1", map[string]any{"age": 30, "name": "Alice", "email": "a@x.io"})
+
+	eng := db.engine("m").(*columnarEngine)
+	slot := eng.idToSlot["u1"]
+
+	// age lives in a typed []int column at the slot.
+	require.Equal(t, reflect.TypeOf([]int{}), eng.byName["age"].values.Type())
+	require.Equal(t, 30, eng.byName["age"].values.Index(slot).Interface())
+
+	// age is absent from leftover; name and email remain.
+	leftover := eng.leftover[slot]
+	require.NotContains(t, leftover, "age")
+	require.Equal(t, "Alice", leftover["name"])
+	require.Equal(t, "a@x.io", leftover["email"])
+}
+
+// AC: leftover-holds-undeclared-fields.
+func TestMixed_LeftoverHoldsUndeclaredFields(t *testing.T) {
+	t.Parallel()
+	db := mixedDB(t, WithDeclaredColumn[int]("age"))
+	setMap(t, db, "withName", map[string]any{"age": 1, "name": "Alice"})
+	setMap(t, db, "ageOnly", map[string]any{"age": 2})
+	setMap(t, db, "twoExtra", map[string]any{"age": 3, "city": "Paris", "note": "vip"})
+
+	eng := db.engine("m").(*columnarEngine)
+
+	require.Equal(t, map[string]any{"name": "Alice"}, eng.leftover[eng.idToSlot["withName"]])
+	require.Nil(t, eng.leftover[eng.idToSlot["ageOnly"]])
+	require.Equal(t, map[string]any{"city": "Paris", "note": "vip"}, eng.leftover[eng.idToSlot["twoExtra"]])
+}
+
+// AC: slot-stays-synced-through-delete-and-compaction.
+func TestMixed_SlotSyncedThroughDeleteAndCompaction(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := mixedDB(t, WithDeclaredColumn[int]("age"))
+	records := map[string]map[string]any{
+		"a": {"age": 10, "name": "Anna"},
+		"b": {"age": 20, "city": "Berlin"},
+		"c": {"age": 30, "name": "Carol", "role": "admin"},
+		"d": {"age": 40},
+	}
+	for id, rec := range records {
+		setMap(t, db, id, rec)
+	}
+	eng := db.engine("m").(*columnarEngine)
+
+	// Delete b: its slot is freed for reuse.
+	freed := eng.idToSlot["b"]
+	require.NoError(t, db.Delete(ctx, dal.NewKeyWithID("m", "b")))
+	require.NotContains(t, eng.idToSlot, "b")
+
+	// Reuse the freed slot with a new record; its declared value and leftover
+	// land at the same slot.
+	setMap(t, db, "e", map[string]any{"age": 50, "name": "Eve"})
+	require.Equal(t, freed, eng.idToSlot["e"])
+	require.Equal(t, 50, eng.byName["age"].values.Index(freed).Interface())
+	require.Equal(t, map[string]any{"name": "Eve"}, eng.leftover[freed])
+
+	// Delete two more to cross the compaction threshold (2 dead of 4 live+dead).
+	require.NoError(t, db.Delete(ctx, dal.NewKeyWithID("m", "c")))
+	require.NoError(t, db.Delete(ctx, dal.NewKeyWithID("m", "d")))
+	require.Equal(t, 0, eng.deadCount, "compaction reclaimed dead slots")
+	require.Len(t, eng.leftover, len(eng.live), "leftover stays the same length as the slot vector")
+
+	// Surviving records read back with declared + undeclared fields intact, and
+	// at each surviving slot the declared value and leftover stay paired.
+	require.Equal(t, map[string]any{"age": float64(10), "name": "Anna"}, getMap(t, db, "a"))
+	require.Equal(t, map[string]any{"age": float64(50), "name": "Eve"}, getMap(t, db, "e"))
+	slotA := eng.idToSlot["a"]
+	require.True(t, eng.live[slotA])
+	require.Equal(t, 10, eng.byName["age"].values.Index(slotA).Interface())
+	require.Equal(t, map[string]any{"name": "Anna"}, eng.leftover[slotA])
+}
+
+// AC: read-reconstructs-full-record.
+func TestMixed_ReadReconstructsFullRecord(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := mixedDB(t, WithDeclaredColumn[int]("age"))
+	written := map[string]any{"age": 42, "name": "Alice", "email": "a@x.io"}
+	setMap(t, db, "u1", written)
+
+	want := map[string]any{"age": float64(42), "name": "Alice", "email": "a@x.io"}
+
+	// Get reassembles the full record.
+	require.Equal(t, want, getMap(t, db, "u1"))
+
+	// A query reassembles the same full record (materialized into a map target).
+	q := dal.From(dal.NewRootCollectionRef("m", "")).NewQuery().
+		WhereField("name", dal.Equal, "Alice").
+		SelectIntoRecord(func() dal.Record {
+			return dal.NewRecordWithIncompleteKey("m", reflect.String, &map[string]any{})
+		})
+	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+	require.NoError(t, err)
+	records := readAll(t, reader)
+	require.Len(t, records, 1)
+	got := records[0].Data().(*map[string]any)
+	require.Equal(t, want, *got)
+
+	// Each key appears exactly once (merge never duplicates a key).
+	require.Len(t, *got, 3)
+}
+
+// recordingDeclaredStrategy records EqualSlots invocations on a declared column
+// while delegating matching to the engine's live column slice via a back
+// reference resolved at SetValue time.
+type recordingDeclaredStrategy struct {
+	values  map[int]any
+	queried []any
+	live    func(int) bool
+}
+
+func newRecordingDeclaredStrategy(live func(int) bool) *recordingDeclaredStrategy {
+	return &recordingDeclaredStrategy{values: map[int]any{}, live: live}
+}
+
+func (s *recordingDeclaredStrategy) SetValue(slot int, value any) { s.values[slot] = value }
+
+func (s *recordingDeclaredStrategy) ClearValue(slot int) { delete(s.values, slot) }
+
+func (s *recordingDeclaredStrategy) EqualSlots(value any) (SlotSet, bool) {
+	s.queried = append(s.queried, value)
+	slots := make(SlotSet)
+	for slot, v := range s.values {
+		if s.live(slot) && v == value {
+			slots[slot] = struct{}{}
+		}
+	}
+	return slots, true
+}
+
+// seedMixedQueryData seeds identical map data into both engines for parity. The
+// declared columns are age (int) and tier (string); city/name are undeclared
+// leftover fields.
+func seedMixedQueryData(t *testing.T, db *database) {
+	t.Helper()
+	setMap(t, db, "r1", map[string]any{"age": 30, "tier": "gold", "city": "Paris", "name": "alice"})
+	setMap(t, db, "r2", map[string]any{"age": 25, "tier": "silver", "city": "Lyon", "name": "bob"})
+	setMap(t, db, "r3", map[string]any{"age": 30, "tier": "gold", "city": "Paris", "name": "carol"})
+	setMap(t, db, "r4", map[string]any{"age": 40, "tier": "bronze", "city": "Nice", "name": "dave"})
+}
+
+// AC: where-on-declared-column-accelerated. A custom strategy on the declared
+// string column "tier" records its invocation, and the accelerated result equals
+// the Serialized engine's.
+func TestMixed_WhereOnDeclaredColumnAccelerated(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	colDB := mixedDB(t, WithDeclaredColumn[int]("age"), WithDeclaredColumn[string]("tier"))
+	eng := colDB.engine("m").(*columnarEngine)
+	stgy := newRecordingDeclaredStrategy(func(slot int) bool { return eng.live[slot] })
+	eng.byName["tier"].strategy = stgy
+	eng.byName["tier"].defaultStgy = nil
+
+	serDB := serMapDB(t)
+	seedMixedQueryData(t, colDB)
+	seedMixedQueryData(t, serDB)
+
+	build := func() dal.Query {
+		return dal.From(dal.NewRootCollectionRef("m", "")).NewQuery().
+			WhereField("tier", dal.Equal, "gold").
+			SelectKeysOnly(reflect.String)
+	}
+	colReader, err := colDB.ExecuteQueryToRecordsReader(ctx, build())
+	require.NoError(t, err)
+	serReader, err := serDB.ExecuteQueryToRecordsReader(ctx, build())
+	require.NoError(t, err)
+
+	require.Equal(t, []any{"gold"}, stgy.queried, "the declared column's strategy was consulted")
+	colIDs := recordIDs(readAll(t, colReader))
+	serIDs := recordIDs(readAll(t, serReader))
+	require.Equal(t, serIDs, colIDs)
+	require.Equal(t, []string{"r1", "r3"}, colIDs)
+}
+
+// AC: where-on-leftover-field-scans.
+func TestMixed_WhereOnLeftoverFieldScans(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	colDB := mixedDB(t, WithDeclaredColumn[int]("age"))
+	serDB := serMapDB(t)
+	seedMixedQueryData(t, colDB)
+	seedMixedQueryData(t, serDB)
+
+	// city is undeclared (a leftover field); candidateSlots has no opinion.
+	eng := colDB.engine("m").(*columnarEngine)
+	_, ok := eng.candidateSlots(dal.Comparison{Operator: dal.Equal,
+		Left: dal.NewFieldRef("", "city"), Right: dal.NewConstant("Paris")})
+	require.False(t, ok, "a leftover field is not a column, so no opinion")
+
+	build := func() dal.Query {
+		return dal.From(dal.NewRootCollectionRef("m", "")).NewQuery().
+			WhereField("city", dal.Equal, "Paris").
+			SelectKeysOnly(reflect.String)
+	}
+	colReader, err := colDB.ExecuteQueryToRecordsReader(ctx, build())
+	require.NoError(t, err)
+	serReader, err := serDB.ExecuteQueryToRecordsReader(ctx, build())
+	require.NoError(t, err)
+
+	colIDs := recordIDs(readAll(t, colReader))
+	serIDs := recordIDs(readAll(t, serReader))
+	require.Equal(t, serIDs, colIDs)
+	require.Equal(t, []string{"r1", "r3"}, colIDs)
+}
+
+// AC: mixed-mode-parity-and-fidelity.
+func TestMixed_ParityAndFidelity(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Faithful mixed-mode collection declaring a reference-bearing column
+	// (tags) alongside an undeclared reference-bearing field (meta).
+	db := mixedDB(t, WithDeclaredColumn[[]string]("tags"))
+	key := dal.NewKeyWithID("m", "u1")
+	tags := []string{"a", "b"}
+	meta := map[string]any{"city": "Paris"}
+	written := map[string]any{"tags": tags, "meta": meta}
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, written)))
+
+	// Mutate both the declared and the undeclared reference after the write.
+	tags[0] = "MUTATED"
+	meta["city"] = "MUTATED"
+
+	got := getMap(t, db, "u1")
+	require.Equal(t, []any{"a", "b"}, got["tags"], "declared ref-bearing column is isolated")
+	require.Equal(t, map[string]any{"city": "Paris"}, got["meta"], "leftover ref-bearing field is isolated")
+
+	// Behavioral parity with Serialized: Set overwrites, Insert-duplicate errors,
+	// Get-absent is not-found.
+	serDB := serMapDB(t)
+	for _, target := range []*database{db, serDB} {
+		k := dal.NewKeyWithID("m", "p1")
+		require.NoError(t, target.Set(ctx, dal.NewRecordWithData(k, map[string]any{"tags": []string{"x"}})))
+		require.NoError(t, target.Set(ctx, dal.NewRecordWithData(k, map[string]any{"tags": []string{"y"}})))
+		dup := target.Insert(ctx, dal.NewRecordWithData(k, map[string]any{"tags": []string{"z"}}))
+		require.Error(t, dup)
+		require.ErrorContains(t, dup, "already exists")
+		absent := target.Get(ctx, dal.NewRecordWithData(dal.NewKeyWithID("m", "absent"), &map[string]any{}))
+		require.True(t, dal.IsNotFound(absent))
+	}
+}
+
+// TestMixed_OptOutSharesLeftoverlessRefs covers the ref-breaking opt-out for a
+// map-backed collection: with WithColumnarRefBreaking(false) a mutation of the
+// undeclared field shows through (leftover values are not deep-copied).
+func TestMixed_UpdateAddsAndChangesFields(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := mixedDB(t, WithDeclaredColumn[int]("age"))
+	key := dal.NewKeyWithID("m", "u1")
+	setMap(t, db, "u1", map[string]any{"age": 1, "name": "Alice"})
+
+	// Update a declared column and add a new leftover field (map-backed accepts
+	// undeclared fields rather than rejecting them).
+	require.NoError(t, db.Update(ctx, key, []update.Update{
+		update.ByFieldName("age", 2),
+		update.ByFieldName("city", "Paris"),
+	}))
+	require.Equal(t, map[string]any{"age": float64(2), "name": "Alice", "city": "Paris"}, getMap(t, db, "u1"))
+}
+
+// TestMixed_LastDeclarationWins covers the duplicate-declaration policy: the last
+// WithDeclaredColumn for a name wins (its element type), and the column keeps its
+// position (no duplicate column).
+func TestMixed_LastDeclarationWins(t *testing.T) {
+	t.Parallel()
+	db := mixedDB(t, WithDeclaredColumn[string]("v"), WithDeclaredColumn[int]("v"))
+	eng := db.engine("m").(*columnarEngine)
+	require.Len(t, eng.columns, 1)
+	require.Equal(t, reflect.TypeOf([]int{}), eng.byName["v"].values.Type())
+	setMap(t, db, "u1", map[string]any{"v": 7, "x": "leftover"})
+	require.Equal(t, map[string]any{"v": float64(7), "x": "leftover"}, getMap(t, db, "u1"))
+}
+
+// TestMixed_DeclaredOnStructIsRedundant covers that declared options on a struct
+// collection are accepted but the struct path still reflects over T.
+func TestMixed_DeclaredOnStructIsRedundant(t *testing.T) {
+	t.Parallel()
+	db := NewDB(WithSchema(false,
+		WithCollection[item]("items", nil, WithColumnarStorage(WithDeclaredColumn[int]("Count"))),
+	)).(*database)
+	eng := db.engine("items").(*columnarEngine)
+	require.False(t, eng.mapBacked)
+	// Struct reflection still produced all columns (not just the declared one).
+	require.Contains(t, eng.byName, "Name")
+	require.Contains(t, eng.byName, "Count")
+	require.Contains(t, eng.byName, "Active")
+}
+
+// TestMixed_InterfaceDeclaredColumn covers a declared interface column becoming
+// an []any fallback slice.
+func TestMixed_InterfaceDeclaredColumn(t *testing.T) {
+	t.Parallel()
+	db := mixedDB(t, WithDeclaredColumn[any]("payload"))
+	eng := db.engine("m").(*columnarEngine)
+	require.Equal(t, reflect.TypeOf([]any{}), eng.byName["payload"].values.Type())
+	setMap(t, db, "u1", map[string]any{"payload": []any{1, 2}, "tag": "x"})
+	require.Equal(t, map[string]any{"payload": []any{float64(1), float64(2)}, "tag": "x"}, getMap(t, db, "u1"))
+}
+
+// TestMixed_IsMapBackedFactory covers isMapBackedFactory's nil-factory and
+// non-map branches directly.
+func TestMixed_IsMapBackedFactory(t *testing.T) {
+	t.Parallel()
+	require.False(t, isMapBackedFactory(nil))
+	require.False(t, isMapBackedFactory(func() any { return new(int) }))
+	require.False(t, isMapBackedFactory(func() any { return &item{} }))
+	require.True(t, isMapBackedFactory(func() any { m := map[string]any{}; return &m }))
+}
+
+// TestMixed_ExplicitStrategyOnDeclaredColumn covers the WithColumnStrategy path
+// in buildDeclaredColumns: an explicit strategy is installed for a declared
+// map-backed column (and the default is not).
+func TestMixed_ExplicitStrategyOnDeclaredColumn(t *testing.T) {
+	t.Parallel()
+	stgy := newRecordingDeclaredStrategy(func(int) bool { return true })
+	db := mixedDB(t, WithDeclaredColumn[string]("tier"), WithColumnStrategy("tier", stgy))
+	eng := db.engine("m").(*columnarEngine)
+	require.Same(t, stgy, eng.byName["tier"].strategy)
+	require.Nil(t, eng.byName["tier"].defaultStgy)
+}
+
+// TestMixed_DecodeMapFieldsErrors covers decodeMapFields' marshal-error branch (a
+// non-serializable value) and its unmarshal-to-map error branch (data that is a
+// JSON array, not an object).
+func TestMixed_DecodeMapFieldsErrors(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := mixedDB(t, WithDeclaredColumn[int]("age"))
+
+	// Non-serializable value -> json.Marshal error.
+	marshalErr := db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("m", "u1"),
+		map[string]any{"age": 1, "bad": make(chan int)}))
+	require.Error(t, marshalErr)
+
+	// Data that marshals to a JSON array, not an object -> unmarshal-to-map error.
+	eng := db.engine("m").(*columnarEngine)
+	_, _, arrErr := eng.decodeMapFields([]int{1, 2, 3})
+	require.Error(t, arrErr)
+}
+
+// TestMixed_RaceInterleavesOperations exercises the mixed-mode engine under the
+// global write lock with concurrent reads, writes, deletes (triggering
+// compaction), and queries. Run with -race.
+func TestMixed_RaceInterleavesOperations(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := mixedDB(t, WithDeclaredColumn[int]("age"))
+
+	const n = 40
+	ids := make([]string, n)
+	for i := range ids {
+		ids[i] = "k" + strconv.Itoa(i)
+		setMap(t, db, ids[i], map[string]any{"age": i, "name": ids[i], "even": i%2 == 0})
+	}
+
+	var wg sync.WaitGroup
+	const workers = 8
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			for round := 0; round < 50; round++ {
+				id := ids[(seed+round)%n]
+				switch round % 4 {
+				case 0:
+					_ = db.Get(ctx, dal.NewRecordWithData(dal.NewKeyWithID("m", id), &map[string]any{}))
+				case 1:
+					_ = db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("m", id),
+						map[string]any{"age": round, "name": id}))
+				case 2:
+					_ = db.Delete(ctx, dal.NewKeyWithID("m", id))
+				case 3:
+					q := dal.From(dal.NewRootCollectionRef("m", "")).NewQuery().
+						WhereField("age", dal.Equal, 0).
+						SelectKeysOnly(reflect.String)
+					reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+					if err == nil {
+						_ = readAll(t, reader)
+					}
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	eng := db.engine("m").(*columnarEngine)
+	for id, slot := range eng.idToSlot {
+		require.True(t, eng.live[slot], "id %s maps to a live slot", id)
+	}
+	require.Len(t, eng.leftover, len(eng.live))
+}

--- a/dalgo2memory/columnar_test.go
+++ b/dalgo2memory/columnar_test.go
@@ -52,15 +52,25 @@ func TestColumnar_RequiresTypedCollection(t *testing.T) {
 	require.True(t, ok)
 	require.Nil(t, eng.initErr)
 
+	// Selecting columnar storage for a non-struct, non-map collection (here a
+	// scalar element type) fails with the typed-collection error on use.
+	scalarDB := NewDB(WithSchema(false,
+		WithCollection[int]("nums", nil, WithColumnarStorage()),
+	)).(*database)
+	scalarErr := scalarDB.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("nums", "n1"), 1))
+	require.Error(t, scalarErr)
+	require.ErrorContains(t, scalarErr, "nums")
+	require.ErrorContains(t, scalarErr, "typed collection")
+
 	// Selecting columnar storage for a schemaless (map[string]any) collection
-	// fails with a descriptive error on use.
+	// with no declared column fails with a descriptive error on use.
 	schemalessDB := NewDB(WithSchema(false,
 		WithCollection[map[string]any]("blobs", nil, WithColumnarStorage()),
 	)).(*database)
 	err := schemalessDB.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("blobs", "b1"), map[string]any{"x": 1}))
 	require.Error(t, err)
 	require.ErrorContains(t, err, "blobs")
-	require.ErrorContains(t, err, "typed collection")
+	require.ErrorContains(t, err, "declared column")
 
 	// Every operation reports the init error.
 	badEng := schemalessDB.engine("blobs").(*columnarEngine)

--- a/dalgo2memory/columnar_test.go
+++ b/dalgo2memory/columnar_test.go
@@ -1,0 +1,611 @@
+package dalgo2memory
+
+import (
+	"context"
+	"reflect"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/update"
+	"github.com/stretchr/testify/require"
+)
+
+// typed record types used across the columnar tests.
+
+// item is a simple typed record with int/string/bool scalar columns and an
+// interface{} column (which must become an []any fallback column).
+type item struct {
+	Name   string
+	Count  int
+	Active bool
+	Extra  any
+}
+
+// doc is a record with a scalar column and reference-bearing columns (a slice
+// and a nested struct), used to prove ref-breaking and the fidelity opt-out.
+type doc struct {
+	Title string
+	Tags  []string
+	Meta  address
+}
+
+func columnarItemDB(t *testing.T, colOpts ...ColumnOption) *database {
+	t.Helper()
+	db := NewDB(WithSchema(false,
+		WithCollection[item]("items", nil, WithColumnarStorage(colOpts...)),
+	)).(*database)
+	return db
+}
+
+// TestColumnar_RequiresTypedCollection verifies
+// columnar-storage#ac:columnar-requires-typed-collection.
+func TestColumnar_RequiresTypedCollection(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Typed collection uses the columnar engine successfully.
+	typedDB := columnarItemDB(t)
+	require.NoError(t, typedDB.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", "i1"), &item{Name: "a"})))
+	eng, ok := typedDB.collections["items"].(*columnarEngine)
+	require.True(t, ok)
+	require.Nil(t, eng.initErr)
+
+	// Selecting columnar storage for a schemaless (map[string]any) collection
+	// fails with a descriptive error on use.
+	schemalessDB := NewDB(WithSchema(false,
+		WithCollection[map[string]any]("blobs", nil, WithColumnarStorage()),
+	)).(*database)
+	err := schemalessDB.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("blobs", "b1"), map[string]any{"x": 1}))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "blobs")
+	require.ErrorContains(t, err, "typed collection")
+
+	// Every operation reports the init error.
+	badEng := schemalessDB.engine("blobs").(*columnarEngine)
+	require.False(t, badEng.exists("b1"))
+	require.Error(t, badEng.load("b1", dal.NewRecordWithData(dal.NewKeyWithID("blobs", "b1"), &map[string]any{})))
+	require.Error(t, badEng.update("b1", map[string]any{"x": 1}))
+	_, rowsErr := badEng.rows()
+	require.Error(t, rowsErr)
+	_, _, candErr := badEng.candidateRows(nil)
+	require.Error(t, candErr)
+	badEng.delete("b1") // no-op, must not panic
+}
+
+// TestColumnar_TypedSlicesAndAnyFallback verifies
+// columnar-storage#ac:columns-are-typed-slices.
+func TestColumnar_TypedSlicesAndAnyFallback(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := columnarItemDB(t)
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", "i1"),
+		&item{Name: "a", Count: 7, Active: true, Extra: "x"})))
+
+	eng := db.collections["items"].(*columnarEngine)
+	require.Equal(t, reflect.TypeOf([]string{}), eng.byName["Name"].values.Type())
+	require.Equal(t, reflect.TypeOf([]int{}), eng.byName["Count"].values.Type())
+	require.Equal(t, reflect.TypeOf([]bool{}), eng.byName["Active"].values.Type())
+	require.Equal(t, reflect.TypeOf([]any{}), eng.byName["Extra"].values.Type())
+}
+
+// TestColumnar_SlotStableAcrossColumns verifies
+// columnar-storage#ac:slot-stable-across-columns.
+func TestColumnar_SlotStableAcrossColumns(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := columnarItemDB(t)
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", "a"), &item{Name: "a", Count: 1})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", "b"), &item{Name: "b", Count: 2})))
+
+	eng := db.collections["items"].(*columnarEngine)
+	slotA := eng.idToSlot["a"]
+	slotB := eng.idToSlot["b"]
+	require.NotEqual(t, slotA, slotB)
+
+	// a's values are all drawn from its slot.
+	require.Equal(t, "a", eng.byName["Name"].values.Index(slotA).Interface())
+	require.Equal(t, 1, eng.byName["Count"].values.Index(slotA).Interface())
+
+	// Writing more records does not move a's slot.
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", "c"), &item{Name: "c", Count: 3})))
+	require.Equal(t, slotA, eng.idToSlot["a"])
+}
+
+// TestColumnar_WriteBreaksRefsByDefault verifies
+// columnar-storage#ac:write-breaks-refs-by-default.
+func TestColumnar_WriteBreaksRefsByDefault(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := NewDB(WithSchema(false, WithCollection[doc]("docs", nil, WithColumnarStorage()))).(*database)
+	key := dal.NewKeyWithID("docs", "d1")
+	written := &doc{Title: "t", Tags: []string{"a", "b"}, Meta: address{City: "Paris"}}
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, written)))
+
+	written.Tags[0] = "MUTATED"
+	written.Meta.City = "MUTATED"
+
+	var got doc
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(key, &got)))
+	require.Equal(t, []string{"a", "b"}, got.Tags)
+	require.Equal(t, "Paris", got.Meta.City)
+}
+
+// TestColumnar_FidelityOptOutMatrix verifies
+// columnar-storage#ac:fidelity-opt-out-toggles-ref-breaking: a default
+// collection (a), a per-collection opt-out (b), and a schema-wide opt-out with
+// one collection re-enabling fidelity (c).
+func TestColumnar_FidelityOptOutMatrix(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	mutateThenRead := func(db *database, collection string) []string {
+		key := dal.NewKeyWithID(collection, "d1")
+		written := &doc{Title: "t", Tags: []string{"a", "b"}}
+		require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, written)))
+		written.Tags[0] = "MUTATED"
+		var got doc
+		require.NoError(t, db.Get(ctx, dal.NewRecordWithData(key, &got)))
+		return got.Tags
+	}
+
+	// (a) default faithful collection: mutation does not show through.
+	faithfulDB := NewDB(WithSchema(false,
+		WithCollection[doc]("a", nil, WithColumnarStorage()),
+	)).(*database)
+	require.Equal(t, []string{"a", "b"}, mutateThenRead(faithfulDB, "a"))
+
+	// (b) per-collection opt-out: mutation shows through.
+	optOutDB := NewDB(WithSchema(false,
+		WithCollection[doc]("b", nil, WithColumnarStorage(WithColumnarRefBreaking(false))),
+	)).(*database)
+	require.Equal(t, []string{"MUTATED", "b"}, mutateThenRead(optOutDB, "b"))
+
+	// (c) schema-wide opt-out, but one collection re-enables fidelity. The
+	// re-enabled collection is faithful; the inheriting collection reflects the
+	// mutation, proving per-collection overrides schema-wide.
+	schemaWideDB := NewDB(
+		WithoutSchemaRefBreaking(),
+		WithSchema(false,
+			WithCollection[doc]("reenabled", nil, WithColumnarStorage(WithColumnarRefBreaking(true))),
+			WithCollection[doc]("inherits", nil, WithColumnarStorage()),
+		),
+	).(*database)
+	require.Equal(t, []string{"a", "b"}, mutateThenRead(schemaWideDB, "reenabled"))
+	require.Equal(t, []string{"MUTATED", "b"}, mutateThenRead(schemaWideDB, "inherits"))
+}
+
+// TestColumnar_ParityWithSerializedOps verifies
+// columnar-storage#ac:parity-with-serialized-ops: Set overwrites,
+// Insert-duplicate errors, Get/Update-absent are not-found, Update of an
+// undefined field is rejected — identical outcomes to the Serialized engine.
+func TestColumnar_ParityWithSerializedOps(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	run := func(t *testing.T, opts ...CollectionOption) {
+		db := NewDB(WithSchema(false, WithCollection[user]("users", nil, opts...))).(*database)
+		key := dal.NewKeyWithID("users", "u1")
+
+		// Set overwrites.
+		require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, &user{Name: "Alice", Role: "admin"})))
+		require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, &user{Name: "Alice2", Role: "admin"})))
+		var got user
+		require.NoError(t, db.Get(ctx, dal.NewRecordWithData(key, &got)))
+		require.Equal(t, "Alice2", got.Name)
+
+		// Insert on existing id errors and does not overwrite.
+		err := db.Insert(ctx, dal.NewRecordWithData(key, &user{Name: "Bob"}))
+		require.Error(t, err)
+		require.ErrorContains(t, err, "already exists")
+		require.NoError(t, db.Get(ctx, dal.NewRecordWithData(key, &got)))
+		require.Equal(t, "Alice2", got.Name)
+
+		// Get/Update on an absent id are not-found.
+		absent := dal.NewKeyWithID("users", "absent")
+		getErr := db.Get(ctx, dal.NewRecordWithData(absent, &user{}))
+		require.True(t, dal.IsNotFound(getErr))
+		updErr := db.Update(ctx, absent, []update.Update{update.ByFieldName("Role", "x")})
+		require.True(t, dal.IsNotFound(updErr))
+
+		// Update of an undefined field is rejected.
+		badUpd := db.Update(ctx, key, []update.Update{update.ByFieldName("Undefined", 1)})
+		require.Error(t, badUpd)
+		require.ErrorContains(t, badUpd, "users")
+
+		// A defined-field update applies.
+		require.NoError(t, db.Update(ctx, key, []update.Update{update.ByFieldName("Role", "member")}))
+		require.NoError(t, db.Get(ctx, dal.NewRecordWithData(key, &got)))
+		require.Equal(t, "member", got.Role)
+	}
+
+	t.Run("columnar", func(t *testing.T) { t.Parallel(); run(t, WithColumnarStorage()) })
+	t.Run("serialized", func(t *testing.T) { t.Parallel(); run(t, WithSerializedStorage()) })
+}
+
+// TestColumnar_InsertRejectsUnknownField proves a store carrying an undefined
+// field is rejected (parity with the Serialized engine's DisallowUnknownFields).
+func TestColumnar_InsertRejectsUnknownField(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := columnarItemDB(t)
+	err := db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", "i1"),
+		map[string]any{"Name": "a", "Bogus": 1}))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "Bogus")
+}
+
+// TestColumnar_DeleteTombstonesAndReuses verifies
+// columnar-storage#ac:delete-tombstones-and-hides.
+func TestColumnar_DeleteTombstonesAndReuses(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := columnarItemDB(t)
+	for _, id := range []string{"a", "b", "c"} {
+		require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", id), &item{Name: id})))
+	}
+	eng := db.collections["items"].(*columnarEngine)
+	slotA, slotB, slotC := eng.idToSlot["a"], eng.idToSlot["b"], eng.idToSlot["c"]
+
+	require.NoError(t, db.Delete(ctx, dal.NewKeyWithID("items", "b")))
+
+	// b is hidden from Exists/Get/queries; a and c keep their slots.
+	existsB, err := db.Exists(ctx, dal.NewKeyWithID("items", "b"))
+	require.NoError(t, err)
+	require.False(t, existsB)
+	require.True(t, dal.IsNotFound(db.Get(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", "b"), &item{}))))
+	require.Equal(t, slotA, eng.idToSlot["a"])
+	require.Equal(t, slotC, eng.idToSlot["c"])
+
+	rows, err := eng.rows()
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+
+	// A later insert reuses b's freed slot.
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", "d"), &item{Name: "d"})))
+	require.Equal(t, slotB, eng.idToSlot["d"])
+}
+
+// TestColumnar_CompactionPreservesLiveRecords verifies
+// columnar-storage#ac:compaction-preserves-live-records.
+func TestColumnar_CompactionPreservesLiveRecords(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := columnarItemDB(t)
+	for i, id := range []string{"a", "b", "c", "d"} {
+		require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", id), &item{Name: id, Count: i})))
+	}
+	eng := db.collections["items"].(*columnarEngine)
+
+	// Delete b and c so the dead fraction (2/4 = 0.5) crosses the threshold and
+	// compaction runs on the second delete.
+	require.NoError(t, db.Delete(ctx, dal.NewKeyWithID("items", "b")))
+	require.NoError(t, db.Delete(ctx, dal.NewKeyWithID("items", "c")))
+
+	require.Equal(t, 0, eng.deadCount, "dead slots reclaimed")
+	require.Len(t, eng.live, 2)
+	require.Empty(t, eng.freeList)
+
+	// Every live record is still readable with correct values.
+	var a, d item
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", "a"), &a)))
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", "d"), &d)))
+	require.Equal(t, item{Name: "a", Count: 0}, a)
+	require.Equal(t, item{Name: "d", Count: 3}, d)
+
+	// Deleted records are gone.
+	require.True(t, dal.IsNotFound(db.Get(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", "b"), &item{}))))
+}
+
+// TestColumnar_GetAndQueryReassemble verifies
+// columnar-storage#ac:get-and-query-reassemble: reassembled rows equal stored
+// data and share no references.
+func TestColumnar_GetAndQueryReassemble(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := NewDB(WithSchema(false, WithCollection[doc]("docs", nil, WithColumnarStorage()))).(*database)
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("docs", "d1"),
+		&doc{Title: "shared", Tags: []string{"x"}, Meta: address{City: "Paris"}})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("docs", "d2"),
+		&doc{Title: "shared", Tags: []string{"y"}, Meta: address{City: "Lyon"}})))
+
+	// Get into a typed target equals stored data.
+	var got doc
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(dal.NewKeyWithID("docs", "d1"), &got)))
+	require.Equal(t, doc{Title: "shared", Tags: []string{"x"}, Meta: address{City: "Paris"}}, got)
+
+	// Query materializes typed rows that share no references.
+	q := dal.From(dal.NewRootCollectionRef("docs", "")).NewQuery().
+		WhereField("Title", dal.Equal, "shared").
+		SelectIntoRecord(func() dal.Record {
+			return dal.NewRecordWithIncompleteKey("docs", reflect.String, &doc{})
+		})
+	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+	require.NoError(t, err)
+	records := readAll(t, reader)
+	require.Len(t, records, 2)
+	first := records[0].Data().(*doc)
+	second := records[1].Data().(*doc)
+	require.NotSame(t, first, second)
+	first.Tags[0] = "MUTATED"
+	require.NotEqual(t, "MUTATED", second.Tags[0])
+}
+
+// queryRow is a small typed record for the columnar-vs-serialized query
+// equality test (comparable string column for the WHERE predicate).
+type queryRow struct {
+	Group string
+	Name  string
+	Rank  int
+}
+
+func seedQueryRows(t *testing.T, db *database, collection string) {
+	t.Helper()
+	ctx := context.Background()
+	rows := []struct {
+		id  string
+		rec queryRow
+	}{
+		{"r1", queryRow{Group: "a", Name: "alice", Rank: 3}},
+		{"r2", queryRow{Group: "b", Name: "bob", Rank: 1}},
+		{"r3", queryRow{Group: "a", Name: "carol", Rank: 2}},
+		{"r4", queryRow{Group: "a", Name: "dave", Rank: 5}},
+	}
+	for _, r := range rows {
+		require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID(collection, r.id), &r.rec)))
+	}
+}
+
+// TestColumnar_QueryMatchesSerialized verifies
+// columnar-storage#ac:columnar-query-matches-serialized: the supported single
+// equality WHERE plus projection and ORDER BY/LIMIT return identical content
+// and order through both engines.
+func TestColumnar_QueryMatchesSerialized(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	colDB := NewDB(WithSchema(false, WithCollection[queryRow]("q", nil, WithColumnarStorage()))).(*database)
+	serDB := NewDB(WithSchema(false, WithCollection[queryRow]("q", nil, WithSerializedStorage()))).(*database)
+	seedQueryRows(t, colDB, "q")
+	seedQueryRows(t, serDB, "q")
+
+	build := func() dal.Query {
+		return dal.From(dal.NewRootCollectionRef("q", "")).NewQuery().
+			WhereField("Group", dal.Equal, "a").
+			OrderBy(dal.DescendingField("Rank")).
+			Limit(2).
+			SelectColumns(
+				dal.Column{Expression: dal.NewFieldRef("", "Name")},
+				dal.Column{Expression: dal.NewFieldRef("", "Rank")},
+			)
+	}
+
+	colReader, err := colDB.ExecuteQueryToRecordsReader(ctx, build())
+	require.NoError(t, err)
+	serReader, err := serDB.ExecuteQueryToRecordsReader(ctx, build())
+	require.NoError(t, err)
+
+	colRecords := readAll(t, colReader)
+	serRecords := readAll(t, serReader)
+	require.Len(t, colRecords, 2)
+	require.Equal(t, len(serRecords), len(colRecords))
+	for i := range colRecords {
+		require.Equal(t, serRecords[i].Key().ID, colRecords[i].Key().ID)
+		require.Equal(t, serRecords[i].Data(), colRecords[i].Data())
+	}
+}
+
+// TestColumnar_DefaultStrategyScansColumn verifies
+// columnar-storage#ac:default-strategy-scans-column: the default strategy on a
+// comparable string column returns exactly the matching live slots and does not
+// return "no opinion".
+func TestColumnar_DefaultStrategyScansColumn(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := NewDB(WithSchema(false, WithCollection[queryRow]("q", nil, WithColumnarStorage()))).(*database)
+	seedQueryRows(t, db, "q")
+	eng := db.collections["q"].(*columnarEngine)
+
+	slots, ok := eng.byName["Group"].strategy.EqualSlots("a")
+	require.True(t, ok, "comparable column has an opinion")
+	require.Len(t, slots, 3)
+	want := map[string]struct{}{"r1": {}, "r3": {}, "r4": {}}
+	got := map[string]struct{}{}
+	for slot := range slots {
+		got[eng.slotToID[slot]] = struct{}{}
+	}
+	require.Equal(t, want, got)
+
+	// A deleted record's slot is excluded from the strategy's answer.
+	require.NoError(t, db.Delete(ctx, dal.NewKeyWithID("q", "r3")))
+	slots, ok = eng.byName["Group"].strategy.EqualSlots("a")
+	require.True(t, ok)
+	require.Len(t, slots, 2)
+}
+
+// TestColumnar_DefaultStrategyNoOpinionOnAny verifies the default strategy
+// returns "no opinion" for a non-comparable []any column.
+func TestColumnar_DefaultStrategyNoOpinionOnAny(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := columnarItemDB(t)
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", "i1"),
+		&item{Name: "a", Extra: []any{1, 2}})))
+	eng := db.collections["items"].(*columnarEngine)
+
+	_, ok := eng.byName["Extra"].strategy.EqualSlots([]any{1, 2})
+	require.False(t, ok, "non-comparable []any column returns no opinion")
+}
+
+// recordingStrategy wraps the live column slice (via a back-reference resolved
+// at SetValue time) and records the values written and the EqualSlots calls,
+// so a test can assert the engine consulted the strategy. When opinion is
+// false it always returns "no opinion" to exercise the scan fall-back.
+type recordingStrategy struct {
+	values  map[int]any
+	queried []any
+	opinion bool
+	live    func(int) bool
+}
+
+func newRecordingStrategy(opinion bool, live func(int) bool) *recordingStrategy {
+	return &recordingStrategy{values: map[int]any{}, opinion: opinion, live: live}
+}
+
+func (s *recordingStrategy) SetValue(slot int, value any) { s.values[slot] = value }
+
+func (s *recordingStrategy) ClearValue(slot int) { delete(s.values, slot) }
+
+func (s *recordingStrategy) EqualSlots(value any) (SlotSet, bool) {
+	s.queried = append(s.queried, value)
+	if !s.opinion {
+		return nil, false
+	}
+	slots := make(SlotSet)
+	for slot, v := range s.values {
+		if s.live(slot) && v == value {
+			slots[slot] = struct{}{}
+		}
+	}
+	return slots, true
+}
+
+// TestColumnar_WhereUsesStrategy verifies
+// columnar-storage#ac:where-uses-strategy: the query consults the column's
+// strategy and uses its slot set, and the result matches the Serialized engine.
+func TestColumnar_WhereUsesStrategy(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	colDB := NewDB(WithSchema(false,
+		WithCollection[queryRow]("q", nil, WithColumnarStorage()),
+	)).(*database)
+	// Install a recording strategy whose live-check is bound to the engine, so
+	// the engine's write side populates it as rows are seeded.
+	eng := colDB.engine("q").(*columnarEngine)
+	stgy := newRecordingStrategy(true, func(slot int) bool { return eng.live[slot] })
+	eng.byName["Group"].strategy = stgy
+	eng.byName["Group"].defaultStgy = nil
+
+	serDB := NewDB(WithSchema(false, WithCollection[queryRow]("q", nil, WithSerializedStorage()))).(*database)
+	seedQueryRows(t, colDB, "q")
+	seedQueryRows(t, serDB, "q")
+
+	build := func() dal.Query {
+		return dal.From(dal.NewRootCollectionRef("q", "")).NewQuery().
+			WhereField("Group", dal.Equal, "a").
+			SelectKeysOnly(reflect.String)
+	}
+	colReader, err := colDB.ExecuteQueryToRecordsReader(ctx, build())
+	require.NoError(t, err)
+	serReader, err := serDB.ExecuteQueryToRecordsReader(ctx, build())
+	require.NoError(t, err)
+
+	require.NotEmpty(t, stgy.queried, "the engine consulted the strategy's read side")
+	require.Equal(t, []any{"a"}, stgy.queried)
+
+	colIDs := recordIDs(readAll(t, colReader))
+	serIDs := recordIDs(readAll(t, serReader))
+	require.Equal(t, serIDs, colIDs)
+	require.Equal(t, []string{"r1", "r3", "r4"}, colIDs)
+}
+
+// TestColumnar_WhereFallsBackOnNoOpinion verifies
+// columnar-storage#ac:where-falls-back-on-no-opinion: when the strategy returns
+// "no opinion", the engine scans and still returns the correct result.
+func TestColumnar_WhereFallsBackOnNoOpinion(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	colDB := NewDB(WithSchema(false, WithCollection[queryRow]("q", nil, WithColumnarStorage()))).(*database)
+	eng := colDB.engine("q").(*columnarEngine)
+	stgy := newRecordingStrategy(false, func(slot int) bool { return eng.live[slot] })
+	eng.byName["Group"].strategy = stgy
+
+	serDB := NewDB(WithSchema(false, WithCollection[queryRow]("q", nil, WithSerializedStorage()))).(*database)
+	seedQueryRows(t, colDB, "q")
+	seedQueryRows(t, serDB, "q")
+
+	build := func() dal.Query {
+		return dal.From(dal.NewRootCollectionRef("q", "")).NewQuery().
+			WhereField("Group", dal.Equal, "a").
+			SelectKeysOnly(reflect.String)
+	}
+	colReader, err := colDB.ExecuteQueryToRecordsReader(ctx, build())
+	require.NoError(t, err)
+	serReader, err := serDB.ExecuteQueryToRecordsReader(ctx, build())
+	require.NoError(t, err)
+
+	require.NotEmpty(t, stgy.queried, "the strategy was consulted before falling back")
+	colIDs := recordIDs(readAll(t, colReader))
+	serIDs := recordIDs(readAll(t, serReader))
+	require.Equal(t, serIDs, colIDs)
+	require.Equal(t, []string{"r1", "r3", "r4"}, colIDs)
+}
+
+func recordIDs(records []dal.Record) []string {
+	ids := make([]string, len(records))
+	for i, r := range records {
+		ids[i] = r.Key().ID.(string)
+	}
+	return ids
+}
+
+// TestColumnar_RaceInterleavesOperations verifies
+// columnar-storage#ac:columnar-passes-race: under the single global write lock,
+// concurrent reads interleaved with writes, deletes (which trigger compaction),
+// and queries report no data race and stay correct. Run with -race.
+func TestColumnar_RaceInterleavesOperations(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := columnarItemDB(t)
+
+	const n = 40
+	ids := make([]string, n)
+	for i := range ids {
+		ids[i] = "k" + strconv.Itoa(i)
+		require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", ids[i]), &item{Name: ids[i], Count: i, Active: i%2 == 0})))
+	}
+
+	var wg sync.WaitGroup
+	const workers = 8
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			for round := 0; round < 50; round++ {
+				id := ids[(seed+round)%n]
+				switch round % 4 {
+				case 0:
+					var got item
+					_ = db.Get(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", id), &got))
+				case 1:
+					_ = db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("items", id), &item{Name: id, Count: round}))
+				case 2:
+					_ = db.Delete(ctx, dal.NewKeyWithID("items", id))
+				case 3:
+					q := dal.From(dal.NewRootCollectionRef("items", "")).NewQuery().
+						WhereField("Active", dal.Equal, true).
+						SelectKeysOnly(reflect.String)
+					reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+					if err == nil {
+						_ = readAll(t, reader)
+					}
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	// The engine remains internally consistent: every id->slot maps to a live
+	// slot, and a query still returns correct results.
+	eng := db.collections["items"].(*columnarEngine)
+	for id, slot := range eng.idToSlot {
+		require.True(t, eng.live[slot], "id %s maps to a live slot", id)
+	}
+	q := dal.From(dal.NewRootCollectionRef("items", "")).NewQuery().SelectKeysOnly(reflect.String)
+	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+	require.NoError(t, err)
+	require.Len(t, readAll(t, reader), len(eng.idToSlot))
+}

--- a/dalgo2memory/database.go
+++ b/dalgo2memory/database.go
@@ -15,7 +15,8 @@ import (
 // NewDB creates an in-memory DALgo database.
 func NewDB(options ...Option) dal.DB {
 	db := &database{
-		collections: make(map[string]storageEngine),
+		collections:       make(map[string]storageEngine),
+		schemaRefBreaking: true,
 	}
 	for _, option := range options {
 		if option != nil {
@@ -34,6 +35,9 @@ type database struct {
 	// on first access (see database.engine).
 	collections map[string]storageEngine
 	schema      *memorySchema
+	// schemaRefBreaking is the schema-wide columnar fidelity default (faithful
+	// unless WithoutSchemaRefBreaking was used). NewDB initializes it to true.
+	schemaRefBreaking bool
 }
 
 func (db *database) ID() string {
@@ -264,7 +268,7 @@ func (s session) ExecuteQueryToRecordsReader(_ context.Context, query dal.Query)
 	if err != nil {
 		return nil, err
 	}
-	allRows, err := s.loadRows(collectionName)
+	allRows, err := s.loadCandidateRows(collectionName, q.Where())
 	if err != nil {
 		return nil, err
 	}

--- a/dalgo2memory/database.go
+++ b/dalgo2memory/database.go
@@ -2,7 +2,6 @@ package dalgo2memory
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -16,7 +15,7 @@ import (
 // NewDB creates an in-memory DALgo database.
 func NewDB(options ...Option) dal.DB {
 	db := &database{
-		collections: make(map[string]map[string][]byte),
+		collections: make(map[string]storageEngine),
 	}
 	for _, option := range options {
 		if option != nil {
@@ -29,8 +28,11 @@ func NewDB(options ...Option) dal.DB {
 type database struct {
 	dal.ConcurrencyAvailable
 
-	mu          sync.RWMutex
-	collections map[string]map[string][]byte
+	mu sync.RWMutex
+	// collections maps a collection name to its storage engine. Stored records
+	// live solely inside these engine instances; the engine is created lazily
+	// on first access (see database.engine).
+	collections map[string]storageEngine
 	schema      *memorySchema
 }
 
@@ -157,8 +159,7 @@ func (s session) Options() dal.TransactionOptions {
 }
 
 func (s session) Exists(_ context.Context, key *dal.Key) (bool, error) {
-	_, ok := s.getBytes(key)
-	return ok, nil
+	return s.db.engine(key.Collection()).exists(keyID(key)), nil
 }
 
 func (s session) Get(_ context.Context, record dal.Record) error {
@@ -166,14 +167,8 @@ func (s session) Get(_ context.Context, record dal.Record) error {
 		record.SetError(err)
 		return err
 	}
-	b, ok := s.getBytes(record.Key())
-	if !ok {
-		err := dal.NewErrNotFoundByKey(record.Key(), nil)
-		record.SetError(err)
-		return err
-	}
 	record.SetError(nil)
-	if err := json.Unmarshal(b, record.Data()); err != nil {
+	if err := s.db.engine(record.Key().Collection()).load(keyID(record.Key()), record); err != nil {
 		record.SetError(err)
 		return err
 	}
@@ -216,9 +211,7 @@ func (s session) InsertMulti(ctx context.Context, records []dal.Record, opts ...
 }
 
 func (s session) Delete(_ context.Context, key *dal.Key) error {
-	if collection := s.db.collections[key.Collection()]; collection != nil {
-		delete(collection, keyID(key))
-	}
+	s.db.engine(key.Collection()).delete(keyID(key))
 	return nil
 }
 
@@ -236,34 +229,16 @@ func (s session) Update(ctx context.Context, key *dal.Key, updates []update.Upda
 
 func (s session) UpdateRecord(_ context.Context, record dal.Record, updates []update.Update, _ ...dal.Precondition) error {
 	collectionName := record.Key().Collection()
-	factory, err := s.db.recordFactory(collectionName)
-	if err != nil {
+	if err := s.db.guardCollection(collectionName); err != nil {
 		return err
 	}
-	b, ok := s.getBytes(record.Key())
-	if !ok {
-		return dal.NewErrNotFoundByKey(record.Key(), nil)
-	}
-	var data map[string]any
-	if err := json.Unmarshal(b, &data); err != nil {
-		return err
-	}
+	fieldUpdates := make(map[string]any, len(updates))
 	for _, upd := range updates {
 		if fieldName := upd.FieldName(); fieldName != "" {
-			data[fieldName] = upd.Value()
+			fieldUpdates[fieldName] = upd.Value()
 		}
 	}
-	next, err := json.Marshal(data)
-	if err != nil {
-		return err
-	}
-	if factory != nil {
-		if err := checkUnknownFields(collectionName, factory, next); err != nil {
-			return err
-		}
-	}
-	s.collection(record.Key())[keyID(record.Key())] = next
-	return nil
+	return s.db.engine(collectionName).update(keyID(record.Key()), fieldUpdates)
 }
 
 func (s session) UpdateMulti(ctx context.Context, keys []*dal.Key, updates []update.Update, preconditions ...dal.Precondition) error {
@@ -289,8 +264,11 @@ func (s session) ExecuteQueryToRecordsReader(_ context.Context, query dal.Query)
 	if err != nil {
 		return nil, err
 	}
-	collection := s.db.collections[collectionName]
-	if len(collection) == 0 {
+	allRows, err := s.loadRows(collectionName)
+	if err != nil {
+		return nil, err
+	}
+	if len(allRows) == 0 {
 		return dal.NewRecordsReader([]dal.Record{}), nil
 	}
 	known := map[string]bool{"": true, base.Name(): true}
@@ -306,16 +284,12 @@ func (s session) ExecuteQueryToRecordsReader(_ context.Context, query dal.Query)
 			return nil, err
 		}
 	}
-	rows := make([]memoryRow, 0, len(collection))
-	for id, b := range collection {
-		var data map[string]any
-		if err := json.Unmarshal(b, &data); err != nil {
-			return nil, err
-		}
-		if !matchesWhere(data, q.Where()) {
+	rows := make([]memoryRow, 0, len(allRows))
+	for _, row := range allRows {
+		if !matchesWhere(row.data, q.Where()) {
 			continue
 		}
-		rows = append(rows, memoryRow{id: id, data: data, raw: b})
+		rows = append(rows, row)
 	}
 	if grouped {
 		srcs := make([]rowSources, len(rows))
@@ -343,7 +317,7 @@ func (s session) ExecuteQueryToRecordsReader(_ context.Context, query dal.Query)
 		template := q.IntoRecord()
 		if template == nil && factory != nil {
 			data := factory()
-			if err := json.Unmarshal(row.raw, data); err != nil {
+			if err := row.materialize(data); err != nil {
 				return nil, err
 			}
 			records[i] = dal.NewRecordWithData(key, data).SetError(nil)
@@ -354,7 +328,7 @@ func (s session) ExecuteQueryToRecordsReader(_ context.Context, query dal.Query)
 			continue
 		}
 		data := template.Data()
-		if err := json.Unmarshal(row.raw, data); err != nil {
+		if err := row.materialize(data); err != nil {
 			return nil, err
 		}
 		records[i] = dal.NewRecordWithData(key, data).SetError(nil)
@@ -365,58 +339,24 @@ func (s session) ExecuteQueryToRecordsReader(_ context.Context, query dal.Query)
 var _ dal.ReadwriteTransaction = (*session)(nil)
 
 type memoryRow struct {
-	id   string
-	data map[string]any
-	raw  []byte
+	id          string
+	data        map[string]any
+	materialize func(target any) error
 }
 
 func (s session) save(record dal.Record, overwrite bool) error {
 	collectionName := record.Key().Collection()
-	factory, err := s.db.recordFactory(collectionName)
-	if err != nil {
+	if err := s.db.guardCollection(collectionName); err != nil {
 		record.SetError(err)
 		return err
-	}
-	id := keyID(record.Key())
-	collection := s.collection(record.Key())
-	if !overwrite {
-		if _, ok := collection[id]; ok {
-			return fmt.Errorf("record already exists: %s", record.Key())
-		}
 	}
 	record.SetError(nil)
-	b, err := json.Marshal(record.Data())
-	if err != nil {
+	if err := s.db.engine(collectionName).store(keyID(record.Key()), record, overwrite); err != nil {
 		record.SetError(err)
 		return err
 	}
-	if factory != nil {
-		if err := checkUnknownFields(collectionName, factory, b); err != nil {
-			record.SetError(err)
-			return err
-		}
-	}
-	collection[id] = b
 	record.SetError(nil)
 	return nil
-}
-
-func (s session) getBytes(key *dal.Key) ([]byte, bool) {
-	collection := s.db.collections[key.Collection()]
-	if collection == nil {
-		return nil, false
-	}
-	b, ok := collection[keyID(key)]
-	return b, ok
-}
-
-func (s session) collection(key *dal.Key) map[string][]byte {
-	collection := s.db.collections[key.Collection()]
-	if collection == nil {
-		collection = make(map[string][]byte)
-		s.db.collections[key.Collection()] = collection
-	}
-	return collection
 }
 
 func keyID(key *dal.Key) string {

--- a/dalgo2memory/database_test.go
+++ b/dalgo2memory/database_test.go
@@ -164,7 +164,7 @@ func TestMalformedStoredData(t *testing.T) {
 	ctx := context.Background()
 	db := NewDB().(*database)
 	key := dal.NewKeyWithID("Bad", "json")
-	db.collections[key.Collection()] = map[string][]byte{keyID(key): []byte("{")}
+	db.collections[key.Collection()] = &serializedEngine{records: map[string][]byte{keyID(key): []byte("{")}}
 
 	require.Error(t, db.Get(ctx, dal.NewRecordWithData(key, &thing{})))
 	require.Error(t, db.GetMulti(ctx, []dal.Record{dal.NewRecordWithData(key, &thing{})}))

--- a/dalgo2memory/engine.go
+++ b/dalgo2memory/engine.go
@@ -1,0 +1,49 @@
+package dalgo2memory
+
+import (
+	"github.com/dal-go/dalgo/dal"
+)
+
+// storageEngine is the internal, per-collection storage seam. It owns how one
+// collection's records are stored and read back, abstracting the concrete
+// representation (JSON bytes for the Serialized engine, typed slices for a
+// future Columnar engine) behind a representation-neutral interface: no member
+// accepts or returns a serialized byte representation.
+//
+// An engine instance backs exactly one collection. Engine selection is per
+// collection (see CollectionOption); a single database can host different
+// engines for different collections.
+type storageEngine interface {
+	// exists reports whether a record with the given id is stored.
+	exists(id string) bool
+
+	// store writes the record's decoded data under id. When overwrite is false
+	// and a record with that id already exists, it returns a duplicate error.
+	store(id string, record dal.Record, overwrite bool) error
+
+	// load reads the record stored under id into the caller-provided record.
+	// It returns a not-found error when no record with that id is stored.
+	load(id string, record dal.Record) error
+
+	// delete removes the record stored under id, if any.
+	delete(id string)
+
+	// update applies decoded field updates (name -> value) to the record
+	// stored under id, re-validating against the engine's own representation.
+	// It returns a not-found error when no record with that id is stored.
+	update(id string, updates map[string]any) error
+
+	// rows enumerates the collection's stored rows for query execution. Each
+	// row exposes a decoded map[string]any field view (for WHERE/GROUP
+	// BY/ORDER BY/projection) and a materialize callback that decodes the row
+	// into a caller-provided typed target.
+	rows() ([]engineRow, error)
+}
+
+// engineRow is one enumerated row: its id, a decoded field view, and a
+// materialize callback that loads the row into a caller-provided typed target.
+type engineRow struct {
+	id          string
+	data        map[string]any
+	materialize func(target any) error
+}

--- a/dalgo2memory/engine_test.go
+++ b/dalgo2memory/engine_test.go
@@ -1,0 +1,137 @@
+package dalgo2memory
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/stretchr/testify/require"
+)
+
+// countingEngine is a test-only second storage engine: it wraps a Serialized
+// engine and records how many writes it received, proving the registry routes
+// per collection through a distinct, non-Serialized engine instance.
+type countingEngine struct {
+	inner  *serializedEngine
+	writes int
+}
+
+func (e *countingEngine) exists(id string) bool { return e.inner.exists(id) }
+
+func (e *countingEngine) store(id string, record dal.Record, overwrite bool) error {
+	e.writes++
+	return e.inner.store(id, record, overwrite)
+}
+
+func (e *countingEngine) load(id string, record dal.Record) error { return e.inner.load(id, record) }
+
+func (e *countingEngine) delete(id string) { e.inner.delete(id) }
+
+func (e *countingEngine) update(id string, updates map[string]any) error {
+	return e.inner.update(id, updates)
+}
+
+func (e *countingEngine) rows() ([]engineRow, error) { return e.inner.rows() }
+
+// withCountingStorage is a test-only CollectionOption selecting countingEngine.
+func withCountingStorage() CollectionOption {
+	return func(def *collectionDef) {
+		def.newEngine = func(collection string, factory func() any) storageEngine {
+			return &countingEngine{inner: newSerializedEngine(collection, factory)}
+		}
+	}
+}
+
+// TestSerializedStorageMatchesDefault verifies AC:default-is-serialized: a
+// collection registered with WithSerializedStorage() behaves identically to an
+// option-less one across Set/Get/equality-filtered query.
+func TestSerializedStorageMatchesDefault(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	run := func(opts ...CollectionOption) *user {
+		db := NewDB(WithSchema(false,
+			WithCollection[user]("users", nil, opts...),
+		)).(*database)
+		require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("users", "u1"), &user{Name: "Alice", Role: "admin"})))
+		require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("users", "u2"), &user{Name: "Bob", Role: "member"})))
+
+		q := dal.From(dal.NewRootCollectionRef("users", "")).NewQuery().WhereField("Role", dal.Equal, "admin").SelectKeysOnly(reflect.String)
+		reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+		require.NoError(t, err)
+		records := readAll(t, reader)
+		require.Len(t, records, 1)
+		got, ok := records[0].Data().(*user)
+		require.True(t, ok)
+		return got
+	}
+
+	defaultResult := run()
+	explicitResult := run(WithSerializedStorage())
+	require.Equal(t, defaultResult, explicitResult)
+	require.Equal(t, "Alice", defaultResult.Name)
+}
+
+// TestMixedEnginesInOneDB verifies AC:mixed-engines-in-one-db: one database can
+// host different engines per collection, each routing through its own instance
+// with no cross-collection interference.
+func TestMixedEnginesInOneDB(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := NewDB(WithSchema(false,
+		WithCollection[user]("a", nil, WithSerializedStorage()),
+		WithCollection[user]("b", nil, withCountingStorage()),
+	)).(*database)
+
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("a", "a1"), &user{Name: "Alice"})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("b", "b1"), &user{Name: "Bob"})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("b", "b2"), &user{Name: "Carol"})))
+
+	// Collection a uses the Serialized engine.
+	_, isSerialized := db.collections["a"].(*serializedEngine)
+	require.True(t, isSerialized)
+
+	// Collection b uses the counting engine, which observed only b's writes.
+	counting, isCounting := db.collections["b"].(*countingEngine)
+	require.True(t, isCounting)
+	require.Equal(t, 2, counting.writes)
+
+	// Each retrieves its own records; operations on one do not affect the other.
+	var a1 user
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(dal.NewKeyWithID("a", "a1"), &a1)))
+	require.Equal(t, "Alice", a1.Name)
+	var b1 user
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(dal.NewKeyWithID("b", "b1"), &b1)))
+	require.Equal(t, "Bob", b1.Name)
+
+	existsA, err := db.Exists(ctx, dal.NewKeyWithID("a", "b1"))
+	require.NoError(t, err)
+	require.False(t, existsA)
+}
+
+// TestUnregisteredCollectionUsesSerialized verifies
+// AC:unregistered-collection-is-serialized: a collection never registered
+// through a schema resolves to the Serialized engine.
+func TestUnregisteredCollectionUsesSerialized(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := NewDB().(*database)
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("ad-hoc", "x1"), &user{Name: "Alice"})))
+	_, isSerialized := db.collections["ad-hoc"].(*serializedEngine)
+	require.True(t, isSerialized)
+
+	var got user
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(dal.NewKeyWithID("ad-hoc", "x1"), &got)))
+	require.Equal(t, "Alice", got.Name)
+}
+
+// TestEngineCachesInstance verifies the registry returns the same engine
+// instance on repeated access for a collection.
+func TestEngineCachesInstance(t *testing.T) {
+	t.Parallel()
+	db := NewDB().(*database)
+	first := db.engine("things")
+	second := db.engine("things")
+	require.Same(t, first, second)
+}

--- a/dalgo2memory/engine_test.go
+++ b/dalgo2memory/engine_test.go
@@ -37,7 +37,7 @@ func (e *countingEngine) rows() ([]engineRow, error) { return e.inner.rows() }
 // withCountingStorage is a test-only CollectionOption selecting countingEngine.
 func withCountingStorage() CollectionOption {
 	return func(def *collectionDef) {
-		def.newEngine = func(collection string, factory func() any) storageEngine {
+		def.newEngine = func(collection string, factory func() any, _ bool) storageEngine {
 			return &countingEngine{inner: newSerializedEngine(collection, factory)}
 		}
 	}

--- a/dalgo2memory/join.go
+++ b/dalgo2memory/join.go
@@ -1,7 +1,6 @@
 package dalgo2memory
 
 import (
-	"encoding/json"
 	"fmt"
 	"maps"
 	"sort"
@@ -183,14 +182,13 @@ func orderJoinedRows(rows []joinedRow, orderBy []dal.OrderExpression) {
 }
 
 func (s session) loadRows(collectionName string) ([]memoryRow, error) {
-	collection := s.db.collections[collectionName]
-	rows := make([]memoryRow, 0, len(collection))
-	for id, b := range collection {
-		var data map[string]any
-		if err := json.Unmarshal(b, &data); err != nil {
-			return nil, err
-		}
-		rows = append(rows, memoryRow{id: id, data: data, raw: b})
+	engineRows, err := s.db.engine(collectionName).rows()
+	if err != nil {
+		return nil, err
+	}
+	rows := make([]memoryRow, len(engineRows))
+	for i, r := range engineRows {
+		rows[i] = memoryRow(r)
 	}
 	return rows, nil
 }

--- a/dalgo2memory/join.go
+++ b/dalgo2memory/join.go
@@ -186,11 +186,46 @@ func (s session) loadRows(collectionName string) ([]memoryRow, error) {
 	if err != nil {
 		return nil, err
 	}
+	return toMemoryRows(engineRows), nil
+}
+
+// candidateRowsEngine is the optional capability a storage engine implements to
+// accelerate the single supported equality WHERE predicate: it returns the rows
+// its column strategy selects (ok=true) or signals "no opinion" (ok=false) so
+// the caller scans all rows. The returned rows are still re-filtered with
+// matchesWhere, so the result is identical to a full scan.
+type candidateRowsEngine interface {
+	candidateRows(condition dal.Condition) ([]engineRow, bool, error)
+}
+
+// loadCandidateRows returns the rows a single-source query must consider for a
+// WHERE condition. When the collection's engine implements candidateRowsEngine
+// and has an opinion about the predicate, only the candidate rows are loaded;
+// otherwise every row is loaded for a full scan.
+func (s session) loadCandidateRows(collectionName string, condition dal.Condition) ([]memoryRow, error) {
+	eng := s.db.engine(collectionName)
+	if ce, ok := eng.(candidateRowsEngine); ok {
+		rows, hasOpinion, err := ce.candidateRows(condition)
+		if err != nil {
+			return nil, err
+		}
+		if hasOpinion {
+			return toMemoryRows(rows), nil
+		}
+	}
+	allRows, err := eng.rows()
+	if err != nil {
+		return nil, err
+	}
+	return toMemoryRows(allRows), nil
+}
+
+func toMemoryRows(engineRows []engineRow) []memoryRow {
 	rows := make([]memoryRow, len(engineRows))
 	for i, r := range engineRows {
 		rows[i] = memoryRow(r)
 	}
-	return rows, nil
+	return rows
 }
 
 func sortByID(rows []memoryRow) {

--- a/dalgo2memory/join_test.go
+++ b/dalgo2memory/join_test.go
@@ -224,7 +224,7 @@ func TestExecuteJoin_EdgeCases(t *testing.T) {
 	t.Run("malformed base row errors", func(t *testing.T) {
 		db := NewDB().(*database)
 		ctx := context.Background()
-		db.collections["users"] = map[string][]byte{"1": []byte("{")}
+		db.collections["users"] = &serializedEngine{records: map[string][]byte{"1": []byte("{")}}
 		require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("orders", "a"), &map[string]any{"userId": 1})))
 		join := dal.NewJoinedSource(ordersAlias(), dal.JoinInner, onUserEqOrder())
 		q := dal.From(usersAlias()).Join(join).NewQuery().SelectIntoRecord(intoMapRecord())
@@ -237,7 +237,7 @@ func TestExecuteJoin_EdgeCases(t *testing.T) {
 		db := NewDB().(*database)
 		ctx := context.Background()
 		require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("users", "1"), &map[string]any{"id": 1})))
-		db.collections["orders"] = map[string][]byte{"a": []byte("{")}
+		db.collections["orders"] = &serializedEngine{records: map[string][]byte{"a": []byte("{")}}
 		join := dal.NewJoinedSource(ordersAlias(), dal.JoinInner, onUserEqOrder())
 		q := dal.From(usersAlias()).Join(join).NewQuery().SelectIntoRecord(intoMapRecord())
 		reader, err := db.ExecuteQueryToRecordsReader(ctx, q)

--- a/dalgo2memory/schema.go
+++ b/dalgo2memory/schema.go
@@ -19,9 +19,12 @@ type collectionDef struct {
 	newEngine engineFactory
 }
 
-// engineFactory builds a storage engine for a collection given its name and
-// record-type factory (nil when schemaless).
-type engineFactory func(collection string, factory func() any) storageEngine
+// engineFactory builds a storage engine for a collection given its name, its
+// record-type factory (nil when schemaless), and the schema-wide ref-breaking
+// default (faithful unless WithoutSchemaRefBreaking was used). An engine that
+// has no per-collection fidelity setting honors schemaRefBreaking; the
+// Serialized engine ignores it (it is always faithful).
+type engineFactory func(collection string, factory func() any, schemaRefBreaking bool) storageEngine
 
 // CollectionOption configures a collection definition produced by WithCollection
 // — currently the per-collection storage-engine selection. Pass it as a trailing
@@ -37,8 +40,53 @@ func WithSerializedStorage() CollectionOption {
 	}
 }
 
+// ColumnOption configures a single aspect of a columnar collection: it either
+// supplies a ColumnStrategy for a named column (WithColumnStrategy) or sets the
+// per-collection ref-breaking override (WithColumnarRefBreaking). It is passed
+// to WithColumnarStorage. Exported so an out-of-core package can return one
+// carrying its own ColumnStrategy without dalgo2memory importing it.
+type ColumnOption func(*columnarConfig)
+
+// WithColumnStrategy supplies a ColumnStrategy for the named column of a
+// columnar collection. Columns without an explicit strategy use the default
+// typed-slice strategy.
+func WithColumnStrategy(name string, strategy ColumnStrategy) ColumnOption {
+	return func(cfg *columnarConfig) {
+		if cfg.strategies == nil {
+			cfg.strategies = make(map[string]ColumnStrategy)
+		}
+		cfg.strategies[name] = strategy
+	}
+}
+
+// WithColumnarRefBreaking sets the per-collection ref-breaking override for a
+// columnar collection, taking precedence over the schema-wide default
+// (WithoutSchemaRefBreaking). Pass true to force faithful storage, false to
+// store reference-bearing columns without the serialization round-trip.
+func WithColumnarRefBreaking(refBreaking bool) ColumnOption {
+	return func(cfg *columnarConfig) {
+		cfg.refBreakOver = &refBreaking
+	}
+}
+
+// WithColumnarStorage selects the columnar storage engine for a
+// schema-registered WithCollection[T] collection, with optional per-column
+// strategies and a per-collection ref-breaking override. Selecting columnar
+// storage for a schemaless or non-struct collection fails with a descriptive
+// error when the collection is used.
+func WithColumnarStorage(opts ...ColumnOption) CollectionOption {
+	return func(def *collectionDef) {
+		var cfg columnarConfig
+		for _, opt := range opts {
+			opt(&cfg)
+		}
+		def.newEngine = newColumnarEngineFactory(cfg)
+	}
+}
+
 // serializedEngineFactory is the engineFactory for the default Serialized engine.
-func serializedEngineFactory(collection string, factory func() any) storageEngine {
+// The Serialized engine is always faithful, so it ignores schemaRefBreaking.
+func serializedEngineFactory(collection string, factory func() any, _ bool) storageEngine {
 	return newSerializedEngine(collection, factory)
 }
 
@@ -96,6 +144,17 @@ type memorySchema struct {
 	allowUndefined bool
 }
 
+// WithoutSchemaRefBreaking disables columnar ref-breaking schema-wide: columnar
+// collections store reference-bearing column values without the serialization
+// round-trip unless a collection re-enables it (see WithColumnarRefBreaking).
+// It has no effect on the always-faithful Serialized engine. The default is
+// faithful (ref-breaking on).
+func WithoutSchemaRefBreaking() Option {
+	return func(db *database) {
+		db.schemaRefBreaking = false
+	}
+}
+
 // recordFactory returns the factory for a collection.
 //
 // It returns (nil, nil) when no schema is registered, or when the collection is
@@ -140,7 +199,7 @@ func (db *database) engine(collection string) storageEngine {
 			newEngine = chosen
 		}
 	}
-	eng := newEngine(collection, factory)
+	eng := newEngine(collection, factory, db.schemaRefBreaking)
 	db.collections[collection] = eng
 	return eng
 }

--- a/dalgo2memory/schema.go
+++ b/dalgo2memory/schema.go
@@ -14,20 +14,53 @@ type Option func(*database)
 type collectionDef struct {
 	name      string
 	newRecord func() any
+	// newEngine builds the storage engine backing the collection. It is set by
+	// a CollectionOption (default: Serialized) and consumed by WithSchema.
+	newEngine engineFactory
+}
+
+// engineFactory builds a storage engine for a collection given its name and
+// record-type factory (nil when schemaless).
+type engineFactory func(collection string, factory func() any) storageEngine
+
+// CollectionOption configures a collection definition produced by WithCollection
+// — currently the per-collection storage-engine selection. Pass it as a trailing
+// argument to WithCollection.
+type CollectionOption func(*collectionDef)
+
+// WithSerializedStorage selects the Serialized storage engine for a collection.
+// It is the default engine, so this option states the default explicitly; an
+// option-less collection behaves identically.
+func WithSerializedStorage() CollectionOption {
+	return func(def *collectionDef) {
+		def.newEngine = serializedEngineFactory
+	}
+}
+
+// serializedEngineFactory is the engineFactory for the default Serialized engine.
+func serializedEngineFactory(collection string, factory func() any) storageEngine {
+	return newSerializedEngine(collection, factory)
 }
 
 // WithCollection registers a collection backed by the concrete record type T.
 //
 // If newRecord is nil, a zero value (new(T)) is used to materialize each record
 // read by a query. Provide a factory to populate default field values instead.
-func WithCollection[T any](name string, newRecord func() *T) collectionDef {
+//
+// Trailing CollectionOption arguments select a per-collection storage engine;
+// with none, the collection uses the default Serialized engine.
+func WithCollection[T any](name string, newRecord func() *T, opts ...CollectionOption) collectionDef {
 	factory := func() any {
 		if newRecord != nil {
 			return newRecord()
 		}
 		return new(T)
 	}
-	return collectionDef{name: name, newRecord: factory}
+	def := collectionDef{name: name, newRecord: factory}
+	for _, opt := range opts {
+		opt(&def)
+	}
+	return def
 }
 
 // WithSchema registers per-collection record types so that queries return records
@@ -40,19 +73,26 @@ func WithCollection[T any](name string, newRecord func() *T) collectionDef {
 func WithSchema(allowUndefinedCollections bool, collections ...collectionDef) Option {
 	return func(db *database) {
 		factories := make(map[string]func() any, len(collections))
+		engines := make(map[string]engineFactory, len(collections))
 		for _, c := range collections {
 			factories[c.name] = c.newRecord
+			if c.newEngine != nil {
+				engines[c.name] = c.newEngine
+			}
 		}
 		db.schema = &memorySchema{
 			collections:    factories,
+			engines:        engines,
 			allowUndefined: allowUndefinedCollections,
 		}
 	}
 }
 
-// memorySchema holds the registered record factories for the in-memory database.
+// memorySchema holds the registered record factories and per-collection engine
+// choices for the in-memory database.
 type memorySchema struct {
 	collections    map[string]func() any
+	engines        map[string]engineFactory
 	allowUndefined bool
 }
 
@@ -80,6 +120,29 @@ func (db *database) recordFactory(collection string) (func() any, error) {
 func (db *database) guardCollection(collection string) error {
 	_, err := db.recordFactory(collection)
 	return err
+}
+
+// engine resolves the storage engine for a collection, constructing it lazily
+// on first access and registering it. The engine choice comes from the
+// collection's registered CollectionOption when present; any collection without
+// a recorded choice (unregistered, or registered without an engine option)
+// resolves to the default Serialized engine. The record-type factory (for
+// unknown-field validation) is resolved alongside; callers that need the guard
+// error should call recordFactory/guardCollection first.
+func (db *database) engine(collection string) storageEngine {
+	if eng, ok := db.collections[collection]; ok {
+		return eng
+	}
+	factory, _ := db.recordFactory(collection)
+	newEngine := serializedEngineFactory
+	if db.schema != nil {
+		if chosen, ok := db.schema.engines[collection]; ok {
+			newEngine = chosen
+		}
+	}
+	eng := newEngine(collection, factory)
+	db.collections[collection] = eng
+	return eng
 }
 
 // checkUnknownFields validates that the marshaled record data contains no fields

--- a/dalgo2memory/schema.go
+++ b/dalgo2memory/schema.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"reflect"
 )
 
 // Option configures an in-memory database created by NewDB.
@@ -56,6 +57,23 @@ func WithColumnStrategy(name string, strategy ColumnStrategy) ColumnOption {
 			cfg.strategies = make(map[string]ColumnStrategy)
 		}
 		cfg.strategies[name] = strategy
+	}
+}
+
+// WithDeclaredColumn declares a columnar column by name for a map-backed
+// (map[string]any) collection, stored in a strongly-typed []T slice. At least
+// one declared column is required to select columnar storage for a map-backed
+// collection; undeclared fields are kept in a parallel leftover map. On a
+// struct collection a declared column is accepted but redundant (the struct
+// path reflects over the record type instead). When the same name is declared
+// more than once, the last declaration wins.
+func WithDeclaredColumn[T any](name string) ColumnOption {
+	return func(cfg *columnarConfig) {
+		var zero T
+		cfg.declared = append(cfg.declared, declaredColumn{
+			name:     name,
+			elemType: reflect.TypeOf(&zero).Elem(),
+		})
 	}
 }
 

--- a/dalgo2memory/schema_test.go
+++ b/dalgo2memory/schema_test.go
@@ -116,7 +116,7 @@ func TestSchemaRejectsUndefinedFieldsOnWrite(t *testing.T) {
 	bad := dal.NewRecordWithData(key, map[string]any{"Name": "Alice", "Unknown": 1})
 	require.Error(t, db.Set(ctx, bad))
 	require.Error(t, db.Insert(ctx, bad))
-	require.Empty(t, db.collections["users"])
+	require.Empty(t, db.collections["users"].(*serializedEngine).records)
 
 	// A payload that only uses defined fields is accepted.
 	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, map[string]any{"Name": "Alice", "Role": "admin"})))
@@ -140,7 +140,7 @@ func TestSchemaQueryMalformedStoredData(t *testing.T) {
 	)).(*database)
 	key := dal.NewKeyWithID("things", "bad")
 	// Decodes fine into map[string]any, but Count("x") fails to decode into thing.
-	db.collections["things"] = map[string][]byte{keyID(key): []byte(`{"Count":"x"}`)}
+	db.collections["things"] = &serializedEngine{records: map[string][]byte{keyID(key): []byte(`{"Count":"x"}`)}}
 
 	q := dal.From(dal.NewRootCollectionRef("things", "")).NewQuery().SelectKeysOnly(reflect.String)
 	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)

--- a/dalgo2memory/serialized.go
+++ b/dalgo2memory/serialized.go
@@ -1,0 +1,115 @@
+package dalgo2memory
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/dal-go/dalgo/dal"
+)
+
+// serializedEngine is the default storage engine: it stores each record as
+// JSON bytes keyed by id, and owns the marshal/unmarshal, duplicate-on-insert,
+// not-found, and unknown-field validation that the adapter performed before the
+// storage-engine seam. Its formal behavioral contract is owned by the
+// serialized-storage Feature; here it is the unselected default.
+//
+// collection and factory carry the schema context needed for unknown-field
+// rejection: factory is nil when the collection has no registered record type
+// (schemaless), in which case no field validation is performed.
+type serializedEngine struct {
+	collection string
+	factory    func() any
+	records    map[string][]byte
+}
+
+var _ storageEngine = (*serializedEngine)(nil)
+
+// newSerializedEngine builds a Serialized engine for a collection with the
+// given record-type factory (nil when schemaless).
+func newSerializedEngine(collection string, factory func() any) *serializedEngine {
+	return &serializedEngine{
+		collection: collection,
+		factory:    factory,
+		records:    make(map[string][]byte),
+	}
+}
+
+func (e *serializedEngine) exists(id string) bool {
+	_, ok := e.records[id]
+	return ok
+}
+
+func (e *serializedEngine) store(id string, record dal.Record, overwrite bool) error {
+	if !overwrite {
+		if _, ok := e.records[id]; ok {
+			return fmt.Errorf("record already exists: %s", record.Key())
+		}
+	}
+	b, err := json.Marshal(record.Data())
+	if err != nil {
+		return err
+	}
+	if e.factory != nil {
+		if err := checkUnknownFields(e.collection, e.factory, b); err != nil {
+			return err
+		}
+	}
+	e.records[id] = b
+	return nil
+}
+
+func (e *serializedEngine) load(id string, record dal.Record) error {
+	b, ok := e.records[id]
+	if !ok {
+		return dal.NewErrNotFoundByKey(record.Key(), nil)
+	}
+	return json.Unmarshal(b, record.Data())
+}
+
+func (e *serializedEngine) delete(id string) {
+	delete(e.records, id)
+}
+
+func (e *serializedEngine) update(id string, updates map[string]any) error {
+	b, ok := e.records[id]
+	if !ok {
+		return dal.NewErrNotFoundByKey(dal.NewKeyWithID(e.collection, id), nil)
+	}
+	var data map[string]any
+	if err := json.Unmarshal(b, &data); err != nil {
+		return err
+	}
+	for fieldName, value := range updates {
+		data[fieldName] = value
+	}
+	next, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	if e.factory != nil {
+		if err := checkUnknownFields(e.collection, e.factory, next); err != nil {
+			return err
+		}
+	}
+	e.records[id] = next
+	return nil
+}
+
+func (e *serializedEngine) rows() ([]engineRow, error) {
+	rows := make([]engineRow, 0, len(e.records))
+	for id, b := range e.records {
+		var data map[string]any
+		if err := json.Unmarshal(b, &data); err != nil {
+			return nil, err
+		}
+		raw := b
+		rows = append(rows, engineRow{
+			id:   id,
+			data: data,
+			materialize: func(target any) error {
+				return json.Unmarshal(raw, target)
+			},
+		})
+	}
+	return rows, nil
+}

--- a/dalgo2memory/serialized_test.go
+++ b/dalgo2memory/serialized_test.go
@@ -1,0 +1,313 @@
+package dalgo2memory
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/update"
+	"github.com/stretchr/testify/require"
+)
+
+// profile is a record type with a nested slice and struct, used to prove the
+// Serialized engine's ref-breaking fidelity (mutating a caller value after a
+// write, or one decoded read, never affects stored data or another read).
+type profile struct {
+	Name    string
+	Tags    []string
+	Address address
+}
+
+type address struct {
+	City string
+}
+
+// TestSerialized_StoredAsDecodableBytes verifies
+// serialized-storage#ac:stored-as-decodable-bytes: a record Set then Get
+// returns data equal to what was written, and the stored form is a byte buffer
+// that, when decoded directly, reproduces that same data.
+func TestSerialized_StoredAsDecodableBytes(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := NewDB().(*database)
+	key := dal.NewKeyWithID("users", "u1")
+	written := &user{Name: "Alice", Role: "admin"}
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, written)))
+
+	// Get reconstructs equal data.
+	var got user
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(key, &got)))
+	require.Equal(t, *written, got)
+
+	// The stored form is a byte buffer, not the original value; decoding those
+	// bytes directly yields the same data.
+	engine, ok := db.collections["users"].(*serializedEngine)
+	require.True(t, ok)
+	stored, ok := engine.records[keyID(key)]
+	require.True(t, ok)
+	require.IsType(t, []byte{}, stored)
+	var decoded user
+	require.NoError(t, json.Unmarshal(stored, &decoded))
+	require.Equal(t, *written, decoded)
+}
+
+// TestSerialized_DefaultAndSchemalessCapable verifies
+// serialized-storage#ac:serialized-is-default-and-schemaless-capable: an
+// unregistered (schemaless) collection and a WithSerializedStorage() collection
+// both operate through the Serialized engine and succeed.
+func TestSerialized_DefaultAndSchemalessCapable(t *testing.T) {
+	t.Parallel()
+
+	// Compile-time conformance guard (mirrors the assertion in serialized.go).
+	var _ storageEngine = (*serializedEngine)(nil)
+
+	ctx := context.Background()
+	db := NewDB(WithSchema(true,
+		WithCollection[user]("users", nil, WithSerializedStorage()),
+	)).(*database)
+
+	// Schema-typed collection selected via WithSerializedStorage().
+	typedKey := dal.NewKeyWithID("users", "u1")
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(typedKey, &user{Name: "Alice", Role: "admin"})))
+	_, typedIsSerialized := db.collections["users"].(*serializedEngine)
+	require.True(t, typedIsSerialized)
+	var typedGot user
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(typedKey, &typedGot)))
+	require.Equal(t, "Alice", typedGot.Name)
+
+	// Unregistered, schemaless collection (allowed by allowUndefinedCollections).
+	schemalessKey := dal.NewKeyWithID("ad-hoc", "x1")
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(schemalessKey, map[string]any{"anything": "goes"})))
+	engine, schemalessIsSerialized := db.collections["ad-hoc"].(*serializedEngine)
+	require.True(t, schemalessIsSerialized)
+	require.Nil(t, engine.factory, "schemaless collection has no record factory")
+	var schemalessGot map[string]any
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(schemalessKey, &schemalessGot)))
+	require.Equal(t, "goes", schemalessGot["anything"])
+}
+
+// TestSerialized_MutationAfterWriteIsolated verifies
+// serialized-storage#ac:mutation-after-write-isolated: mutating a nested field
+// of the caller value AFTER Set returns does not affect stored data; a fresh
+// Get reflects the write-time value.
+func TestSerialized_MutationAfterWriteIsolated(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := NewDB().(*database)
+	key := dal.NewKeyWithID("profiles", "p1")
+
+	written := &profile{Name: "Alice", Tags: []string{"a", "b"}, Address: address{City: "Paris"}}
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, written)))
+
+	// Mutate nested slice element and nested struct field after Set returns.
+	written.Tags[0] = "MUTATED"
+	written.Address.City = "MUTATED"
+
+	var got profile
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(key, &got)))
+	require.Equal(t, []string{"a", "b"}, got.Tags)
+	require.Equal(t, "Paris", got.Address.City)
+}
+
+// TestSerialized_TwoReadsIndependent verifies
+// serialized-storage#ac:two-reads-independent: reading one stored record into
+// two separate targets and mutating one leaves the other unchanged.
+func TestSerialized_TwoReadsIndependent(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := NewDB().(*database)
+	key := dal.NewKeyWithID("profiles", "p1")
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key,
+		&profile{Name: "Alice", Tags: []string{"a", "b"}, Address: address{City: "Paris"}})))
+
+	var first, second profile
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(key, &first)))
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(key, &second)))
+
+	first.Tags[0] = "MUTATED"
+	first.Address.City = "MUTATED"
+
+	require.Equal(t, []string{"a", "b"}, second.Tags)
+	require.Equal(t, "Paris", second.Address.City)
+}
+
+// TestSerialized_NonSerializableWriteErrors verifies
+// serialized-storage#ac:non-serializable-write-errors: writing a record with a
+// non-serializable value returns a descriptive error, sets it on the record,
+// and leaves no entry for that id.
+func TestSerialized_NonSerializableWriteErrors(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := NewDB().(*database)
+	key := dal.NewKeyWithID("bad", "ch")
+	record := dal.NewRecordWithData(key, map[string]any{"ch": make(chan int)})
+
+	err := db.Set(ctx, record)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "json")
+	require.Equal(t, err, record.Error(), "the error is set on the record")
+
+	exists, existsErr := db.Exists(ctx, key)
+	require.NoError(t, existsErr)
+	require.False(t, exists, "no entry exists for the id after a failed write")
+}
+
+// TestSerialized_UnknownFieldRejectedWhenTyped verifies
+// serialized-storage#ac:unknown-field-rejected-when-typed: a write carrying a
+// field undefined on the registered type is rejected with a descriptive error
+// naming the collection; the same data on a schemaless collection succeeds.
+func TestSerialized_UnknownFieldRejectedWhenTyped(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	data := map[string]any{"Name": "Alice", "Undefined": 1}
+
+	// Schema-typed collection rejects the unknown field, naming the collection.
+	typedDB := NewDB(WithSchema(false, WithCollection[user]("users", nil))).(*database)
+	typedKey := dal.NewKeyWithID("users", "u1")
+	err := typedDB.Set(ctx, dal.NewRecordWithData(typedKey, data))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "users", "error names the collection")
+	require.Empty(t, typedDB.collections["users"].(*serializedEngine).records)
+
+	// Schemaless collection accepts the same data.
+	schemalessDB := NewDB().(*database)
+	schemalessKey := dal.NewKeyWithID("users", "u1")
+	require.NoError(t, schemalessDB.Set(ctx, dal.NewRecordWithData(schemalessKey, data)))
+	var got map[string]any
+	require.NoError(t, schemalessDB.Get(ctx, dal.NewRecordWithData(schemalessKey, &got)))
+	require.EqualValues(t, 1, got["Undefined"])
+}
+
+// TestSerialized_InsertDuplicateErrors verifies
+// serialized-storage#ac:insert-duplicate-errors: Insert on an existing id
+// returns an "already exists" error and leaves the existing record unchanged,
+// while Set for that id overwrites.
+func TestSerialized_InsertDuplicateErrors(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := NewDB().(*database)
+	key := dal.NewKeyWithID("users", "u1")
+	require.NoError(t, db.Insert(ctx, dal.NewRecordWithData(key, &user{Name: "Alice", Role: "admin"})))
+
+	// Insert on the existing id fails with an "already exists" error.
+	err := db.Insert(ctx, dal.NewRecordWithData(key, &user{Name: "Bob", Role: "member"}))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "already exists")
+
+	// The existing record is unchanged.
+	var got user
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(key, &got)))
+	require.Equal(t, user{Name: "Alice", Role: "admin"}, got)
+
+	// Set for that id overwrites successfully.
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, &user{Name: "Bob", Role: "member"})))
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(key, &got)))
+	require.Equal(t, user{Name: "Bob", Role: "member"}, got)
+}
+
+// TestSerialized_GetAbsentNotFound verifies
+// serialized-storage#ac:get-absent-not-found: Get on an absent id returns a
+// not-found error set on the record, and Exists reports false.
+func TestSerialized_GetAbsentNotFound(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := NewDB().(*database)
+	key := dal.NewKeyWithID("users", "absent")
+
+	record := dal.NewRecordWithData(key, &user{})
+	err := db.Get(ctx, record)
+	require.Error(t, err)
+	require.True(t, dal.IsNotFound(err))
+	// The not-found error is set on the record: the record reports it does not
+	// exist (dal.Record.Error() normalizes a not-found error to a false Exists).
+	require.False(t, record.Exists(), "the not-found error is set on the record")
+
+	exists, existsErr := db.Exists(ctx, key)
+	require.NoError(t, existsErr)
+	require.False(t, exists)
+}
+
+// TestSerialized_QueryDecodesRows verifies
+// serialized-storage#ac:query-decodes-rows: an equality-filtered query that
+// materializes into a typed target yields decoded rows for filtering and
+// decoded typed result records that do not share references.
+func TestSerialized_QueryDecodesRows(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := NewDB(WithSchema(false,
+		WithCollection[profile]("profiles", nil),
+	)).(*database)
+
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("profiles", "p1"),
+		&profile{Name: "shared", Tags: []string{"x"}, Address: address{City: "Paris"}})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("profiles", "p2"),
+		&profile{Name: "shared", Tags: []string{"y"}, Address: address{City: "Lyon"}})))
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(dal.NewKeyWithID("profiles", "p3"),
+		&profile{Name: "other", Tags: []string{"z"}, Address: address{City: "Nice"}})))
+
+	q := dal.From(dal.NewRootCollectionRef("profiles", "")).NewQuery().
+		WhereField("Name", dal.Equal, "shared").
+		SelectIntoRecord(func() dal.Record {
+			return dal.NewRecordWithIncompleteKey("profiles", reflect.String, &profile{})
+		})
+	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+	require.NoError(t, err)
+	records := readAll(t, reader)
+
+	// The equality filter, evaluated over decoded map rows, selects only the two
+	// "shared" records.
+	require.Len(t, records, 2)
+	first, ok := records[0].Data().(*profile)
+	require.True(t, ok)
+	second, ok := records[1].Data().(*profile)
+	require.True(t, ok)
+	require.Equal(t, "shared", first.Name)
+	require.Equal(t, "shared", second.Name)
+
+	// Two result records do not share references: mutating one's nested slice
+	// leaves the other unchanged.
+	require.NotSame(t, first, second)
+	first.Tags[0] = "MUTATED"
+	require.NotEqual(t, "MUTATED", second.Tags[0])
+}
+
+// TestSerialized_UpdateAppliesAndRevalidates verifies
+// serialized-storage#ac:update-applies-and-revalidates: Update applies a
+// defined-field change (read-modify-write, persisted); an update introducing an
+// undefined field is rejected with a descriptive error; Update on an absent id
+// returns not-found and stores nothing.
+func TestSerialized_UpdateAppliesAndRevalidates(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := NewDB(WithSchema(false,
+		WithCollection[user]("users", nil),
+	)).(*database)
+	key := dal.NewKeyWithID("users", "u1")
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, &user{Name: "Alice", Role: "admin"})))
+
+	// A defined-field change is read-modified-written and persisted; the
+	// untouched field (Name) survives the read-modify-write.
+	require.NoError(t, db.Update(ctx, key, []update.Update{update.ByFieldName("Role", "member")}))
+	var got user
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(key, &got)))
+	require.Equal(t, user{Name: "Alice", Role: "member"}, got)
+
+	// An update introducing an undefined field is rejected, naming the
+	// collection; the stored record is unchanged.
+	err := db.Update(ctx, key, []update.Update{update.ByFieldName("Undefined", 1)})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "users")
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(key, &got)))
+	require.Equal(t, user{Name: "Alice", Role: "member"}, got)
+
+	// Update on an absent id returns not-found and stores nothing.
+	absentKey := dal.NewKeyWithID("users", "absent")
+	err = db.Update(ctx, absentKey, []update.Update{update.ByFieldName("Role", "x")})
+	require.Error(t, err)
+	require.True(t, dal.IsNotFound(err))
+	exists, existsErr := db.Exists(ctx, absentKey)
+	require.NoError(t, existsErr)
+	require.False(t, exists)
+}

--- a/dalgo2memory/strategy.go
+++ b/dalgo2memory/strategy.go
@@ -1,0 +1,99 @@
+package dalgo2memory
+
+import "reflect"
+
+// SlotSet is a set of per-row slot indices. The columnar engine assigns each
+// live record a stable slot shared across all of a collection's column slices;
+// a ColumnStrategy's equality read side returns the slots whose column equals a
+// queried value. A set (rather than a slice) is returned so that, when the
+// adapter grows multi-predicate AND WHERE, per-predicate sets can be
+// intersected.
+type SlotSet map[int]struct{}
+
+// ColumnStrategy backs a single column of a columnar collection. It is exported
+// so an out-of-core package (e.g. a bitmap index) can supply a strategy via
+// WithColumnStrategy without dalgo2memory importing it.
+//
+// The engine remains the source of truth for stored values (its typed column
+// slices); a strategy is an index kept in sync through the write side, used to
+// accelerate the equality read side.
+type ColumnStrategy interface {
+	// SetValue records that the column holds value at the given slot. The engine
+	// calls it on every write (insert/overwrite/update) for the column.
+	SetValue(slot int, value any)
+
+	// ClearValue records that the slot no longer holds a value for the column.
+	// The engine calls it on delete and during compaction rebuilds.
+	ClearValue(slot int)
+
+	// EqualSlots returns the live slots whose column equals value, with ok=true.
+	// Returning ok=false signals "no opinion": the engine falls back to scanning.
+	// Equality is the adapter's value equality (Go == on comparable decoded
+	// values, as in matchesWhere).
+	EqualSlots(value any) (slots SlotSet, ok bool)
+}
+
+// typedSliceStrategy is the default per-column strategy. It does not keep its
+// own copy of the column's values; instead it scans the engine's typed column
+// slice on read, treating a slot as a candidate only when it is live. For a
+// comparable element type it answers EqualSlots by scanning; for a
+// non-comparable element type (e.g. an []any fallback column holding
+// slices/maps) it returns "no opinion" so the engine scans.
+type typedSliceStrategy struct {
+	column     *column
+	comparable bool
+}
+
+var _ ColumnStrategy = (*typedSliceStrategy)(nil)
+
+// newTypedSliceStrategy builds the default strategy for a column, deciding once
+// whether the column scans for equality. An []any fallback column is treated as
+// non-comparable (its stored values are heterogeneous and may be
+// slices/maps that cannot be compared with ==), so the strategy defers to the
+// scan fall-back for it.
+func newTypedSliceStrategy(col *column) *typedSliceStrategy {
+	return &typedSliceStrategy{
+		column:     col,
+		comparable: col.elemType != anyType && col.elemType.Comparable(),
+	}
+}
+
+// SetValue is a no-op for the default strategy: it reads live values directly
+// from the engine's column slice, so there is nothing to record.
+func (s *typedSliceStrategy) SetValue(slot int, value any) {
+	_, _ = slot, value // default strategy scans the live column slice; nothing to record
+}
+
+// ClearValue is a no-op for the default strategy (see SetValue).
+func (s *typedSliceStrategy) ClearValue(slot int) {
+	_ = slot // default strategy scans the live column slice; nothing to clear
+}
+
+// EqualSlots scans the column slice for live slots equal to value. It returns
+// "no opinion" when the element type is not comparable.
+func (s *typedSliceStrategy) EqualSlots(value any) (SlotSet, bool) {
+	if !s.comparable {
+		return nil, false
+	}
+	slots := make(SlotSet)
+	for slot := 0; slot < s.column.values.Len(); slot++ {
+		if !s.column.engine.live[slot] {
+			continue
+		}
+		stored := s.column.values.Index(slot).Interface()
+		if valuesEqualForStrategy(stored, value) {
+			slots[slot] = struct{}{}
+		}
+	}
+	return slots, true
+}
+
+// valuesEqualForStrategy mirrors matchesWhere's equality (data[field] ==
+// constant.Value): plain Go == on the decoded values, guarded so that
+// comparing against a non-comparable queried value cannot panic.
+func valuesEqualForStrategy(stored, queried any) bool {
+	if queried != nil && !reflect.TypeOf(queried).Comparable() {
+		return false
+	}
+	return stored == queried
+}

--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -28,6 +28,7 @@ The Feature format follows [SpecScore](https://specscore.md/feature-specificatio
 | [storage-engine-seam](storage-engine-seam/README.md) | Approved | — |
 | [serialized-storage](serialized-storage/README.md) | Approved | — |
 | [columnar-storage](columnar-storage/README.md) | Approved | — |
+| [columnar-mixed-mode-maps](columnar-mixed-mode-maps/README.md) | Approved | — |
 
 ## Open Questions
 

--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/features-index-specification
+---
+
 # Features
 
 > [View in SpecStudio](https://specstudio.synchestra.io/project/features?id=dalgo@dal-go@github.com&path=spec%2Ffeatures) — graph, discussions, approvals
@@ -21,6 +25,9 @@ The Feature format follows [SpecScore](https://specscore.md/feature-specificatio
 | [qualified-orderby-resolution](qualified-orderby-resolution/README.md) | Approved | — |
 | [query-column-projection](query-column-projection/README.md) | Stable | — |
 | [query-group-by-aggregation](query-group-by-aggregation/README.md) | Stable | — |
+| [storage-engine-seam](storage-engine-seam/README.md) | Approved | — |
+| [serialized-storage](serialized-storage/README.md) | Approved | — |
+| [columnar-storage](columnar-storage/README.md) | Approved | — |
 
 ## Open Questions
 

--- a/spec/features/columnar-mixed-mode-maps/README.md
+++ b/spec/features/columnar-mixed-mode-maps/README.md
@@ -1,0 +1,181 @@
+---
+format: https://specscore.md/feature-specification
+status: Approved
+---
+
+# Feature: Mixed-mode columnar storage for map[string]any collections (dalgo2memory)
+
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/columnar-mixed-mode-maps?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/columnar-mixed-mode-maps?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/columnar-mixed-mode-maps?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/columnar-mixed-mode-maps?op=request-change) |
+**Status:** Approved
+**Date:** 2026-06-06
+**Owner:** alex
+**Source Ideas:** dalgo2memory-storage-engines
+**Supersedes:** —
+**Grade:** A
+
+## Summary
+
+Extends the columnar engine to `map[string]any`-backed collections in **mixed mode**: a caller declares which columns to store columnarly; those declared fields are kept in typed columnar slices (and removed from each record's map), while every undeclared field is kept in a parallel `[]map[string]any` "leftover" slice indexed by the same per-row slot. Reads merge the declared columns back with the leftover map to reconstruct the full record. This brings columnar's typed-slice storage and `ColumnStrategy` acceleration to schemaless map records without forcing a Go struct type.
+
+## Problem
+
+The `columnar-storage` Feature requires a Go struct record type `T` — it errors when `WithColumnarStorage` is selected for a `map[string]any` (schemaless) collection, because it derives columns by reflecting over `T`'s fields. But many `dalgo2memory` callers (DataTug query results, dynamic records) use `map[string]any`. They cannot benefit from columnar typed slices or from a per-column index, even when they know which fields are hot. Mixed mode closes that gap: declare the hot columns, store them columnarly with strategies, and keep the open-ended remainder in a per-row map — without giving up the dynamic shape `map[string]any` collections rely on.
+
+## Dependencies
+
+- columnar-storage
+
+## Behavior
+
+### Selecting mixed mode
+
+#### REQ: mixed-mode-selection
+
+`WithColumnarStorage` MUST be selectable for a `map[string]any`-backed collection when at least one column is explicitly declared (see `REQ:declared-column-option`). Selecting columnar storage for a `map[string]any` collection with **no** declared column MUST fail with a descriptive error (the engine cannot infer columns from a dynamic map). (Struct-typed collections are unchanged from `columnar-storage` and out of scope here — see Out of Scope.)
+
+#### REQ: declared-column-option
+
+A `ColumnOption` MUST be provided that declares a columnar column by name together with its element type for a map-backed collection, so the column can be stored in a strongly-typed slice.
+
+#### REQ: declared-value-type-enforced
+
+When a written record carries a declared column whose value cannot be stored as that column's declared element type, the write MUST fail with a descriptive error and store nothing for that record — the value MUST NOT be silently dropped or coerced away. (The exact boundary for numeric values arriving as `float64` from a decoded map is an Open Question; a clearly-incompatible value such as a string for an `int` column is an error.)
+
+### Mixed storage layout
+
+#### REQ: declared-columns-typed-slices
+
+Each declared column MUST be stored in a strongly-typed slice (the same typed-column representation as `columnar-storage`), indexed by the shared per-row slot, and the declared field MUST be removed from the record's stored leftover map so it is not stored twice.
+
+#### REQ: leftover-map-storage
+
+All fields of a stored record that are not declared columns MUST be retained in a parallel leftover store — a `[]map[string]any` (one map per row) indexed by the same per-row slot used by the declared columns. A record with only declared fields stores an empty (or nil) leftover map at its slot; a record with only undeclared fields stores all of them in the leftover map.
+
+#### REQ: shared-slot-across-columns-and-leftover
+
+The declared-column slices and the leftover-map slice MUST share one per-row slot index, and tombstone delete, slot reuse, and compaction MUST move (or free) a row's declared-column cells and its leftover map together so they never desynchronize.
+
+### Reading and querying
+
+#### REQ: read-merges-declared-and-leftover
+
+`Get` and query reassembly MUST reconstruct each record as a `map[string]any` by merging the declared columns' slot values with that slot's leftover map, producing a record equal to what was written. A declared column and a leftover field MUST NOT both supply the same key; the merged record MUST contain each original field exactly once.
+
+#### REQ: where-on-declared-uses-strategy
+
+An equality `WHERE` predicate on a **declared** column MUST use that column's `ColumnStrategy` (default typed-slice strategy, or an external one) to select candidate slots, exactly as `columnar-storage` does. An equality `WHERE` predicate on an **undeclared** (leftover-map) field MUST fall back to scanning the leftover maps. In both cases the result MUST be identical to what the Serialized engine returns for the same `map[string]any` data and query.
+
+### Inherited columnar behavior
+
+#### REQ: inherits-fidelity-and-parity
+
+Mixed-mode collections MUST inherit `columnar-storage`'s write fidelity and behavioral parity: declared scalar columns are stored by direct assignment and declared reference-bearing columns are deep-copied (subject to the existing fidelity opt-out); the leftover map's values are deep-copied on write under the faithful default so post-write caller mutation does not affect stored data; and `Set`/`Insert`/`Delete`/`Update` present the same observable outcomes (overwrite, insert-duplicate error, not-found) as the Serialized engine for the same `map[string]any` data.
+
+## Acceptance Criteria
+
+### AC: mixed-mode-requires-declared-column (verifies REQ:mixed-mode-selection, REQ:declared-column-option)
+
+**Given** a `map[string]any` collection selected with `WithColumnarStorage` and one declared column, and separately a `map[string]any` collection selected with `WithColumnarStorage` and no declared column
+**When** each database is constructed/used
+**Then** the first uses the mixed-mode columnar engine successfully, and the second fails with a descriptive error stating columns must be declared for a map-backed columnar collection.
+
+### AC: declared-value-wrong-type-errors (verifies REQ:declared-value-type-enforced)
+
+**Given** a mixed-mode collection declaring column `age` as an `int`
+**When** a record is written whose `age` value is a clearly-incompatible type (e.g. the string `"old"`)
+**Then** the write returns a descriptive error, and no record is stored for that id (the value is neither dropped nor coerced).
+
+### AC: declared-field-removed-from-leftover (verifies REQ:declared-columns-typed-slices)
+
+**Given** a mixed-mode collection declaring column `age` (an `int`) over records that also carry undeclared fields `name` and `email`
+**When** a record `{age, name, email}` is stored and the engine's storage is inspected
+**Then** `age` is held in a typed `[]int` column at the record's slot and is absent from that slot's leftover map, while `name` and `email` remain in the leftover map.
+
+### AC: leftover-holds-undeclared-fields (verifies REQ:leftover-map-storage)
+
+**Given** a mixed-mode collection declaring only `age`
+**When** records with varying undeclared fields are stored (one with `{age, name}`, one with `{age}` only, one with `{age, city, note}`)
+**Then** each slot's leftover map contains exactly that record's undeclared fields (empty/nil for the `{age}`-only record), indexed by the same slot as its `age` value.
+
+### AC: slot-stays-synced-through-delete-and-compaction (verifies REQ:shared-slot-across-columns-and-leftover)
+
+**Given** a mixed-mode collection with several records and enough deletions to trigger compaction
+**When** records are deleted (freeing slots, later reused) and compaction runs
+**Then** every surviving record's declared-column value and its leftover map remain paired at the same slot, and every record reads back with its correct declared and undeclared fields.
+
+### AC: read-reconstructs-full-record (verifies REQ:read-merges-declared-and-leftover)
+
+**Given** a mixed-mode collection declaring `age` over records carrying `age`, `name`, and `email`
+**When** a record is fetched via `Get` and via a query
+**Then** the reconstructed `map[string]any` equals the originally written record (all of `age`, `name`, `email` present exactly once), and the merge never duplicates or drops a key.
+
+### AC: where-on-declared-column-accelerated (verifies REQ:where-on-declared-uses-strategy)
+
+**Given** a mixed-mode collection declaring `age`, with a custom test `ColumnStrategy` on `age` that records when its equality read-side is invoked, and an equivalent Serialized collection over the same map data
+**When** an equality query `age == N` runs against the mixed-mode collection
+**Then** the declared column's strategy is consulted to select candidates, and the result rows are identical in content and order to the Serialized collection's result for the same query.
+
+### AC: where-on-leftover-field-scans (verifies REQ:where-on-declared-uses-strategy)
+
+**Given** a mixed-mode collection declaring `age` (so `city` is an undeclared leftover field), and an equivalent Serialized collection over the same map data
+**When** an equality query `city == "X"` runs against the mixed-mode collection
+**Then** the engine falls back to scanning the leftover maps and returns rows identical in content and order to the Serialized collection's result.
+
+### AC: mixed-mode-parity-and-fidelity (verifies REQ:inherits-fidelity-and-parity)
+
+**Given** a faithful mixed-mode collection declaring a column over `map[string]any` records that include a declared reference-bearing value and an undeclared reference-bearing value
+**When** a record is written, the caller mutates both the declared and the undeclared field after the write, and the same `Set`/`Insert`-duplicate/`Get`-absent operations are run against a Serialized collection
+**Then** a subsequent read of the mixed-mode record is unaffected by the post-write mutation, and the operation outcomes match the Serialized engine's.
+
+## Architecture & Components
+
+- **Mixed-mode `columnarEngine` path (extended).** The existing `columnarEngine` gains a map-backed construction path: instead of reflecting over a struct `T`, it builds its typed columns from the declared-column options, and adds a `leftover []map[string]any` slice indexed by the same slot vector (`live`/`slotToID`/`idToSlot`/`freeList`). The struct-typed path is unchanged.
+- **Declared-column option (new).** A `ColumnOption` (e.g. a `WithDeclaredColumn`-style option carrying name + element type) records declared columns on the existing `columnarConfig`. For a struct collection these are redundant with reflected fields; for a map collection they are the column set. The exact signature (generic `[T]` vs sample-value vs type token) is an implementation detail (see Open Questions).
+- **Write split.** On write, the engine partitions the record map into declared keys (→ typed column slices, via the existing hybrid scalar/ref-bearing write) and the remaining keys (→ a deep-copied leftover map at the slot under the faithful default). Insert/duplicate/not-found behavior is shared with the struct path.
+- **Read merge.** Reassembly builds `map[string]any` by copying the slot's leftover map and overlaying each declared column's slot value; the `map[string]any` view feeds the existing WHERE/GROUP BY/ORDER BY/projection/join code unchanged, and the typed-materialization path returns the merged map.
+- **WHERE routing.** The candidate-row path consults a declared column's `ColumnStrategy` when the predicate targets a declared column; a predicate on a leftover field reports "no opinion" so the existing scan fall-back applies over the merged rows.
+
+## Data Flow
+
+Write (map record at id): resolve slot → for each declared column, hybrid-write its value into the typed slice (removing the key from the remainder) → deep-copy the remaining keys into `leftover[slot]` (faithful default) → mark slot live, update declared columns' strategies. Read (`Get`/query): id → slot → merged map = copy of `leftover[slot]` overlaid with each declared column's slot value. Query: candidate slots from a declared column's strategy when the equality predicate targets it, else full live-slot scan; then reassemble merged rows and apply the existing filter/group/order/projection. Delete/compaction: free or relocate the slot's declared-column cells and its `leftover[slot]` together.
+
+## Error Handling & Failure Modes
+
+- `WithColumnarStorage` on a `map[string]any` collection with no declared column → descriptive error (`REQ:mixed-mode-selection`).
+- A written value for a declared column that cannot be stored as the declared element type → descriptive write error, nothing stored for that record (`REQ:declared-value-type-enforced`).
+- `Insert` on an existing id → already-exists error; `Get` on an absent id → not-found — matching the Serialized engine (`REQ:inherits-fidelity-and-parity`).
+- A query predicate on an undeclared field is not an error — it is the defined leftover-map scan fall-back (`REQ:where-on-declared-uses-strategy`).
+
+## Testing Strategy
+
+Table tests plus a `-race` interleaving, mirroring `columnar-storage`'s suite but over `map[string]any` data: mixed-mode selection (declared ok / no-declared error); declared field removed from leftover while undeclared fields remain; leftover holds exactly the undeclared fields (including empty); slot/leftover stay paired through delete, slot reuse, and compaction; read reconstructs the full record with no duplicate/dropped keys; WHERE on a declared column consults its strategy and matches Serialized; WHERE on a leftover field scans and matches Serialized; fidelity (declared + leftover ref-bearing values isolated after write) and behavioral parity with Serialized. `dalgo2memory` MUST remain at 100% statement coverage, and the mixed-mode engine MUST be clean under `go test -race`. A test-only external `ColumnStrategy` on a declared column proves the extension surface still works in mixed mode.
+
+## Rehearse Integration
+
+All ACs are exercisable through pure Go — `dalgo2memory` operations and queries over in-memory `map[string]any` collections, a parallel Serialized collection for equality comparison, a test-only `ColumnStrategy`, and a `-race` interleaving — so they map directly to table/`-race` tests (see `## Testing Strategy`). Per-AC Rehearse stub files are deferred to the Plan, where each AC becomes a concrete `*_test.go` case.
+
+## Out of Scope
+
+- **Inferring columns from observed data** — columns for a map-backed collection are explicitly declared; no automatic promotion of frequently-seen keys to columns.
+- **Range/inequality/composite read-side acceleration** — inherited equality-only limit from `columnar-storage`; leftover-field and non-equality predicates scan.
+- **Multi-predicate (`AND`/`OR`) `WHERE`** — unchanged from `columnar-storage`; only the single supported equality predicate is wired.
+- **Struct-typed collections** — already covered by `columnar-storage`; this Feature only adds the map-backed path (declared options on a struct collection are accepted but redundant).
+- **Per-collection two-phase locking / rollback, persistence** — unchanged; single global write lock, in-memory.
+
+## Assumption Carryover
+
+From the source Idea `dalgo2memory-storage-engines`:
+
+- **Resolved (Should):** mixed-mode `map[string]any` storage — declared columns in typed slices + undeclared fields in a parallel `[]map[string]any` — is realized here, exactly as the Idea's column-set decision described.
+- **Carried (Must):** the slot/tombstone/compaction model and single-global-lock concurrency from `columnar-storage` extend to the leftover slice — `REQ:shared-slot-across-columns-and-leftover` (validated under `-race`).
+- **Carried (Must):** the exported `ColumnStrategy` seam keeps working for declared columns in mixed mode — `REQ:where-on-declared-uses-strategy`.
+- **Carried (Should):** fidelity is faithful by default with the existing opt-out — `REQ:inherits-fidelity-and-parity`.
+
+## Open Questions
+
+- The exact declared-column option signature: generic `WithDeclaredColumn[T](name)` yielding `[]T`, a sample/zero-value form `WithDeclaredColumn(name, zero any)`, or a reflect.Type token — a Plan-time choice; all satisfy `REQ:declared-column-option`.
+- Whether JSON-number normalization (declared `int` vs a value arriving as `float64` from a decoded map) is coerced or rejected — settled at implementation against the declared-type contract; `AC:declared-value-wrong-type-errors` pins only the clearly-incompatible (string-into-int) boundary.
+- Duplicate declaration of the same column name: the intended resolution is last-declaration-wins, but the exact policy (last-wins vs. construction error) is a Plan-time decision and is not pinned by an AC here.
+
+---
+*This document follows the https://specscore.md/feature-specification*

--- a/spec/features/columnar-storage/README.md
+++ b/spec/features/columnar-storage/README.md
@@ -1,0 +1,252 @@
+---
+format: https://specscore.md/feature-specification
+status: Approved
+---
+
+# Feature: Columnar storage engine (dalgo2memory)
+
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/columnar-storage?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/columnar-storage?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/columnar-storage?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/columnar-storage?op=request-change) |
+**Status:** Approved
+**Date:** 2026-06-06
+**Owner:** alex
+**Source Ideas:** dalgo2memory-storage-engines
+**Supersedes:** —
+**Grade:** A
+
+## Summary
+
+An opt-in columnar storage engine for typed `dalgo2memory` collections. Each column of the record type is stored in its own strongly-typed slice over a stable per-row slot model (tombstone + bulk compaction). The engine exposes a pluggable, exported `ColumnStrategy` per column — with an equality read-side wired into `WHERE` — so an out-of-core package (e.g. a bitmap index) can accelerate filtering later without `dalgo2memory` taking a dependency. Observable results for the operations and queries the adapter supports are identical to the Serialized engine; only the in-memory representation differs.
+
+## Problem
+
+The Serialized engine stores every record as opaque bytes and `json.Unmarshal`s on every read and every row of a scan. For DataTug analytics and larger in-memory datasets, equality `WHERE` filtering over many rows is the hot path (and multi-field filtering is the eventual goal once the query engine supports it), and a row-of-bytes layout makes per-field access expensive and gives an index nowhere to attach. A columnar layout (one typed slice per field) is the representation that makes field access cheap and gives a per-column index a natural home. This Feature delivers that engine for typed collections, behind the storage-engine seam, while keeping the adapter's observable behavior and its single-writer concurrency model unchanged.
+
+## Dependencies
+
+- storage-engine-seam
+- serialized-storage
+
+## Behavior
+
+### Selecting the columnar engine
+
+#### REQ: columnar-selection
+
+A `WithColumnarStorage(...ColumnOption)` `CollectionOption` MUST be provided that selects the columnar engine for a schema-registered `WithCollection[T]` collection. Selecting columnar storage for a collection that is not a schema-registered typed collection MUST fail with a descriptive error. (`map[string]any` mixed-mode columnar collections are out of scope for this Feature — see Out of Scope.)
+
+### Columnar layout
+
+#### REQ: typed-column-slices
+
+The engine MUST derive one column per JSON-serializable field of the record type `T` and store each column's values in a slice typed to that field's Go type (e.g. `[]int`, `[]string`, `[]time.Time`). A column MUST fall back to an untyped `[]any` slice only when the field's type is an interface or otherwise has no single concrete element type. All of a collection's column slices MUST be indexed by a single shared per-row slot.
+
+#### REQ: stable-row-slot
+
+Each stored record MUST occupy one slot index shared across every column slice, and the record's id MUST map to that slot. A live record's slot MUST remain stable for the record's lifetime (until deletion or compaction), so all of a record's per-column values are always found at the same index.
+
+### Write semantics and fidelity
+
+#### REQ: hybrid-write-fidelity
+
+On write, a scalar/value-typed column (numbers, strings, bools, and other reference-free values) MUST be stored by direct assignment into its typed slice, and a reference-bearing column (struct, slice, map, or pointer values) MUST be deep-copied via a serialization round-trip before storage, so that — by default — stored data shares no references with the caller's value. Mutating the caller's value after a write MUST NOT affect stored data.
+
+#### REQ: fidelity-opt-out
+
+A schema-wide option and a per-collection option MUST be provided to disable ref-breaking. When ref-breaking is disabled for a collection, reference-bearing column values MAY be stored without the round-trip (trading fidelity for write speed). The default MUST be faithful (ref-breaking on), and a per-collection setting MUST override the schema-wide setting.
+
+#### REQ: behavioral-parity-with-serialized
+
+For the operations the adapter supports, the columnar engine MUST present the same observable semantics as the Serialized engine: `Set` overwrites; `Insert` on an existing id errors and does not overwrite; `Get`/`Update` on an absent id return not-found; an `Update` naming a field not defined on `T` is rejected with a descriptive error. Differences between engines MUST be representational only, never behavioral.
+
+### Deletes and compaction
+
+#### REQ: tombstone-delete
+
+`Delete` MUST mark the record's slot dead (tombstone) and make it available for reuse by a later insert, while keeping every other record's slot stable. A tombstoned slot MUST NOT appear in `Get`, `Exists`, or any query result.
+
+#### REQ: compaction
+
+When the fraction of dead slots crosses a threshold, the engine MUST compact — reclaiming dead slots — while preserving every live record and its reassembled values. Compaction MUST run under the existing global write lock and MUST NOT be observable to readers as partial or inconsistent state.
+
+### Read and query
+
+#### REQ: row-reassembly
+
+For `Get` and query execution, the engine MUST reassemble each live row from its per-column slot values into the shapes the adapter consumes: a `map[string]any` field view (for WHERE/GROUP BY/ORDER BY/projection) and a typed materialization into `Get`'s record or the query's `IntoRecord`/factory target. Reassembled rows MUST share no references with one another, nor with stored data when the collection is faithful.
+
+#### REQ: query-results-identical
+
+For every query the adapter supports (single-source and join, with the currently supported equality `WHERE`, plus projection/GROUP BY/ORDER BY/LIMIT), a columnar collection MUST return results identical to those an equivalent Serialized collection returns for the same data and query.
+
+### The ColumnStrategy seam
+
+#### REQ: column-strategy-interface
+
+The engine MUST define and export a `ColumnStrategy` interface with a write side (set or clear a column's value at a given slot) and an equality read side (given a value, return the set of live slots whose column equals it, or signal "no opinion"). A per-column `ColumnOption` MUST supply the strategy for a named column; columns without an explicit option use the default strategy. Equality on the read side is defined as the adapter's existing value equality (Go `==` on the comparable decoded value, as in `matchesWhere`); the read side is not required to answer for non-comparable column values and MAY signal "no opinion" for them.
+
+#### REQ: default-strategy-equality
+
+The default per-column strategy MUST be the typed-slice strategy. For a column whose element type is comparable (Go `==` is valid — numbers, strings, bools, and other comparable values), it MUST answer the equality read side by scanning its slice and returning the matching live slots, using the same value equality the adapter's existing WHERE uses. For a column whose element type is not comparable (e.g. an `[]any` fallback column holding slices/maps, or a struct containing them), the default strategy MAY return "no opinion", deferring to the scanning fall-back.
+
+#### REQ: where-equality-uses-strategy
+
+For the equality `WHERE` predicate the adapter currently supports — a single `field == value` comparison — the query engine MUST consult the target column's `ColumnStrategy`: when the strategy returns a slot set, the engine MUST use it to select candidate rows rather than scanning all rows; a "no opinion" MUST fall back to scanning. The read side MUST return a set of slots so that, if and when the adapter grows multi-predicate (`AND`) `WHERE`, the engine can intersect per-predicate sets — but this Feature wires only the single supported predicate and MUST NOT broaden predicate support. The selected result MUST be identical to the Serialized engine's result for the same query.
+
+#### REQ: external-strategy-pluggable
+
+The `ColumnStrategy` interface and the per-column option MUST be exported so a separate package (e.g. `bitmap4dalgo2memory`) can provide a column strategy that plugs into `WithColumnarStorage`, and `dalgo2memory` MUST NOT import or depend on any such extension package.
+
+### Concurrency
+
+#### REQ: single-lock-race-free
+
+Columnar storage MUST operate under the existing single global write lock with no additional locking. Slot allocation, writes, updates, tombstones, compaction, and concurrent reads MUST be race-free, verified with `go test -race`.
+
+## Acceptance Criteria
+
+### AC: columnar-requires-typed-collection (verifies REQ:columnar-selection)
+
+**Given** a schema-registered `WithCollection[T]` collection selected with `WithColumnarStorage()` and, separately, a schemaless/undefined collection selected with `WithColumnarStorage()`
+**When** each database is constructed/used
+**Then** the typed collection uses the columnar engine successfully, and the schemaless selection fails with a descriptive error.
+
+### AC: columns-are-typed-slices (verifies REQ:typed-column-slices)
+
+**Given** a columnar collection for a type `T` with `int`, `string`, and `bool` fields plus one `interface{}` field
+**When** records are stored and the engine's column storage is inspected
+**Then** the `int`/`string`/`bool` columns are slices of those concrete types and the `interface{}` field's column is an `[]any` slice.
+
+### AC: slot-stable-across-columns (verifies REQ:stable-row-slot)
+
+**Given** several records stored in a columnar collection
+**When** any record is read back
+**Then** all of that record's field values are drawn from the same slot index across the column slices, and a record's slot does not change when other records are written.
+
+### AC: write-breaks-refs-by-default (verifies REQ:hybrid-write-fidelity)
+
+**Given** a faithful columnar collection whose type has a scalar field and a reference-bearing field (e.g. a nested struct or slice)
+**When** a record is written and the caller then mutates the reference-bearing field
+**Then** a subsequent read returns the value as it was at write time, unaffected by the mutation.
+
+### AC: fidelity-opt-out-toggles-ref-breaking (verifies REQ:fidelity-opt-out)
+
+**Given** the same type used in (a) a default collection, (b) a collection with ref-breaking disabled per-collection, and (c) a database with ref-breaking disabled schema-wide but one collection re-enabling it
+**When** a reference-bearing value is written and then mutated by the caller
+**Then** the faithful collections (a and the re-enabled c collection) are unaffected, the opt-out collection (b) reflects the mutation, and the per-collection setting overrides the schema-wide default.
+
+### AC: parity-with-serialized-ops (verifies REQ:behavioral-parity-with-serialized)
+
+**Given** identical data in a columnar and a Serialized collection of the same type
+**When** `Set`/`Insert`-duplicate/`Get`-absent/`Update`-absent and an `Update` naming an undefined field are exercised on each
+**Then** both engines produce the same outcomes (overwrite, already-exists error, not-found, not-found, undefined-field rejection).
+
+### AC: delete-tombstones-and-hides (verifies REQ:tombstone-delete)
+
+**Given** a columnar collection with records `a`, `b`, `c`
+**When** `b` is deleted
+**Then** `Get`/`Exists` for `b` report absence and queries omit `b`, while `a` and `c` remain readable at unchanged slots, and a later insert may reuse `b`'s freed slot.
+
+### AC: compaction-preserves-live-records (verifies REQ:compaction)
+
+**Given** a columnar collection with enough deletions to cross the compaction threshold
+**When** compaction runs
+**Then** every live record is still readable with its correct values and query results are unchanged, and dead slots have been reclaimed.
+
+### AC: get-and-query-reassemble (verifies REQ:row-reassembly)
+
+**Given** a columnar collection of typed records
+**When** a record is fetched via `Get` into a typed target and a query materializes rows into `IntoRecord` targets
+**Then** each reassembled record equals the stored data, and two reassembled rows share no references.
+
+### AC: columnar-query-matches-serialized (verifies REQ:query-results-identical)
+
+**Given** identical data in a columnar and a Serialized collection
+**When** the same query — the supported single equality `WHERE` predicate, plus a projection and an `ORDER BY`/`LIMIT` — runs against each
+**Then** the result rows are identical in content and order.
+
+### AC: strategy-interface-exported (verifies REQ:column-strategy-interface, REQ:external-strategy-pluggable)
+
+**Given** the `dalgo2memory` package
+**When** its exported surface is inspected
+**Then** a `ColumnStrategy` interface with a write side and an equality read-side is exported, a per-column option accepts a strategy, and a test-only external strategy can be supplied via `WithColumnarStorage` without `dalgo2memory` importing the strategy's package.
+
+### AC: default-strategy-scans-column (verifies REQ:default-strategy-equality)
+
+**Given** a columnar collection using the default strategy on a `string` column
+**When** the strategy's equality read-side is queried for a value present in some rows
+**Then** it returns exactly the live slots whose column equals that value (and does not return "no opinion").
+
+### AC: where-uses-strategy (verifies REQ:where-equality-uses-strategy)
+
+**Given** a columnar collection and a custom test strategy on the filtered column that records when its equality read-side is invoked
+**When** a query with the supported single `field == value` predicate runs
+**Then** the engine consults the column's strategy and uses the returned slot set to select candidates (the custom strategy records the invocation) rather than scanning all rows, and the result is identical to the Serialized engine's result for the same query.
+
+### AC: where-falls-back-on-no-opinion (verifies REQ:where-equality-uses-strategy, REQ:default-strategy-equality)
+
+**Given** a columnar collection whose target column's strategy returns "no opinion" for the predicate (e.g. a custom strategy, or the default strategy on a non-comparable `[]any` column)
+**When** an equality query on that column runs
+**Then** the engine falls back to scanning and still returns the correct result, identical to the Serialized engine.
+
+### AC: columnar-passes-race (verifies REQ:single-lock-race-free)
+
+**Given** the columnar engine under the existing global write lock
+**When** the test suite runs with `-race`, interleaving reads with writes, deletes, and a compaction
+**Then** no data race is reported and results remain correct.
+
+## Architecture & Components
+
+- **`columnarEngine` (new, internal).** Implements the seam's `storageEngine` interface. Holds: an ordered set of typed column containers (one per `T` field), an `id ↔ slot` mapping, a free-list of tombstoned slots, and a live/dead marker per slot. Column containers are built by reflection over `T`'s fields (concrete typed slice, `[]any` fallback).
+- **`ColumnStrategy` interface + default typed-slice strategy (new, exported).** Write side records/clears a value at a slot; equality read side returns matching live slots or "no opinion". The default strategy wraps the typed slice and scans it. `WithColumnarStorage(...ColumnOption)` and a per-column option (carrying a strategy constructor) are exported so external packages can plug in.
+- **Write path.** Marshal-free for scalar columns (direct slot assignment); serialization round-trip for reference-bearing columns when faithful (skipped when the opt-out is set). Insert/duplicate/not-found/undefined-field behavior mirrors the Serialized engine.
+- **Read/query path.** `row-reassembly` builds the `map[string]any` view and typed targets from slot values, reusing the existing WHERE/GROUP BY/ORDER BY/projection/join logic; for the supported single equality `WHERE` predicate, a candidate-selection step consults the column's strategy and uses its slot set (generalizing to intersection if multi-predicate WHERE is later added) before reassembly.
+- **Compaction.** Triggered by a dead-slot threshold under the write lock; rebuilds the slot mapping and column slices, updating the free-list. The default strategy is rebuilt from the compacted slices; an external strategy is notified to rebuild via its write side.
+
+## Data Flow
+
+Write: resolve slot (reuse a free slot or append) → per column, direct-assign (scalar) or round-trip-then-assign (ref-bearing, when faithful) → mark slot live → update each column's strategy write side. Read (`Get`): id → slot → reassemble typed target from column values. Query: candidate slots = the equality predicate's column-strategy matching slots (or full live-slot scan on "no opinion"; generalizes to intersection across predicates if multi-predicate WHERE is later supported) → reassemble `map[string]any` for filter/group/order/projection and typed targets for results. Delete: id → slot → mark dead, push to free-list, clear strategies. Compaction (threshold crossed): copy live slots down, rebuild mapping/slices/strategies.
+
+## Error Handling & Failure Modes
+
+- `WithColumnarStorage` on a non-typed/unregistered collection → descriptive error (`REQ:columnar-selection`).
+- `Insert` on an existing id → already-exists error; `Get`/`Update` on an absent id → not-found; `Update` of an undefined field → descriptive error — all matching the Serialized engine (`REQ:behavioral-parity-with-serialized`).
+- A reference-bearing value that fails its serialization round-trip while faithful → descriptive error, nothing stored.
+- A column strategy returning "no opinion" is not an error — it is the defined fall-back to scanning (`REQ:where-equality-uses-strategy`).
+
+## Testing Strategy
+
+Table tests plus `-race` runs covering: columnar selection (typed ok / schemaless error); typed-slice columns with `[]any` fallback; slot stability; write ref-breaking and the schema-wide/per-collection opt-out matrix; behavioral parity with Serialized (insert-dup, not-found, undefined-field); tombstone hide + slot reuse; compaction preserving live records; reassembly equality and non-shared references; columnar-vs-Serialized query equality (the supported single equality predicate, projection, ORDER BY/LIMIT, join); exported `ColumnStrategy` with a test-only external strategy; default strategy scanning (comparable column) and "no opinion" on a non-comparable `[]any` column; WHERE consulting the strategy and falling back on "no opinion"; and a `-race` interleaving of reads/writes/deletes/compaction. `dalgo2memory` MUST remain at 100% statement coverage, and `var _ storageEngine = (*columnarEngine)(nil)` plus `var _ ColumnStrategy = (*typedSliceStrategy)(nil)` guard the interfaces.
+
+## Rehearse Integration
+
+All ACs are exercisable through pure Go — `dalgo2memory` operations and queries over in-memory typed collections, a parallel Serialized collection for equality comparison, a test-only `ColumnStrategy`, and a `-race` interleaving — so they map directly to table/`-race` tests (see `## Testing Strategy`). Per-AC Rehearse stub files are deferred to the Plan, where each AC becomes a concrete `*_test.go` case.
+
+## Out of Scope
+
+- **Mixed-mode `map[string]any` columnar storage** (explicitly declared typed columns with undeclared fields kept in a parallel `[]map[string]any`) — deferred to a separate follow-on Feature; this Feature covers typed `WithCollection[T]` collections only.
+- **Bitmap / roaring-bitmap indexing** — an out-of-core extension (`bitmap4dalgo2memory`) that plugs into the exported `ColumnStrategy`; not built here, only designed for.
+- **Multi-predicate (`AND`/`OR`) `WHERE`** — the adapter currently supports a single equality predicate on this path; this Feature wires the strategy for that predicate and does not broaden WHERE. The `ColumnStrategy` slot-set contract is shaped so intersection can be added when multi-predicate WHERE lands.
+- **Range/inequality/composite read-side acceleration** — the `ColumnStrategy` read side covers equality only; other predicates fall back to scanning.
+- **Per-collection two-phase locking and transactional rollback** — the single global write lock is retained (deferred per the source Idea).
+- **Broadening query-predicate support** beyond what the adapter already supports — columnar matches the Serialized engine's behavior, it does not extend it.
+- **Persistence/durability** — storage remains in-memory.
+
+## Assumption Carryover
+
+From the source Idea `dalgo2memory-storage-engines`:
+
+- **Carried (Must):** columnar slot/tombstone/compaction is correct and race-free under the single global write lock — `REQ:tombstone-delete`, `REQ:compaction`, `REQ:single-lock-race-free` (validated by `AC:columnar-passes-race`).
+- **Carried (Must):** columnar backs the full existing query surface with identical results — `REQ:row-reassembly`, `REQ:query-results-identical`.
+- **Carried (Must):** the exported `ColumnStrategy` is sufficient for an external package to back a column without a core dependency — `REQ:column-strategy-interface`, `REQ:external-strategy-pluggable`.
+- **Carried (Should):** strongly-typed slices per column (with `[]any` fallback) — `REQ:typed-column-slices`.
+- **Resolved:** fidelity is faithful by default with a schema-wide/per-collection opt-out, realized via the hybrid (scalar direct / ref-bearing round-trip) write — `REQ:hybrid-write-fidelity`, `REQ:fidelity-opt-out`.
+- **Deferred (Might):** a type-copy engine and bitmap extension — other work, not this Feature.
+
+## Open Questions
+
+- The compaction trigger: the exact dead-slot threshold and whether compaction runs inline on a write that crosses it or via a separate maintenance call — a Plan-time choice; both satisfy `REQ:compaction`.
+- The precise signatures of the `ColumnStrategy` interface (e.g. slot-set representation, how a strategy is notified to rebuild on compaction) — an implementation detail for the Plan.
+- The exact rule for when a field's column is typed vs `[]any` (e.g. named interface types, `json.RawMessage`) — refined at implementation against `T` reflection.
+
+---
+*This document follows the https://specscore.md/feature-specification*

--- a/spec/features/concurrency-capability/README.md
+++ b/spec/features/concurrency-capability/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Implemented
+---
+
 # Feature: Concurrency Capability
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/concurrency-capability?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/concurrency-capability?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/concurrency-capability?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/concurrency-capability?op=request-change) |

--- a/spec/features/dbschema/README.md
+++ b/spec/features/dbschema/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Implemented
+---
+
 # Feature: Schema Description Vocabulary & Read Capability (`dbschema`)
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema?op=request-change) |

--- a/spec/features/dbschema/collection-def/README.md
+++ b/spec/features/dbschema/collection-def/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Implemented
+---
+
 # Feature: dbschema CollectionDef
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/collection-def?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/collection-def?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/collection-def?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/collection-def?op=request-change) |

--- a/spec/features/dbschema/default-expr/README.md
+++ b/spec/features/dbschema/default-expr/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Implemented
+---
+
 # Feature: dbschema DefaultExpr (Sealed Interface)
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/default-expr?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/default-expr?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/default-expr?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/default-expr?op=request-change) |

--- a/spec/features/dbschema/errors/README.md
+++ b/spec/features/dbschema/errors/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Implemented
+---
+
 # Feature: dbschema NotSupportedError
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/errors?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/errors?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/errors?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/errors?op=request-change) |

--- a/spec/features/dbschema/field-def/README.md
+++ b/spec/features/dbschema/field-def/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Implemented
+---
+
 # Feature: dbschema FieldDef
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/field-def?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/field-def?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/field-def?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/field-def?op=request-change) |

--- a/spec/features/dbschema/index-def/README.md
+++ b/spec/features/dbschema/index-def/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Implemented
+---
+
 # Feature: dbschema IndexDef
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/index-def?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/index-def?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/index-def?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/index-def?op=request-change) |

--- a/spec/features/dbschema/schema-reader/README.md
+++ b/spec/features/dbschema/schema-reader/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Implemented
+---
+
 # Feature: dbschema SchemaReader (Introspection Capability)
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/schema-reader?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/schema-reader?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/schema-reader?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/schema-reader?op=request-change) |

--- a/spec/features/dbschema/types/README.md
+++ b/spec/features/dbschema/types/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Implemented
+---
+
 # Feature: dbschema Types (`Type`, `Precision`)
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/types?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/types?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/types?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/types?op=request-change) |

--- a/spec/features/ddl/README.md
+++ b/spec/features/ddl/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Implemented
+---
+
 # Feature: Schema Modification (DDL) Execution Surface (`ddl`)
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl?op=request-change) |

--- a/spec/features/ddl/alter-ops/README.md
+++ b/spec/features/ddl/alter-ops/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Implemented
+---
+
 # Feature: ddl AlterOp (Composable Alteration Operations)
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/alter-ops?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/alter-ops?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/alter-ops?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/alter-ops?op=request-change) |

--- a/spec/features/ddl/applier/README.md
+++ b/spec/features/ddl/applier/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Implemented
+---
+
 # Feature: ddl Applier (Visitor for AlterOp Dispatch)
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/applier?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/applier?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/applier?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/applier?op=request-change) |

--- a/spec/features/ddl/errors/README.md
+++ b/spec/features/ddl/errors/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Implemented
+---
+
 # Feature: ddl PartialSuccessError
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/errors?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/errors?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/errors?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/errors?op=request-change) |

--- a/spec/features/ddl/operations/README.md
+++ b/spec/features/ddl/operations/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Implemented
+---
+
 # Feature: ddl Top-Level Operations
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/operations?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/operations?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/operations?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/operations?op=request-change) |

--- a/spec/features/ddl/options/README.md
+++ b/spec/features/ddl/options/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Implemented
+---
+
 # Feature: ddl Options (`IfNotExists`, `IfExists`)
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/options?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/options?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/options?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/options?op=request-change) |

--- a/spec/features/ddl/schema-modifier/README.md
+++ b/spec/features/ddl/schema-modifier/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Implemented
+---
+
 # Feature: ddl SchemaModifier Interface
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/schema-modifier?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/schema-modifier?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/schema-modifier?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/schema-modifier?op=request-change) |

--- a/spec/features/ddl/transactional-ddl/README.md
+++ b/spec/features/ddl/transactional-ddl/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Implemented
+---
+
 # Feature: ddl TransactionalDDL Capability
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/transactional-ddl?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/transactional-ddl?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/transactional-ddl?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/transactional-ddl?op=request-change) |

--- a/spec/features/dtql/README.md
+++ b/spec/features/dtql/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Approved
+---
+
 # Feature: DTQL — YAML serialization of dal.StructuredQuery
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dtql?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dtql?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dtql?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dtql?op=request-change) |

--- a/spec/features/qualified-orderby-resolution/README.md
+++ b/spec/features/qualified-orderby-resolution/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Approved
+---
+
 # Feature: Source-qualified, multi-key ORDER BY resolution in dalgo2memory
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/qualified-orderby-resolution?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/qualified-orderby-resolution?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/qualified-orderby-resolution?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/qualified-orderby-resolution?op=request-change) |

--- a/spec/features/query-column-projection/README.md
+++ b/spec/features/query-column-projection/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: Column selection in the query builder, projected by dalgo2memory
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-column-projection?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-column-projection?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-column-projection?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-column-projection?op=request-change) |

--- a/spec/features/query-group-by-aggregation/README.md
+++ b/spec/features/query-group-by-aggregation/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
 # Feature: GROUP BY with aggregation in the query builder, executed by dalgo2memory
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-group-by-aggregation?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-group-by-aggregation?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-group-by-aggregation?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-group-by-aggregation?op=request-change) |

--- a/spec/features/query-joins/README.md
+++ b/spec/features/query-joins/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Approved
+---
+
 # Feature: First-class INNER/LEFT joins in dal's query model
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-joins?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-joins?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-joins?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/query-joins?op=request-change) |

--- a/spec/features/recordops/README.md
+++ b/spec/features/recordops/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Implemented
+---
+
 # Feature: `recordops` package
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops?op=request-change) |

--- a/spec/features/recordops/diff/README.md
+++ b/spec/features/recordops/diff/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Implemented
+---
+
 # Feature: `recordops` — Diff
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops/diff?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops/diff?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops/diff?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops/diff?op=request-change) |

--- a/spec/features/recordset-computed-columns/README.md
+++ b/spec/features/recordset-computed-columns/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Approved
+---
+
 # Feature: Computed Columns in recordset (neutral evaluator contract)
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordset-computed-columns?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordset-computed-columns?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordset-computed-columns?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordset-computed-columns?op=request-change) |

--- a/spec/features/serialized-storage/README.md
+++ b/spec/features/serialized-storage/README.md
@@ -1,0 +1,180 @@
+---
+format: https://specscore.md/feature-specification
+status: Approved
+---
+
+# Feature: Serialized storage engine (dalgo2memory default)
+
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/serialized-storage?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/serialized-storage?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/serialized-storage?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/serialized-storage?op=request-change) |
+**Status:** Approved
+**Date:** 2026-06-06
+**Owner:** alex
+**Source Ideas:** dalgo2memory-storage-engines
+**Supersedes:** —
+**Grade:** A
+
+## Summary
+
+Formalizes `dalgo2memory`'s existing storage behavior as the **Serialized** engine: each record is kept as serialized JSON bytes per collection, and reads decode those bytes. This engine is the seam's default and the implementation behind `WithSerializedStorage()`. Its defining property is full serialization fidelity — stored data shares no references with caller values, non-serializable values are rejected, and unknown fields are rejected for schema-typed collections.
+
+## Problem
+
+The behavior `dalgo2memory` already has — store each record as JSON bytes, decode on read — is currently spread across `session.save`/`Get`/`UpdateRecord` and the query paths with no name and no stated contract. Once the storage-engine seam exists, that behavior must become a concrete engine with an explicit, testable contract so that (a) it can be selected/defaulted through the seam, (b) other engines (Columnar) have a reference contract to match for the parts that must stay identical, and (c) the serialization-fidelity guarantees that make `dalgo2memory` a faithful test double are pinned down rather than incidental.
+
+## Behavior
+
+### Representation and fidelity
+
+#### REQ: json-byte-representation
+
+The Serialized engine MUST store each record as a serialized byte buffer keyed by record id within its collection, and reconstruct records by decoding those bytes. The serialization format for this MVP is JSON (`encoding/json`); the engine name is format-agnostic so the serializer may change later without renaming.
+
+#### REQ: ref-breaking-fidelity
+
+Because records are stored as bytes and decoded afresh on every read, a stored record MUST share no references with the value supplied to a write or returned by a prior read. Mutating a caller's struct after writing it, or mutating a value obtained from one read, MUST NOT affect stored data or any subsequent read.
+
+#### REQ: reject-non-serializable
+
+A write whose data cannot be serialized (e.g. it contains a value the serializer cannot encode) MUST fail with a descriptive error, set that error on the record, and MUST NOT store partial or corrupt data for that id.
+
+#### REQ: unknown-field-rejection
+
+For a collection registered with a record type, the Serialized engine MUST reject a write or update whose serialized data contains fields not defined on that type, returning a descriptive error that names the collection. A schemaless collection (no registered type) MUST perform no unknown-field check.
+
+### Write semantics
+
+#### REQ: insert-vs-set
+
+`Set` MUST create-or-overwrite the record at its id. `Insert` MUST fail with a descriptive "already exists" error when a record with that id is already present, and MUST NOT overwrite it. Both MUST serialize and (for schema-typed collections) run the unknown-field check before storing, so a rejected write leaves storage unchanged.
+
+### Read and query
+
+#### REQ: get-decodes-or-not-found
+
+`Get`/`GetMulti` on a present id MUST decode the stored bytes into the caller-provided record's data. `Get` on an absent id MUST return a not-found error and set it on the record. `Exists` MUST report presence/absence by id without decoding.
+
+#### REQ: query-row-views
+
+For query execution the Serialized engine MUST expose each stored row both as a decoded `map[string]any` field view (consumed by WHERE/GROUP BY/ORDER BY/projection) and as a typed materialization into the query's `IntoRecord`/factory target, in both cases by decoding the stored bytes. Distinct decoded rows MUST NOT share references.
+
+### Update
+
+#### REQ: update-read-modify-write
+
+`Update`/`UpdateRecord` MUST read the stored record, apply the given field updates to its decoded data, re-run the unknown-field check for schema-typed collections, and store the re-serialized result. `Update` on an absent id MUST return a not-found error and store nothing.
+
+### Role within the seam
+
+#### REQ: default-and-schemaless
+
+The Serialized engine MUST be the concrete engine the seam resolves to for the default (unselected) case and for an explicit `WithSerializedStorage()`, and MUST support both schema-registered and schemaless collections. The engine is always fully faithful: fidelity is inherent to the byte representation and is never disabled here — any fidelity opt-out belongs to the Columnar engine, not this one.
+
+## Acceptance Criteria
+
+### AC: stored-as-decodable-bytes (verifies REQ:json-byte-representation)
+
+**Given** a Serialized-backed collection
+**When** a record is `Set` and then `Get`
+**Then** the retrieved data equals the written data, having been reconstructed by decoding the stored serialized bytes (the stored form is a byte buffer, not the original value).
+
+### AC: mutation-after-write-isolated (verifies REQ:ref-breaking-fidelity)
+
+**Given** a record written via `Set` whose data includes a nested struct or slice
+**When** the caller mutates that nested field after the `Set` returns, then the record is `Get` into a fresh target
+**Then** the retrieved data reflects the value as it was at write time, unaffected by the post-write mutation.
+
+### AC: two-reads-independent (verifies REQ:ref-breaking-fidelity)
+
+**Given** one stored record
+**When** it is read into two separate targets and one target's nested field is mutated
+**Then** the other target is unchanged.
+
+### AC: non-serializable-write-errors (verifies REQ:reject-non-serializable)
+
+**Given** a Serialized-backed collection
+**When** a record whose data contains a non-serializable value is written
+**Then** the write returns a descriptive error, the error is set on the record, and no entry for that id exists afterward.
+
+### AC: unknown-field-rejected-when-typed (verifies REQ:unknown-field-rejection)
+
+**Given** a collection registered with record type `T`
+**When** a write carries a field not defined on `T`
+**Then** it is rejected with a descriptive error naming the collection; the same data written to a schemaless collection succeeds.
+
+### AC: insert-duplicate-errors (verifies REQ:insert-vs-set)
+
+**Given** a record already present at an id
+**When** `Insert` is called for that id
+**Then** it returns an "already exists" error and the existing record is unchanged, whereas `Set` for that id overwrites successfully.
+
+### AC: get-absent-not-found (verifies REQ:get-decodes-or-not-found)
+
+**Given** a Serialized-backed collection with no record at id `x`
+**When** `Get` is called for `x`
+**Then** it returns a not-found error set on the record, while `Exists` for `x` reports `false`.
+
+### AC: query-decodes-rows (verifies REQ:query-row-views)
+
+**Given** several stored records
+**When** a structured query with an equality filter runs and also materializes into a typed `IntoRecord` target
+**Then** the engine yields decoded `map[string]any` rows for filtering and decoded typed records for results, and two result records do not share references.
+
+### AC: update-applies-and-revalidates (verifies REQ:update-read-modify-write)
+
+**Given** a stored record in a schema-typed collection
+**When** `Update` applies a field change defined on the type, and separately an update introducing an undefined field is attempted
+**Then** the defined-field update is read-modified-written and persisted, the undefined-field update is rejected with a descriptive error, and `Update` on an absent id returns not-found and stores nothing.
+
+### AC: serialized-is-default-and-schemaless-capable (verifies REQ:default-and-schemaless)
+
+**Given** a database with an unregistered collection and another collection selected via `WithSerializedStorage()`
+**When** records are written to and read from both
+**Then** both operate through the Serialized engine and succeed, demonstrating support for schemaless and schema-typed collections respectively.
+
+## Architecture & Components
+
+- **`serializedEngine` (new, internal).** Implements the `storageEngine` interface from the seam Feature. Holds the per-collection `map[id][]byte`. Encapsulates today's `json.Marshal` (write), `json.Unmarshal` (read/materialize), `checkUnknownFields` (schema-typed validation), the insert-duplicate guard, and the not-found error — i.e. the logic currently inline in `session.save`/`Get`/`UpdateRecord` and the query loops moves into this engine unchanged in behavior.
+- **Decoded views for queries.** The engine's row enumeration unmarshals each stored buffer into a `map[string]any` for the existing filter/group/order/projection code, and offers a materialize-into-target that unmarshals into the query's `IntoRecord`/factory value — replacing the current direct `json.Unmarshal(row.raw, …)` calls with engine-owned ones.
+- **Schema awareness.** When the collection has a registered record factory, writes/updates run the unknown-field check; without one, they don't — preserving today's schemaless behavior.
+
+## Data Flow
+
+Write: caller data → `json.Marshal` → (schema-typed: `checkUnknownFields`) → store bytes at id (Insert first checks absence). Read: bytes at id → `json.Unmarshal` into caller target (or not-found). Query: for each id, bytes → `json.Unmarshal` → `map[string]any` view (+ typed materialize on demand). Update: bytes → decode → apply field updates → re-validate (schema-typed) → re-`json.Marshal` → store.
+
+## Error Handling & Failure Modes
+
+- Non-serializable write → marshal error, set on record, nothing stored (`REQ:reject-non-serializable`).
+- Unknown field on a schema-typed collection → descriptive error naming the collection; nothing stored (`REQ:unknown-field-rejection`).
+- `Insert` on an existing id → "already exists" error; existing record untouched (`REQ:insert-vs-set`).
+- `Get`/`Update` on an absent id → not-found error; for `Get` it is set on the record; `Update` stores nothing (`REQ:get-decodes-or-not-found`, `REQ:update-read-modify-write`).
+
+## Testing Strategy
+
+Table tests covering: byte round-trip equality; post-write mutation isolation and two-read independence (fidelity); non-serializable rejection with no residual entry; unknown-field rejection on typed vs acceptance on schemaless; insert-duplicate vs set-overwrite; get/exists on absent id; equality-query decoding with typed materialization and non-shared results; update read-modify-write with re-validation and absent-id not-found. These largely formalize existing `dalgo2memory` tests against the named engine. `dalgo2memory` MUST remain at 100% statement coverage, and a compile-time assertion `var _ storageEngine = (*serializedEngine)(nil)` guards the interface conformance.
+
+## Rehearse Integration
+
+All ACs are exercisable through pure Go — `dalgo2memory` operations over in-memory collections, including a deliberately non-serializable value and a schema-typed-vs-schemaless pair — so they map directly to table tests (see `## Testing Strategy`). Per-AC Rehearse stub files are deferred to the Plan, where each AC becomes a concrete `*_test.go` case.
+
+## Out of Scope
+
+- The storage-engine interface, selection plumbing, and default routing — owned by the `storage-engine-seam` Feature; here the engine only implements that interface and states its behavioral contract.
+- The Columnar engine, typed slices, slot/tombstone/compaction, `ColumnStrategy`, and any fidelity opt-out — owned by the `columnar-storage` Feature. The Serialized engine is always faithful.
+- Any change to the concurrency model (single global write lock retained) or to query-predicate support (still single `Equal`); this Feature does not broaden either.
+- Persistence/durability — storage remains in-memory bytes.
+
+## Assumption Carryover
+
+From the source Idea `dalgo2memory-storage-engines`:
+
+- **Carried (Must):** fidelity (ref-breaking + reject-non-serializable + unknown-field rejection) is preserved by default — embodied by `REQ:ref-breaking-fidelity`, `REQ:reject-non-serializable`, `REQ:unknown-field-rejection` and their ACs.
+- **Carried (Should):** the default engine has the name **Serialized** and is explicitly selectable — embodied by `REQ:default-and-schemaless`.
+- **Resolved:** "disable fidelity per-schema/per-collection" does not apply to the Serialized engine (fidelity is inherent to its byte representation); the opt-out is a Columnar concern, recorded here as out of scope.
+- **Deferred:** columnar storage, concurrency model, and the bitmap extension — other Features.
+
+## Open Questions
+
+- Whether the engine should expose the serialized bytes (or a content hash) for future diffing/debugging, or keep them fully internal — not needed for the MVP contract.
+
+---
+*This document follows the https://specscore.md/feature-specification*

--- a/spec/features/storage-engine-seam/README.md
+++ b/spec/features/storage-engine-seam/README.md
@@ -1,0 +1,154 @@
+---
+format: https://specscore.md/feature-specification
+status: Approved
+---
+
+# Feature: Pluggable per-collection storage engine seam (dalgo2memory)
+
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/storage-engine-seam?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/storage-engine-seam?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/storage-engine-seam?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/storage-engine-seam?op=request-change) |
+**Status:** Approved
+**Date:** 2026-06-06
+**Owner:** alex
+**Source Ideas:** dalgo2memory-storage-engines
+**Supersedes:** —
+**Grade:** A
+
+## Summary
+
+Introduces an internal storage-engine seam in `dalgo2memory` so each collection can choose how its records are stored, and adds the per-collection selection plumbing on `WithCollection[T]`. This Feature delivers only the seam (the engine interface, the selection option, and the routing of all operations through the selected engine) and the **Serialized** default; the Serialized engine's own behavioral contract and the Columnar engine are specified in separate Features.
+
+## Problem
+
+Today `dalgo2memory` hard-codes a single storage representation: `database.collections` is a `map[string]map[string][]byte`, and every `Get`/`Set`/`Insert`/`Update`/`Delete` and query path reads or writes those JSON bytes directly. There is no place to plug in an alternative representation (columnar typed slices, an indexed column, etc.) without editing every operation. Before any alternative engine can exist, the adapter needs a single seam that (a) abstracts per-collection storage behind an interface, (b) routes all operations through the engine selected for a collection, and (c) lets a caller pick that engine per collection — while leaving today's behavior exactly as-is for callers who pick nothing.
+
+## Behavior
+
+### The storage-engine interface
+
+#### REQ: engine-interface
+
+`dalgo2memory` MUST define an internal storage-engine interface that owns, for one collection, the operations the adapter performs on stored records: store a record by id (with an overwrite/insert distinction), test existence by id, load a record by id into a caller-provided `dal.Record`, delete by id, apply field updates by id, and enumerate the collection's rows for query execution. The enumeration contract MUST expose, per row, both a decoded field view (`map[string]any`, as the WHERE/GROUP BY/ORDER BY/projection code consumes today) and the ability to materialize the row into a caller-provided typed target. The interface MUST be representation-neutral: it MUST NOT assume any particular on-disk/in-memory representation (e.g. JSON bytes). In particular, the update member MUST receive decoded field updates (name→value), not marshaled bytes, and each engine MUST own any re-validation it needs (such as unknown-field rejection) against its own representation.
+
+#### REQ: route-through-engine
+
+All `database` and `session` operations (`Exists`, `Get`/`GetMulti`, `Set`/`SetMulti`, `Insert`/`InsertMulti`, `Delete`/`DeleteMulti`, `Update`/`UpdateRecord`/`UpdateMulti`, and both query-execution paths) MUST operate through the storage-engine interface for the target collection rather than reading or writing a byte map directly. The adapter MUST hold no storage representation outside the engine instances.
+
+### Selecting an engine per collection
+
+#### REQ: withcollection-options
+
+`WithCollection[T]` MUST accept a trailing variadic `...CollectionOption` parameter that may carry a storage-engine selection, and a new exported `CollectionOption` type MUST be introduced for that purpose. Existing call sites that pass no option (`WithCollection[T](name, newRecord)`) MUST continue to compile and behave unchanged. A storage-engine selection carried by a `CollectionOption` takes effect only when the collection definition is registered with the database — today that registration channel is `WithSchema` (which already consumes `WithCollection[T]` definitions). The option records the chosen engine on the collection definition; it has no effect on a collection that is never registered.
+
+#### REQ: serialized-default
+
+The **Serialized** engine is the default and the only engine reachable without registration. A collection that is never registered (no collection definition), or whose registered definition carries no storage-engine option, MUST be backed by the Serialized engine, and its observable behavior MUST be identical to the adapter's behavior before this Feature. An explicit `WithSerializedStorage()` `CollectionOption` MUST also be provided that selects the same Serialized engine, so the default can be stated explicitly on a registered collection.
+
+#### REQ: per-collection-engine
+
+Engine selection MUST be per collection: to back a collection with a non-default engine, its definition (carrying the storage-engine `CollectionOption`) MUST be registered with the database via the schema registration channel. A single `database` MUST be able to register multiple collections backed by different engines simultaneously, each routing through its own engine instance, while any unregistered collection in the same database continues to use Serialized.
+
+### Preserving today's behavior
+
+#### REQ: behavior-preserved
+
+Refactoring the existing operations behind the seam MUST NOT change any observable behavior of the default (Serialized) path: the full existing `dalgo2memory` test suite MUST pass unchanged, and `dalgo2memory` MUST remain at 100% statement coverage.
+
+## Acceptance Criteria
+
+### AC: engine-interface-defined (verifies REQ:engine-interface)
+
+**Given** the `dalgo2memory` package
+**When** its source is inspected
+**Then** an internal storage-engine interface exists declaring store-by-id (with insert/overwrite distinction), exists-by-id, load-by-id-into-record, delete-by-id, update-by-id, and row-enumeration members, and the enumeration member yields each row as a `map[string]any` field view plus a typed-materialization path with no parameter or return type that is a serialized byte representation.
+
+### AC: operations-succeed-through-engine (verifies REQ:route-through-engine)
+
+**Given** a `database` with one collection
+**When** a `Set`, then a `Get`, a `Delete`, an `Update`, and a structured query whose filter is a single `Equal` comparison (the predicate the adapter currently supports) are executed
+**Then** every operation succeeds and returns the same results as before this Feature, with each result produced via the collection's storage-engine instance.
+
+### AC: no-byte-map-on-database (verifies REQ:route-through-engine)
+
+**Given** the refactored `dalgo2memory` package
+**When** the `database` type is inspected
+**Then** no `map[string]map[string][]byte` (or other direct byte-storage) field remains on `database`; stored records live solely inside per-collection storage-engine instances.
+
+### AC: withcollection-options-backward-compatible (verifies REQ:withcollection-options)
+
+**Given** the existing signature `WithCollection[T any](name string, newRecord func() *T)` extended to `WithCollection[T any](name string, newRecord func() *T, opts ...CollectionOption)`, and an existing call `WithCollection[T]("users", newRecord)` that passes no option
+**When** the package is compiled and that collection is used
+**Then** the call compiles unchanged with `newRecord` keeping its `func() *T` type, behaves exactly as before, and an exported `CollectionOption` type is available to pass as a trailing argument.
+
+### AC: default-is-serialized (verifies REQ:serialized-default)
+
+**Given** a registered collection with no storage-engine option, and an otherwise identical registered collection created with `WithSerializedStorage()`
+**When** the same sequence of `Set`/`Get`/equality-filtered query operations runs against each
+**Then** both produce identical results, and both match the adapter's pre-Feature behavior.
+
+### AC: unregistered-collection-is-serialized (verifies REQ:serialized-default)
+
+**Given** a `database` and a collection that was never registered through a schema
+**When** records are written to and read from it
+**Then** the operations succeed using the Serialized engine, exactly as before this Feature.
+
+### AC: mixed-engines-in-one-db (verifies REQ:per-collection-engine)
+
+**Given** a `database` registering collection `a` with `WithSerializedStorage()` and collection `b` with a second engine option
+**When** records are written to both
+**Then** each collection stores and retrieves its records through its own engine instance, and operations on one collection do not affect the other.
+
+### AC: existing-suite-green (verifies REQ:behavior-preserved)
+
+**Given** the refactor that moves operations behind the seam
+**When** the existing `dalgo2memory` test suite and coverage run
+**Then** all tests pass unchanged and statement coverage remains 100%.
+
+## Architecture & Components
+
+- **`storageEngine` interface (new, internal).** Declares the per-collection operations listed in `REQ:engine-interface`. Row enumeration returns rows that expose a `map[string]any` view (for the existing WHERE/GROUP BY/ORDER BY/projection logic) and a `materialize(target any) error` capability (replacing today's `json.Unmarshal(row.raw, data)` calls), so no caller depends on a byte representation.
+- **`database` storage field (changed).** `collections map[string]map[string][]byte` is replaced by a per-collection engine registry (e.g. `map[string]storageEngine`), created lazily on first write or eagerly from registered collection definitions. The single global `db.mu` RWMutex is retained unchanged.
+- **`CollectionOption` (new, exported) + `WithSerializedStorage()` (new, exported).** `WithCollection[T]` gains `opts ...CollectionOption`; an option records which engine constructor backs the collection. The engine choice is carried on `collectionDef` and propagated into the database when the schema is applied (and, for the default, used whenever a collection has no recorded choice).
+- **`session` methods (changed).** Each method resolves the target collection's engine and delegates, rather than touching a byte map. The Serialized engine encapsulates today's `json.Marshal`/`json.Unmarshal`/`checkUnknownFields` logic (its contract is specified in the Serialized-storage Feature).
+
+## Data Flow
+
+`WithCollection[T](name, newRecord, opts...)` records an engine choice (default: Serialized) on the collection definition → `WithSchema` propagates choices into the `database` → on each operation, the `session` looks up the collection's `storageEngine` (constructing the default Serialized engine if none was registered) and delegates → query execution iterates the engine's rows, using the `map[string]any` view for filtering/grouping/ordering/projection and `materialize` for typed `IntoRecord`/factory results.
+
+## Error Handling & Failure Modes
+
+- An operation on a collection with no registered engine choice does not error — it uses the Serialized default (`REQ:serialized-default`).
+- The seam introduces no new error surface for the Serialized path; existing errors (not-found, duplicate-on-insert, unknown-field rejection) continue to originate from the engine and are unchanged for the default.
+- Engine-specific preconditions (e.g. an engine that requires a schema) are the concern of that engine's own Feature, not the seam; the seam only routes.
+
+## Testing Strategy
+
+Table tests proving: the default and `WithSerializedStorage()` paths are observably identical and match pre-Feature behavior; an unregistered collection uses Serialized; two collections in one database can use different engines independently; and the existing suite passes unchanged behind the seam. A compile-time interface assertion (`var _ storageEngine = ...`) guards the Serialized engine against the interface. `dalgo2memory` MUST remain at 100% statement coverage, exercising the default-resolution branch and the per-collection routing.
+
+## Rehearse Integration
+
+All ACs are exercisable through pure Go — package compilation, source-level interface presence, and `dalgo2memory` operations over in-memory collections — so they map directly to table tests (see `## Testing Strategy`). Per-AC Rehearse stub files are deferred to the Plan, where each AC becomes a concrete `*_test.go` case; the rehearsal surface is the Go test suite.
+
+## Out of Scope
+
+- The **Serialized** engine's own behavioral contract (JSON representation, ref-breaking fidelity, `DisallowUnknownFields` rejection) — specified in the `serialized-storage` Feature; here it is only the default an unselected collection routes to.
+- The **Columnar** engine and its `WithColumnarStorage(...)` option, typed slices, slot/tombstone/compaction model, and `ColumnStrategy` seam — specified in the `columnar-storage` Feature.
+- Any change to the concurrency model: the single global write lock is retained; per-collection locking, two-phase locking, and rollback are out of scope (deferred per the source Idea).
+- Out-of-core extension packages (e.g. `bitmap4dalgo2memory`) — they attach at the Columnar engine's `ColumnStrategy` seam, not at this engine seam.
+- Persistence/durability — engines remain in-memory.
+
+## Assumption Carryover
+
+From the source Idea `dalgo2memory-storage-engines`:
+
+- **Carried (Must):** the engine seam can host an alternative storage path without changing observable behavior of the existing query/Get/Set surface — validated by `AC:existing-suite-green` and `AC:default-is-serialized`.
+- **Carried (Should):** engine selection composes cleanly through `WithCollection[T]` options without a config explosion — embodied by `REQ:withcollection-options` and validated by `AC:withcollection-options-backward-compatible`.
+- **Deferred:** columnar concurrency correctness, the `ColumnStrategy` extension contract, tombstone/compaction, and the bitmap extension — owned by the `columnar-storage` Feature, not this one.
+- **Resolved:** the default engine has a name — **Serialized** — and is selectable explicitly via `WithSerializedStorage()`.
+
+## Open Questions
+
+- The exact method set and signatures of the `storageEngine` interface (e.g. whether `materialize` takes `any` or a typed callback) — an implementation detail for the Plan.
+- Whether engine instances are created eagerly when a schema is applied or lazily on first write to a collection — a Plan-time choice; both satisfy the ACs.
+
+---
+*This document follows the https://specscore.md/feature-specification*

--- a/spec/features/transaction-message/README.md
+++ b/spec/features/transaction-message/README.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/feature-specification
+status: Approved
+---
+
 # Feature: Transaction Message
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/transaction-message?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/transaction-message?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/transaction-message?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/transaction-message?op=request-change) |

--- a/spec/ideas/README.md
+++ b/spec/ideas/README.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/ideas-index-specification
+---
+
 # Ideas
 
 Pre-spec one-pagers refined through structured divergent and convergent thinking. Each Idea here is a candidate that may promote to one or more Features in `spec/features/`.
@@ -12,6 +16,7 @@ The Idea format follows [SpecScore](https://specscore.md/idea-specification).
 | [dal-records-reader-iter-seq](dal-records-reader-iter-seq.md) | Draft | 2026-05-15 | alex | — |
 | [dalgo-dialect-aware-sql-emission](dalgo-dialect-aware-sql-emission.md) | Draft | 2026-05-15 | alex | — |
 | [dalgo-schema-modification](dalgo-schema-modification.md) | Approved | 2026-05-12 | alex | — |
+| [dalgo2memory-storage-engines](dalgo2memory-storage-engines.md) | Specified | 2026-06-06 | alex | columnar-storage, serialized-storage, storage-engine-seam |
 | [first-class-query-joins](first-class-query-joins.md) | Specified | 2026-06-05 | alexander.trakhimenok | query-joins |
 | [qualified-orderby-resolution](qualified-orderby-resolution.md) | Specified | 2026-06-05 | alex | qualified-orderby-resolution |
 | [query-column-projection](query-column-projection.md) | Implemented | 2026-06-05 | alex | query-column-projection |

--- a/spec/ideas/README.md
+++ b/spec/ideas/README.md
@@ -16,7 +16,7 @@ The Idea format follows [SpecScore](https://specscore.md/idea-specification).
 | [dal-records-reader-iter-seq](dal-records-reader-iter-seq.md) | Draft | 2026-05-15 | alex | — |
 | [dalgo-dialect-aware-sql-emission](dalgo-dialect-aware-sql-emission.md) | Draft | 2026-05-15 | alex | — |
 | [dalgo-schema-modification](dalgo-schema-modification.md) | Approved | 2026-05-12 | alex | — |
-| [dalgo2memory-storage-engines](dalgo2memory-storage-engines.md) | Specified | 2026-06-06 | alex | columnar-storage, serialized-storage, storage-engine-seam |
+| [dalgo2memory-storage-engines](dalgo2memory-storage-engines.md) | Specified | 2026-06-06 | alex | columnar-mixed-mode-maps, columnar-storage, serialized-storage, storage-engine-seam |
 | [first-class-query-joins](first-class-query-joins.md) | Specified | 2026-06-05 | alexander.trakhimenok | query-joins |
 | [qualified-orderby-resolution](qualified-orderby-resolution.md) | Specified | 2026-06-05 | alex | qualified-orderby-resolution |
 | [query-column-projection](query-column-projection.md) | Implemented | 2026-06-05 | alex | query-column-projection |

--- a/spec/ideas/concurrency-capability.md
+++ b/spec/ideas/concurrency-capability.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/idea-specification
+status: Approved
+---
+
 # Idea: DALgo Concurrency Capability Interface
 
 **Status:** Approved

--- a/spec/ideas/dal-records-reader-iter-seq.md
+++ b/spec/ideas/dal-records-reader-iter-seq.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/idea-specification
+status: Draft
+---
+
 # Idea: Migrate dal.RecordsReader to iter.Seq
 
 **Status:** Draft

--- a/spec/ideas/dalgo-dialect-aware-sql-emission.md
+++ b/spec/ideas/dalgo-dialect-aware-sql-emission.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/idea-specification
+status: Draft
+---
+
 # Idea: DALgo dialect-aware SQL emission
 
 **Status:** Draft

--- a/spec/ideas/dalgo-schema-modification.md
+++ b/spec/ideas/dalgo-schema-modification.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/idea-specification
+status: Approved
+---
+
 # Idea: DALgo Schema Modification (DDL) Surface
 
 **Status:** Approved

--- a/spec/ideas/dalgo2memory-storage-engines.md
+++ b/spec/ideas/dalgo2memory-storage-engines.md
@@ -1,0 +1,98 @@
+---
+format: https://specscore.md/idea-specification
+status: Specified
+---
+
+# Idea: dalgo2memory Pluggable Storage Engines
+
+**Status:** Specified
+**Date:** 2026-06-06
+**Owner:** alex
+**Promotes To:** columnar-storage, serialized-storage, storage-engine-seam
+**Supersedes:** —
+**Related Ideas:** —
+
+## Problem Statement
+
+How might we let dalgo2memory offer alternative in-memory storage engines behind a common seam — so arbitrary multi-field WHERE filtering reads measurably faster than today's JSON-bytes engine, while preserving the adapter's serialization-fidelity contract by default?
+
+## Context
+
+dalgo2memory currently stores every record as JSON bytes (collection -> id -> []byte) and json.Unmarshal's on every read/scan. DataTug analytics and larger in-memory datasets make multi-field WHERE scans the hot path. User wants a pluggable storage-engine seam with variants: type-copy rows, columnar typed slices, and per-column bitmap storage. Fidelity (ref-breaking + reject-non-serializable) must stay default-on, disableable per-schema or per-collection.
+
+## Recommended Direction
+
+The target API is:
+
+```go
+dalgo2memory.WithSchema(false,
+    dalgo2memory.WithCollection[User]("users", nil,
+        dalgo2memory.WithColumnarStorage(
+            bitmap4dalgo2memory.WithBitmapColumn("role"),
+        ),
+    ),
+)
+```
+
+This implies a **two-level seam**, both in core:
+
+1. **Per-collection storage engine.** `WithCollection[T]` gains variadic options that select how that collection is stored (rather than introducing a new `Collection[T]` name). The current `map[string]map[string][]byte` JSON-bytes representation stays the **default engine** (no option needed), unchanged in behavior — it keeps the serialization-fidelity contract (ref-breaking via marshal/unmarshal, `DisallowUnknownFields` rejection) for free. `WithColumnarStorage(...)` selects a **columnar engine** that stores each column in its own typed slice — the layout that wins on scans and multi-field filtering.
+
+2. **Per-column storage strategy inside the columnar engine.** `WithColumnarStorage` accepts per-column options. The default strategy for a column is a plain typed slice. Core defines and **exports a `ColumnStrategy` interface** so a column can be backed by something else — and that "something else" can live in a *separate package*. `bitmap4dalgo2memory.WithBitmapColumn("role")` is exactly that: an external package that returns a column option implementing core's `ColumnStrategy`, backing the `role` column with a bitmap index.
+
+The dependency direction is the whole point: **core owns the columnar engine and the `ColumnStrategy` interface; the bitmap library is imported only by `bitmap4dalgo2memory`, never by core.** `dalgo2memory` stays foundational and dependency-free, while the bitmap index — which delivers the stated multi-field-WHERE speedup — ships out of core and composes in through the exported interface.
+
+`ColumnStrategy` needs two capabilities so a bitmap column can both stay current and accelerate reads: a **write side** (record a column value as rows are inserted/updated/deleted) and a **read side** for equality predicates (given `column == value`, return the matching row-IDs, or "no opinion" → fall back to scanning that column). The query engine intersects/unions those row-ID sets across a multi-field `WHERE` before materializing rows.
+
+Fidelity stays default-on and is relaxable only by an explicit per-schema or per-collection opt-out, so the test-double contract is never weakened silently. A type-copy ("decoded row") engine remains a possible future variant behind the same per-collection seam.
+
+## Alternatives Considered
+
+- **Bitmap index built into core.** The most direct route to the read-speedup metric, but rejected as a core deliverable: `dalgo2memory` is a foundational library and the owner does not want a bitmap (e.g. roaring) dependency in it. Designed for — via the exported `ColumnStrategy` interface — but shipped later as the out-of-core `bitmap4dalgo2memory` package.
+- **Ship the speedup in the MVP (bitmap column strategy in the first cut).** Tempting, but it puts the hardest unknown last. Columnar storage with a stable per-row slot and a sound concurrency model is the foundation everything else (including bitmap) sits on; getting *that* right is the MVP's job. Speed comes after correctness + the seam.
+- **Type-copy ("decoded row") engine as the MVP.** Store the deep-copied decoded value (JSON round-trip to break refs) so reads copy instead of unmarshal. Small and localized — but it does nothing for the stated multi-field-WHERE win (a full scan still touches every row) and sidesteps the concurrency model the owner wants ironed out. Kept as a documented future variant behind the same per-collection seam.
+- **Replace the default engine outright (drop JSON bytes).** Rejected: the JSON round-trip is the adapter's serialization-fidelity boundary. Removing it weakens the test-double contract for every existing dalgo2memory user. The seam must add engines, not delete the faithful one.
+
+## MVP Scope
+
+A spike that ships **columnar storage (one typed slice per column) for a typed collection**, and uses it to iron out the **concurrency / multithreading model** — that is the hard, foundational problem worth solving first. Bitmap is *designed for* (the `ColumnStrategy` interface is exported) but *not built* in the MVP.
+
+1. `WithCollection[T]` extended with variadic options, with the current JSON-bytes representation as the default engine, behavior-identical to today (existing tests stay green — the regression gate).
+2. `WithColumnarStorage(...)`: store each column in its own typed slice, with a stable per-row index shared across all of a collection's columns. Deletes use **tombstones with later bulk compaction** (mark slot dead, reuse on insert, compact when the dead fraction crosses a threshold). Cover the full lifecycle — insert, update, delete, and read/scan — and make the existing query path (WHERE / projection / GROUP BY / joins / ORDER BY) correct against columnar storage. Correctness first; the speedup ships with the bitmap extension.
+3. **Concurrency: keep the existing single global write lock** (`db.mu` RWMutex — one writer at a time, readers share). No deadlocks, no rollback. The MVP's concurrency job is therefore narrow but real: prove that columnar slot allocation, in-place updates, tombstones, and compaction are correct and race-free *under that lock*. Race-detector tests (`go test -race`) interleaving reads with writes/deletes/compaction are the gate. Per-collection two-phase locking with transactional rollback is explicitly deferred.
+4. The exported **`ColumnStrategy` interface** (write side + equality read side) that `WithColumnarStorage` consumes, with the default typed-slice strategy as its first implementation — proving an out-of-core package like `bitmap4dalgo2memory` can later supply `WithBitmapColumn` without a core dependency.
+
+Success: columnar collections pass the existing suite plus `-race`, the concurrency model is documented and defended by tests, and the `ColumnStrategy` seam is exercised by at least the default strategy.
+
+## Not Doing (and Why)
+
+- Per-collection two-phase locking + transactional rollback — deferred; the MVP keeps the single global write lock (no deadlocks, no rollback). Concurrent writes across different collections is a future concern, not an MVP goal
+- Shipping the bitmap index in core — deferred to the out-of-core `bitmap4dalgo2memory` package to keep `dalgo2memory` dependency-free; the `ColumnStrategy` seam is designed to host it, but it is not built here
+- Persistence/durability — engines stay in-memory; this is not a storage backend rewrite
+- Replacing the default JSON-bytes engine — columnar is opt-in per collection via `WithColumnarStorage`; the faithful default stays
+- Composite/range read-side acceleration in the `ColumnStrategy` interface — MVP covers equality predicates only
+- Auto-selecting which columns get a non-default strategy — strategies are declared explicitly via column options, not inferred
+
+## Key Assumptions to Validate
+
+| Tier | Assumption | How to validate |
+|------|------------|-----------------|
+| Must-be-true | Columnar slot allocation, updates, tombstones, and compaction are correct and race-free under the existing single global write lock (no deadlocks, no rollback). | Implement columnar storage; defend with `go test -race` interleaving reads against writes/deletes/compaction. Compaction reindexing under the write lock must not be observable to concurrent readers. |
+| Must-be-true | Columnar storage can back the full existing query surface (WHERE / projection / GROUP BY / joins / ORDER BY / Get / Set) without changing observable behavior. | Run the full existing test suite against columnar collections; all pass unchanged. |
+| Must-be-true | The exported `ColumnStrategy` interface (write side + equality read side) is sufficient for an *external* package to back a column (e.g. bitmap) without forking core or adding a core dependency. | Implement the default typed-slice strategy against the interface; sketch `bitmap4dalgo2memory.WithBitmapColumn` and confirm its import graph points only inward. |
+| Should-be-true | Per-column slice deletes (tombstone vs. compaction) keep row-IDs stable enough that strategies and the query path stay correct and cheap. | Prototype both tombstone and compaction; measure correctness and cost under churn. |
+| Should-be-true | Engine and per-column options compose cleanly through `Collection[T](name, ...)` / `WithColumnarStorage(...)` without a config explosion, and fidelity opt-out reads naturally alongside the current `WithSchema(allowUndefined, ...)` shape. | Sketch the API surface end to end and review for ergonomics. |
+| Might-be-true | A type-copy engine would add further gains for point-Get-heavy workloads beyond columnar. | Defer — only profile after columnar lands and a workload shows residual read cost. |
+
+
+## SpecScore Integration
+
+- **New Features this would create:** a `storage-engine-seam` Feature (the internal interface + exported extension hooks + `jsonbytes` default). The bitmap index is a *separate out-of-core extension*, tracked as its own future Idea/repo, not a Feature of core. Columnar and type-copy engines are deferred candidate Features behind the same seam.
+- **Existing Features affected:** the dalgo2memory query path that backs `query-column-projection`, `query-group-by-aggregation`, and `first-class-query-joins` — all must keep passing through the seam unchanged.
+- **Dependencies:** builds on the existing `WithSchema`/`WithCollection` schema mechanism; no dependency on other in-flight Ideas. Core takes on **no** new third-party dependency.
+
+## Open Questions
+
+- What is the minimal exported shape of `ColumnStrategy` (write side + equality read side) that lets `bitmap4dalgo2memory` plug in without leaking core internals?
+- Compaction trigger: what dead-slot fraction (or absolute count) should kick off bulk compaction, and does it run inline on the next write or as a separate maintenance call?
+- Naming: the chosen direction extends `WithCollection[T]` with options rather than introducing the `Collection[T]` constructor from the original sketch — confirm this trade (less churn) over the shorter name at spec time.

--- a/spec/ideas/dalgo2memory-storage-engines.md
+++ b/spec/ideas/dalgo2memory-storage-engines.md
@@ -8,7 +8,7 @@ status: Specified
 **Status:** Specified
 **Date:** 2026-06-06
 **Owner:** alex
-**Promotes To:** columnar-storage, serialized-storage, storage-engine-seam
+**Promotes To:** columnar-mixed-mode-maps, columnar-storage, serialized-storage, storage-engine-seam
 **Supersedes:** —
 **Related Ideas:** —
 

--- a/spec/ideas/first-class-query-joins.md
+++ b/spec/ideas/first-class-query-joins.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/idea-specification
+status: Specified
+---
+
 # Idea: First-class INNER/LEFT joins in dal's query model
 
 **Status:** Specified

--- a/spec/ideas/qualified-orderby-resolution.md
+++ b/spec/ideas/qualified-orderby-resolution.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/idea-specification
+status: Specified
+---
+
 # Idea: Source-qualified, multi-key ORDER BY resolution in dalgo2memory
 
 **Status:** Specified

--- a/spec/ideas/query-column-projection.md
+++ b/spec/ideas/query-column-projection.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/idea-specification
+status: Implemented
+---
+
 # Idea: Column selection in the query builder, projected by dalgo2memory
 
 **Status:** Implemented

--- a/spec/ideas/query-group-by-aggregation.md
+++ b/spec/ideas/query-group-by-aggregation.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/idea-specification
+status: Implemented
+---
+
 # Idea: GROUP BY with aggregation in the query builder, executed by dalgo2memory
 
 **Status:** Implemented

--- a/spec/ideas/recordops.md
+++ b/spec/ideas/recordops.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/idea-specification
+status: Approved
+---
+
 # Idea: recordops — Recordset Operations Package
 
 **Status:** Approved

--- a/spec/ideas/recordset-computed-columns.md
+++ b/spec/ideas/recordset-computed-columns.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/idea-specification
+status: Specified
+---
+
 # Idea: Computed Columns in recordset (neutral evaluator)
 
 **Status:** Specified

--- a/spec/ideas/transaction-message.md
+++ b/spec/ideas/transaction-message.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/idea-specification
+status: Approved
+---
+
 # Idea: Transaction Message
 
 **Status:** Approved

--- a/spec/plans/2026-06-06-columnar-mixed-mode-maps.md
+++ b/spec/plans/2026-06-06-columnar-mixed-mode-maps.md
@@ -1,0 +1,55 @@
+# Plan: Mixed-mode columnar storage for map[string]any collections (dalgo2memory)
+
+**Status:** Completed
+**Source Feature:** columnar-mixed-mode-maps
+**Date:** 2026-06-06
+**Owner:** alex
+**Supersedes:** —
+
+## Summary
+
+Decomposes the `columnar-mixed-mode-maps` Feature into four linear tasks that extend the existing `columnarEngine` to `map[string]any` collections: a map-backed selection path with declared-column options and type enforcement, the mixed storage layout (typed declared-column slices + a parallel leftover `[]map[string]any` sharing the slot vector), the read-merge and WHERE routing, and the inherited fidelity/parity guarantees. All nine acceptance criteria are covered by a task; none are deferred. Depends on the already-implemented `columnar-storage`.
+
+## Approach
+
+The columnar engine already has the typed-column slices, slot/free-list model, tombstone+compaction, strategies, and the WHERE candidate path; mixed mode adds a map-backed construction and a leftover store alongside them. Task 1 lifts the struct-only restriction: a `map[string]any` collection with at least one declared column builds columns from the declarations (no declaration → descriptive error), and a declared value of an incompatible type is a descriptive write error. Task 2 adds the storage split — declared keys into typed slices (removed from the record), the remainder into a `leftover []map[string]any` indexed by the same slot, kept paired through delete/slot-reuse/compaction. Task 3 reassembles reads by merging declared columns with the slot's leftover map (no duplicate/dropped key) and routes equality WHERE to a declared column's strategy or a leftover-map scan, matching the Serialized engine. Task 4 confirms fidelity (declared + leftover ref-bearing isolation) and behavioral parity. Order: 2 needs 1's construction; 3 needs 2's layout; 4 needs 2's write path.
+
+## Tasks
+
+### Task 1: Map-backed selection, declared-column option, and type enforcement
+
+**Verifies:** columnar-mixed-mode-maps#ac:mixed-mode-requires-declared-column, columnar-mixed-mode-maps#ac:declared-value-wrong-type-errors
+**Status:** done
+
+Lift the struct-only restriction so `WithColumnarStorage` builds a columnar engine for a `map[string]any` collection from explicitly declared columns; selecting it with no declared column fails with a descriptive error. Add the declared-column `ColumnOption` (name + element type) and make a written declared value that cannot be stored as the declared type a descriptive write error that stores nothing for that record.
+
+### Task 2: Mixed storage layout — typed declared columns + leftover map sharing the slot
+
+**Verifies:** columnar-mixed-mode-maps#ac:declared-field-removed-from-leftover, columnar-mixed-mode-maps#ac:leftover-holds-undeclared-fields, columnar-mixed-mode-maps#ac:slot-stays-synced-through-delete-and-compaction
+**Depends-On:** 1
+**Status:** done
+
+Store each declared column in its typed slice (removing the declared key from the record) and retain every undeclared field in a parallel `leftover []map[string]any` indexed by the same per-row slot. Wire the leftover store into slot allocation, tombstone delete, slot reuse, and compaction so a row's declared cells and its leftover map are always moved or freed together.
+
+### Task 3: Read merge and WHERE routing
+
+**Verifies:** columnar-mixed-mode-maps#ac:read-reconstructs-full-record, columnar-mixed-mode-maps#ac:where-on-declared-column-accelerated, columnar-mixed-mode-maps#ac:where-on-leftover-field-scans
+**Depends-On:** 2
+**Status:** done
+
+Reassemble `Get`/query rows by overlaying each declared column's slot value onto a copy of the slot's leftover map, yielding the full `map[string]any` with each key exactly once. Route an equality `WHERE` on a declared column through that column's `ColumnStrategy` and an equality `WHERE` on a leftover field through the scan fall-back; both results identical to the Serialized engine.
+
+### Task 4: Fidelity and behavioral parity
+
+**Verifies:** columnar-mixed-mode-maps#ac:mixed-mode-parity-and-fidelity
+**Depends-On:** 2
+**Status:** done
+
+Confirm declared columns inherit the hybrid write + fidelity opt-out, the leftover map's values are deep-copied under the faithful default (post-write caller mutation does not affect stored data), and `Set`/`Insert`/`Delete`/`Update` outcomes match the Serialized engine for the same `map[string]any` data.
+
+## Open Questions
+
+- The declared-column option signature and the float64/int coercion boundary are inherited Open Questions from the Feature; both are settled at implementation and do not change the task breakdown.
+
+---
+*This document follows the https://specscore.md/plan-specification*

--- a/spec/plans/2026-06-06-columnar-storage.md
+++ b/spec/plans/2026-06-06-columnar-storage.md
@@ -1,0 +1,86 @@
+# Plan: Columnar storage engine (dalgo2memory)
+
+**Status:** Approved
+**Source Feature:** columnar-storage
+**Date:** 2026-06-06
+**Owner:** alex
+**Supersedes:** —
+
+## Summary
+
+Decomposes the `columnar-storage` Feature into nine linear tasks: engine selection, the typed-slice + slot layout, hybrid write with the fidelity opt-out, behavioral parity with Serialized, deletes + compaction, read/query reassembly + Serialized-equality, the `ColumnStrategy` seam + default strategy, wiring the equality `WHERE` to the strategy, and the `-race` concurrency gate. All fifteen acceptance criteria are covered by a task; none are deferred. This is the third of three coordinated plans and depends on the seam (and Serialized, as the behavioral reference) being implemented first.
+
+## Approach
+
+The columnar engine is the largest piece, so it is built bottom-up: representation first, then behavior, then the strategy seam, then the query wiring that uses it, then the concurrency gate. Task 1 adds `WithColumnarStorage(...)` selection (typed collections only, schemaless errors). Task 2 builds the typed column slices (reflection over `T`, `[]any` fallback) over a stable shared row-slot model. Task 3 adds the hybrid write (scalar direct / ref-bearing round-trip) and the schema-wide/per-collection fidelity opt-out. Task 4 establishes behavioral parity with the Serialized engine. Task 5 adds tombstone deletes + slot reuse + threshold compaction under the global lock. Task 6 reassembles rows for `Get`/query and proves columnar query results equal Serialized's. Task 7 defines and exports the `ColumnStrategy` interface + default typed-slice strategy. Task 8 wires the single supported equality `WHERE` predicate to the strategy with a scan fall-back. Task 9 is the `-race` gate over interleaved operations. The order respects dependencies: layout precedes everything; the strategy (7) precedes its WHERE wiring (8); the race gate (9) exercises the finished engine including compaction (5).
+
+## Tasks
+
+### Task 1: WithColumnarStorage selection (typed-only)
+
+**Verifies:** columnar-storage#ac:columnar-requires-typed-collection
+
+Add the `WithColumnarStorage(...ColumnOption)` `CollectionOption` that selects the columnar engine for a schema-registered `WithCollection[T]` collection, and make selection on a schemaless/undefined collection fail with a descriptive error.
+
+### Task 2: Typed column slices over a stable row slot
+
+**Verifies:** columnar-storage#ac:columns-are-typed-slices, columnar-storage#ac:slot-stable-across-columns
+**Depends-On:** 1
+
+Derive one column per JSON-serializable field of `T` via reflection, storing each in a slice typed to the field's Go type (`[]any` fallback for interface/heterogeneous fields), all indexed by a single shared per-row slot; map each record id to a slot that stays stable for the record's lifetime.
+
+### Task 3: Hybrid write and fidelity opt-out
+
+**Verifies:** columnar-storage#ac:write-breaks-refs-by-default, columnar-storage#ac:fidelity-opt-out-toggles-ref-breaking
+**Depends-On:** 2
+
+On write, store scalar/value columns by direct assignment and deep-copy reference-bearing columns via a serialization round-trip so stored data shares no references with caller values by default; add a schema-wide option and a per-collection option to disable ref-breaking (per-collection overriding schema-wide), defaulting to faithful.
+
+### Task 4: Behavioral parity with the Serialized engine
+
+**Verifies:** columnar-storage#ac:parity-with-serialized-ops
+**Depends-On:** 2
+
+Ensure `Set` overwrites, `Insert` on an existing id errors without overwriting, `Get`/`Update` on an absent id return not-found, and an `Update` naming a field undefined on `T` is rejected — matching the Serialized engine's outcomes exactly (representational differences only).
+
+### Task 5: Tombstone deletes and compaction
+
+**Verifies:** columnar-storage#ac:delete-tombstones-and-hides, columnar-storage#ac:compaction-preserves-live-records
+**Depends-On:** 2
+
+`Delete` marks a slot dead and frees it for reuse while keeping other slots stable, and a tombstoned slot never appears in `Get`/`Exists`/queries; when the dead-slot fraction crosses a threshold, compaction reclaims dead slots under the global write lock, preserving every live record and its values without exposing partial state to readers.
+
+### Task 6: Row reassembly and Serialized-equality of query results
+
+**Verifies:** columnar-storage#ac:get-and-query-reassemble, columnar-storage#ac:columnar-query-matches-serialized
+**Depends-On:** 3, 5
+
+Reassemble each live row from its per-column slot values into a `map[string]any` field view and a typed materialization for `Get`/`IntoRecord`/factory targets, with no shared references between rows; verify that the supported single equality `WHERE` predicate plus projection and `ORDER BY`/`LIMIT` (and join) return results identical in content and order to an equivalent Serialized collection.
+
+### Task 7: ColumnStrategy interface and default typed-slice strategy
+
+**Verifies:** columnar-storage#ac:strategy-interface-exported, columnar-storage#ac:default-strategy-scans-column
+**Depends-On:** 2
+
+Define and export a `ColumnStrategy` interface (write side to set/clear a value at a slot; equality read side returning matching live slots or "no opinion") and a per-column option to supply one; implement the default typed-slice strategy that answers equality by scanning comparable columns (Go `==`, as in `matchesWhere`) and may return "no opinion" for non-comparable `[]any` columns — proving an external package can plug in without a core dependency.
+
+### Task 8: Wire equality WHERE to the column strategy
+
+**Verifies:** columnar-storage#ac:where-uses-strategy, columnar-storage#ac:where-falls-back-on-no-opinion
+**Depends-On:** 6, 7
+
+For the single `field == value` predicate the adapter supports, consult the target column's `ColumnStrategy` and use its returned slot set to select candidate rows (the read side returns a set so future multi-predicate `AND` can intersect), falling back to scanning on "no opinion"; the result is identical to the Serialized engine's for the same query.
+
+### Task 9: Concurrency race gate
+
+**Verifies:** columnar-storage#ac:columnar-passes-race
+**Depends-On:** 5, 8
+
+Run the columnar engine under the existing single global write lock with `go test -race`, interleaving reads with writes, deletes, and a compaction, confirming no data race is reported and results remain correct.
+
+## Open Questions
+
+- The exact compaction trigger (dead-slot threshold; inline-on-write vs separate maintenance call) and the `ColumnStrategy` slot-set representation / rebuild-on-compaction signal — settled during implementation; both satisfy the ACs.
+
+---
+*This document follows the https://specscore.md/plan-specification*

--- a/spec/plans/2026-06-06-columnar-storage.md
+++ b/spec/plans/2026-06-06-columnar-storage.md
@@ -1,6 +1,6 @@
 # Plan: Columnar storage engine (dalgo2memory)
 
-**Status:** Approved
+**Status:** Completed
 **Source Feature:** columnar-storage
 **Date:** 2026-06-06
 **Owner:** alex
@@ -19,6 +19,7 @@ The columnar engine is the largest piece, so it is built bottom-up: representati
 ### Task 1: WithColumnarStorage selection (typed-only)
 
 **Verifies:** columnar-storage#ac:columnar-requires-typed-collection
+**Status:** done
 
 Add the `WithColumnarStorage(...ColumnOption)` `CollectionOption` that selects the columnar engine for a schema-registered `WithCollection[T]` collection, and make selection on a schemaless/undefined collection fail with a descriptive error.
 
@@ -26,6 +27,7 @@ Add the `WithColumnarStorage(...ColumnOption)` `CollectionOption` that selects t
 
 **Verifies:** columnar-storage#ac:columns-are-typed-slices, columnar-storage#ac:slot-stable-across-columns
 **Depends-On:** 1
+**Status:** done
 
 Derive one column per JSON-serializable field of `T` via reflection, storing each in a slice typed to the field's Go type (`[]any` fallback for interface/heterogeneous fields), all indexed by a single shared per-row slot; map each record id to a slot that stays stable for the record's lifetime.
 
@@ -33,6 +35,7 @@ Derive one column per JSON-serializable field of `T` via reflection, storing eac
 
 **Verifies:** columnar-storage#ac:write-breaks-refs-by-default, columnar-storage#ac:fidelity-opt-out-toggles-ref-breaking
 **Depends-On:** 2
+**Status:** done
 
 On write, store scalar/value columns by direct assignment and deep-copy reference-bearing columns via a serialization round-trip so stored data shares no references with caller values by default; add a schema-wide option and a per-collection option to disable ref-breaking (per-collection overriding schema-wide), defaulting to faithful.
 
@@ -40,6 +43,7 @@ On write, store scalar/value columns by direct assignment and deep-copy referenc
 
 **Verifies:** columnar-storage#ac:parity-with-serialized-ops
 **Depends-On:** 2
+**Status:** done
 
 Ensure `Set` overwrites, `Insert` on an existing id errors without overwriting, `Get`/`Update` on an absent id return not-found, and an `Update` naming a field undefined on `T` is rejected — matching the Serialized engine's outcomes exactly (representational differences only).
 
@@ -47,6 +51,7 @@ Ensure `Set` overwrites, `Insert` on an existing id errors without overwriting, 
 
 **Verifies:** columnar-storage#ac:delete-tombstones-and-hides, columnar-storage#ac:compaction-preserves-live-records
 **Depends-On:** 2
+**Status:** done
 
 `Delete` marks a slot dead and frees it for reuse while keeping other slots stable, and a tombstoned slot never appears in `Get`/`Exists`/queries; when the dead-slot fraction crosses a threshold, compaction reclaims dead slots under the global write lock, preserving every live record and its values without exposing partial state to readers.
 
@@ -54,6 +59,7 @@ Ensure `Set` overwrites, `Insert` on an existing id errors without overwriting, 
 
 **Verifies:** columnar-storage#ac:get-and-query-reassemble, columnar-storage#ac:columnar-query-matches-serialized
 **Depends-On:** 3, 5
+**Status:** done
 
 Reassemble each live row from its per-column slot values into a `map[string]any` field view and a typed materialization for `Get`/`IntoRecord`/factory targets, with no shared references between rows; verify that the supported single equality `WHERE` predicate plus projection and `ORDER BY`/`LIMIT` (and join) return results identical in content and order to an equivalent Serialized collection.
 
@@ -61,6 +67,7 @@ Reassemble each live row from its per-column slot values into a `map[string]any`
 
 **Verifies:** columnar-storage#ac:strategy-interface-exported, columnar-storage#ac:default-strategy-scans-column
 **Depends-On:** 2
+**Status:** done
 
 Define and export a `ColumnStrategy` interface (write side to set/clear a value at a slot; equality read side returning matching live slots or "no opinion") and a per-column option to supply one; implement the default typed-slice strategy that answers equality by scanning comparable columns (Go `==`, as in `matchesWhere`) and may return "no opinion" for non-comparable `[]any` columns — proving an external package can plug in without a core dependency.
 
@@ -68,6 +75,7 @@ Define and export a `ColumnStrategy` interface (write side to set/clear a value 
 
 **Verifies:** columnar-storage#ac:where-uses-strategy, columnar-storage#ac:where-falls-back-on-no-opinion
 **Depends-On:** 6, 7
+**Status:** done
 
 For the single `field == value` predicate the adapter supports, consult the target column's `ColumnStrategy` and use its returned slot set to select candidate rows (the read side returns a set so future multi-predicate `AND` can intersect), falling back to scanning on "no opinion"; the result is identical to the Serialized engine's for the same query.
 
@@ -75,6 +83,7 @@ For the single `field == value` predicate the adapter supports, consult the targ
 
 **Verifies:** columnar-storage#ac:columnar-passes-race
 **Depends-On:** 5, 8
+**Status:** done
 
 Run the columnar engine under the existing single global write lock with `go test -race`, interleaving reads with writes, deletes, and a compaction, confirming no data race is reported and results remain correct.
 

--- a/spec/plans/2026-06-06-serialized-storage.md
+++ b/spec/plans/2026-06-06-serialized-storage.md
@@ -1,6 +1,6 @@
 # Plan: Serialized storage engine (dalgo2memory default)
 
-**Status:** Approved
+**Status:** Completed
 **Source Feature:** serialized-storage
 **Date:** 2026-06-06
 **Owner:** alex
@@ -19,6 +19,7 @@ The Serialized engine's behavior already exists in the codebase and is extracted
 ### Task 1: serializedEngine type, byte representation, and default/schemaless role
 
 **Verifies:** serialized-storage#ac:stored-as-decodable-bytes, serialized-storage#ac:serialized-is-default-and-schemaless-capable
+**Status:** done
 **Notes:** Builds on the seam plan's Task 3, which extracts the engine.
 
 Formalize the `serializedEngine` implementing `storageEngine`, with a compile-time `var _ storageEngine = (*serializedEngine)(nil)` assertion, storing each record as a serialized (JSON) byte buffer keyed by id and reconstructing by decoding. Confirm it is the engine resolved for the default/`WithSerializedStorage()` selection and that it supports both schema-typed and schemaless collections.
@@ -27,6 +28,7 @@ Formalize the `serializedEngine` implementing `storageEngine`, with a compile-ti
 
 **Verifies:** serialized-storage#ac:mutation-after-write-isolated, serialized-storage#ac:two-reads-independent, serialized-storage#ac:non-serializable-write-errors
 **Depends-On:** 1
+**Status:** done
 
 Pin the fidelity contract: because records are stored as bytes and decoded afresh, mutating a caller value after a write does not affect stored data, two reads of one record are mutually independent, and a write of a non-serializable value fails with a descriptive error set on the record while storing nothing for that id.
 
@@ -34,6 +36,7 @@ Pin the fidelity contract: because records are stored as bytes and decoded afres
 
 **Verifies:** serialized-storage#ac:unknown-field-rejected-when-typed, serialized-storage#ac:insert-duplicate-errors
 **Depends-On:** 1
+**Status:** done
 
 Lock the write rules: for a schema-typed collection a write/update carrying a field undefined on the type is rejected with a descriptive error naming the collection (no check for schemaless collections), `Insert` on an existing id returns an "already exists" error without overwriting, and `Set` overwrites; both validate before storing so a rejected write leaves storage unchanged.
 
@@ -41,6 +44,7 @@ Lock the write rules: for a schema-typed collection a write/update carrying a fi
 
 **Verifies:** serialized-storage#ac:get-absent-not-found, serialized-storage#ac:query-decodes-rows, serialized-storage#ac:update-applies-and-revalidates
 **Depends-On:** 1
+**Status:** done
 
 Cover reads and updates: `Get` on an absent id returns a not-found error set on the record while `Exists` reports false; query execution exposes decoded `map[string]any` views and typed materializations with no shared references between result records; and `Update` reads-modifies-writes the decoded data, re-runs the unknown-field check for typed collections, and returns not-found (storing nothing) on an absent id.
 

--- a/spec/plans/2026-06-06-serialized-storage.md
+++ b/spec/plans/2026-06-06-serialized-storage.md
@@ -1,0 +1,52 @@
+# Plan: Serialized storage engine (dalgo2memory default)
+
+**Status:** Approved
+**Source Feature:** serialized-storage
+**Date:** 2026-06-06
+**Owner:** alex
+**Supersedes:** —
+
+## Summary
+
+Decomposes the `serialized-storage` Feature into four linear tasks that formalize and pin the contract of the `serializedEngine` extracted by the `storage-engine-seam` plan: the byte representation and engine role, the serialization-fidelity guarantees, the schema-aware write semantics, and the read/query/update semantics. All ten acceptance criteria are covered by a task; none are deferred. This is the second of three coordinated plans and depends on the seam plan being implemented first.
+
+## Approach
+
+The Serialized engine's behavior already exists in the codebase and is extracted behind the seam interface by the `storage-engine-seam` plan's Task 3; this plan gives that engine an explicit, tested contract. Task 1 names the `serializedEngine` type, adds the interface conformance assertion, and pins the byte-representation and default/schemaless role. Task 2 locks the fidelity guarantees (ref-breaking on write and across reads, rejection of non-serializable values). Task 3 covers the schema-aware write rules (unknown-field rejection on typed vs schemaless, insert-duplicate vs set). Task 4 covers reads, queries, and updates (not-found, decoded views with non-shared results, read-modify-write with re-validation). The tasks are independent contract slices but ordered representation → fidelity → writes → reads for a natural review flow.
+
+## Tasks
+
+### Task 1: serializedEngine type, byte representation, and default/schemaless role
+
+**Verifies:** serialized-storage#ac:stored-as-decodable-bytes, serialized-storage#ac:serialized-is-default-and-schemaless-capable
+**Notes:** Builds on the seam plan's Task 3, which extracts the engine.
+
+Formalize the `serializedEngine` implementing `storageEngine`, with a compile-time `var _ storageEngine = (*serializedEngine)(nil)` assertion, storing each record as a serialized (JSON) byte buffer keyed by id and reconstructing by decoding. Confirm it is the engine resolved for the default/`WithSerializedStorage()` selection and that it supports both schema-typed and schemaless collections.
+
+### Task 2: Serialization-fidelity guarantees
+
+**Verifies:** serialized-storage#ac:mutation-after-write-isolated, serialized-storage#ac:two-reads-independent, serialized-storage#ac:non-serializable-write-errors
+**Depends-On:** 1
+
+Pin the fidelity contract: because records are stored as bytes and decoded afresh, mutating a caller value after a write does not affect stored data, two reads of one record are mutually independent, and a write of a non-serializable value fails with a descriptive error set on the record while storing nothing for that id.
+
+### Task 3: Schema-aware write semantics
+
+**Verifies:** serialized-storage#ac:unknown-field-rejected-when-typed, serialized-storage#ac:insert-duplicate-errors
+**Depends-On:** 1
+
+Lock the write rules: for a schema-typed collection a write/update carrying a field undefined on the type is rejected with a descriptive error naming the collection (no check for schemaless collections), `Insert` on an existing id returns an "already exists" error without overwriting, and `Set` overwrites; both validate before storing so a rejected write leaves storage unchanged.
+
+### Task 4: Read, query, and update semantics
+
+**Verifies:** serialized-storage#ac:get-absent-not-found, serialized-storage#ac:query-decodes-rows, serialized-storage#ac:update-applies-and-revalidates
+**Depends-On:** 1
+
+Cover reads and updates: `Get` on an absent id returns a not-found error set on the record while `Exists` reports false; query execution exposes decoded `map[string]any` views and typed materializations with no shared references between result records; and `Update` reads-modifies-writes the decoded data, re-runs the unknown-field check for typed collections, and returns not-found (storing nothing) on an absent id.
+
+## Open Questions
+
+- None at this time.
+
+---
+*This document follows the https://specscore.md/plan-specification*

--- a/spec/plans/2026-06-06-storage-engine-seam.md
+++ b/spec/plans/2026-06-06-storage-engine-seam.md
@@ -1,0 +1,51 @@
+# Plan: Pluggable per-collection storage engine seam (dalgo2memory)
+
+**Status:** Approved
+**Source Feature:** storage-engine-seam
+**Date:** 2026-06-06
+**Owner:** alex
+**Supersedes:** —
+
+## Summary
+
+Decomposes the `storage-engine-seam` Feature into four linear tasks: define the representation-neutral `storageEngine` interface, add the `CollectionOption`/`WithSerializedStorage()` selection plumbing on `WithCollection[T]`, route every operation through a per-collection engine registry (extracting today's JSON logic into a default Serialized engine), and prove per-collection selection plus full behavior preservation. All eight acceptance criteria are covered by a task; none are deferred. This is the first of three coordinated plans (`storage-engine-seam` → `serialized-storage` → `columnar-storage`).
+
+## Approach
+
+The seam is an interface plus a refactor, so the order is define-the-contract, add-the-selection, route-everything-through-it, then prove-it. Task 1 declares the internal `storageEngine` interface with no byte assumption. Task 2 adds the exported `CollectionOption` and `WithSerializedStorage()` and threads an engine choice onto the collection definition via `WithSchema`, keeping existing 2-arg `WithCollection[T]` calls compiling. Task 3 is the core refactor: replace `database.collections map[string]map[string][]byte` with a per-collection engine registry, move the existing `json.Marshal`/`json.Unmarshal`/`checkUnknownFields`/insert-guard/not-found logic into a default Serialized engine implementation (whose *formal contract* is owned by the `serialized-storage` plan), and make every `database`/`session` operation delegate — defaulting unregistered collections to Serialized. Task 4 proves a single database can host different engines per collection and that the whole existing suite still passes at 100% coverage. Tasks are strictly ordered: 2 needs 1's interface, 3 needs both, 4 verifies 3.
+
+## Tasks
+
+### Task 1: Define the storageEngine interface
+
+**Verifies:** storage-engine-seam#ac:engine-interface-defined
+
+Declare an internal `storageEngine` interface owning per-collection store-by-id (insert/overwrite), exists-by-id, load-by-id-into-record, delete-by-id, update-by-id (decoded field updates, not bytes), and row enumeration. Enumeration yields each row as a `map[string]any` field view plus a typed-materialization path, with no parameter or return type that is a serialized byte representation.
+
+### Task 2: CollectionOption plumbing and WithSerializedStorage()
+
+**Verifies:** storage-engine-seam#ac:withcollection-options-backward-compatible
+**Depends-On:** 1
+
+Introduce an exported `CollectionOption` type and `WithSerializedStorage()` option, and extend `WithCollection[T]` to `WithCollection[T](name, newRecord, opts ...CollectionOption)` so existing 2-arg calls compile unchanged with `newRecord` keeping its `func() *T` type. Record the selected engine on the collection definition so `WithSchema` carries it into the database.
+
+### Task 3: Route all operations through a per-collection engine registry
+
+**Verifies:** storage-engine-seam#ac:operations-succeed-through-engine, storage-engine-seam#ac:no-byte-map-on-database, storage-engine-seam#ac:default-is-serialized, storage-engine-seam#ac:unregistered-collection-is-serialized
+**Depends-On:** 2
+
+Replace `database.collections map[string]map[string][]byte` with a per-collection engine registry, extracting today's JSON marshal/unmarshal/`checkUnknownFields`/insert-guard/not-found logic into a default `serializedEngine` that implements the interface. Make every `database`/`session` operation (`Exists`, `Get`/`GetMulti`, `Set`/`SetMulti`, `Insert`/`InsertMulti`, `Delete`/`DeleteMulti`, `Update`/`UpdateRecord`/`UpdateMulti`, both query paths) delegate to the target collection's engine, resolving the Serialized default for any unregistered or option-less collection so observable behavior is unchanged.
+
+### Task 4: Per-collection engine selection and behavior preservation
+
+**Verifies:** storage-engine-seam#ac:mixed-engines-in-one-db, storage-engine-seam#ac:existing-suite-green
+**Depends-On:** 3
+
+Support distinct engines per collection within one `database`, each routing through its own engine instance with no cross-collection interference, and confirm the default and `WithSerializedStorage()` paths are observably identical to pre-Feature behavior. The full existing `dalgo2memory` test suite passes unchanged and statement coverage remains 100%.
+
+## Open Questions
+
+- Whether engine instances are constructed eagerly when the schema is applied or lazily on first write — both satisfy the ACs; settled during implementation.
+
+---
+*This document follows the https://specscore.md/plan-specification*

--- a/spec/plans/2026-06-06-storage-engine-seam.md
+++ b/spec/plans/2026-06-06-storage-engine-seam.md
@@ -1,6 +1,6 @@
 # Plan: Pluggable per-collection storage engine seam (dalgo2memory)
 
-**Status:** Approved
+**Status:** Completed
 **Source Feature:** storage-engine-seam
 **Date:** 2026-06-06
 **Owner:** alex
@@ -19,6 +19,7 @@ The seam is an interface plus a refactor, so the order is define-the-contract, a
 ### Task 1: Define the storageEngine interface
 
 **Verifies:** storage-engine-seam#ac:engine-interface-defined
+**Status:** done
 
 Declare an internal `storageEngine` interface owning per-collection store-by-id (insert/overwrite), exists-by-id, load-by-id-into-record, delete-by-id, update-by-id (decoded field updates, not bytes), and row enumeration. Enumeration yields each row as a `map[string]any` field view plus a typed-materialization path, with no parameter or return type that is a serialized byte representation.
 
@@ -26,6 +27,7 @@ Declare an internal `storageEngine` interface owning per-collection store-by-id 
 
 **Verifies:** storage-engine-seam#ac:withcollection-options-backward-compatible
 **Depends-On:** 1
+**Status:** done
 
 Introduce an exported `CollectionOption` type and `WithSerializedStorage()` option, and extend `WithCollection[T]` to `WithCollection[T](name, newRecord, opts ...CollectionOption)` so existing 2-arg calls compile unchanged with `newRecord` keeping its `func() *T` type. Record the selected engine on the collection definition so `WithSchema` carries it into the database.
 
@@ -33,6 +35,7 @@ Introduce an exported `CollectionOption` type and `WithSerializedStorage()` opti
 
 **Verifies:** storage-engine-seam#ac:operations-succeed-through-engine, storage-engine-seam#ac:no-byte-map-on-database, storage-engine-seam#ac:default-is-serialized, storage-engine-seam#ac:unregistered-collection-is-serialized
 **Depends-On:** 2
+**Status:** done
 
 Replace `database.collections map[string]map[string][]byte` with a per-collection engine registry, extracting today's JSON marshal/unmarshal/`checkUnknownFields`/insert-guard/not-found logic into a default `serializedEngine` that implements the interface. Make every `database`/`session` operation (`Exists`, `Get`/`GetMulti`, `Set`/`SetMulti`, `Insert`/`InsertMulti`, `Delete`/`DeleteMulti`, `Update`/`UpdateRecord`/`UpdateMulti`, both query paths) delegate to the target collection's engine, resolving the Serialized default for any unregistered or option-less collection so observable behavior is unchanged.
 
@@ -40,6 +43,7 @@ Replace `database.collections map[string]map[string][]byte` with a per-collectio
 
 **Verifies:** storage-engine-seam#ac:mixed-engines-in-one-db, storage-engine-seam#ac:existing-suite-green
 **Depends-On:** 3
+**Status:** done
 
 Support distinct engines per collection within one `database`, each routing through its own engine instance with no cross-collection interference, and confirm the default and `WithSerializedStorage()` paths are observably identical to pre-Feature behavior. The full existing `dalgo2memory` test suite passes unchanged and statement coverage remains 100%.
 

--- a/spec/plans/README.md
+++ b/spec/plans/README.md
@@ -1,3 +1,7 @@
+---
+format: https://specscore.md/plans-index-specification
+---
+
 # Plans
 
 Implementation plans linked to SpecScore Features. Each plan breaks a Feature into ordered,


### PR DESCRIPTION
## Summary

Adds a pluggable per-collection **storage-engine seam** to `dalgo2memory` and three engines behind it, all sourced from the `dalgo2memory-storage-engines` Idea and decomposed into four Approved (Grade A) Features + Plans.

| Feature | What it adds | Commit |
|---|---|---|
| `storage-engine-seam` | Internal `storageEngine` interface; all ops route through a per-collection engine registry (byte map removed); `WithCollection[T]` gains `...CollectionOption`; `WithSerializedStorage()`; unregistered → Serialized default. No behavior change. | `8b14b88` |
| `serialized-storage` | The default JSON-bytes engine, contract pinned by named AC tests (fidelity, schema validation, read/query/update). | `38625ff` |
| `columnar-storage` | Opt-in `WithColumnarStorage(...)`: reflection-built strongly-typed column slices (`[]any` fallback), stable row-slot + tombstone + compaction (under the existing global lock), hybrid write + schema-wide/per-collection fidelity opt-out, exported `ColumnStrategy` seam with the equality read-side wired into `WHERE`, results identical to Serialized. | `3d77714` |
| `columnar-mixed-mode-maps` | `WithDeclaredColumn[T]` for `map[string]any` collections: declared columns in typed slices + undeclared fields in a parallel leftover `[]map[string]any` sharing the slot; reads merge them; declared-column `WHERE` uses the strategy, leftover `WHERE` scans. | `316c1cc` |

The `ColumnStrategy` interface is exported so an out-of-core package (e.g. a future `bitmap4dalgo2memory`) can back a column without `dalgo2memory` taking a dependency. Bitmap indexing is intentionally **not** in core.

## Design notes
- **Concurrency unchanged:** retains the single global write lock — no per-collection 2PL/rollback (deferred per the Idea). Columnar slot/delete/compaction is race-free under that lock.
- **Single equality `WHERE` only:** the strategy slot-set return is shaped for future multi-predicate `AND` intersection, but only the equality predicate the adapter supports today is wired — no predicate broadening.
- **Known carry-forward:** numeric equality `WHERE` (e.g. `age == 30`) returns empty on *both* columnar and Serialized due to pre-existing int-vs-float64 JSON normalization in `matchesWhere`; parity holds (tracked as an Open Question).

## Quality
- `dalgo2memory` at **100.0% statement coverage**; full repo `go test ./...` green; **`go test -race` clean**; `go vet` + `golangci-lint` clean.
- Every commit references its acceptance-criteria IDs in a `Verifies:` trailer.

## Spec artifacts
- Idea: `spec/ideas/dalgo2memory-storage-engines.md`
- Features: `spec/features/{storage-engine-seam,serialized-storage,columnar-storage,columnar-mixed-mode-maps}/`
- Plans: `spec/plans/2026-06-06-*.md`

(Also includes a `specscore spec migrate` frontmatter backfill across existing spec files, required by updated lint rules.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
