### PR TITLE
fix(docs): correct dalgo2memory import path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ import (
 	"fmt"
 
 	"github.com/dal-go/dalgo/dal"
-	"github.com/dal-go/dalgo/dalgo2memory"
+	"github.com/dal-go/dalgo/adapters/dalgo2memory"
 )
 
 type User struct {


### PR DESCRIPTION
The README Quick Example imports `github.com/dal-go/dalgo/dalgo2memory`, but the package only exists at `adapters/dalgo2memory` (no root-level re-export). As written the example does not resolve / build.

Fixes the import to `github.com/dal-go/dalgo/adapters/dalgo2memory`, matching the reference links elsewhere in the README and the dal-go.github.io landing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)