### PR TITLE
fix: SpecScore lint — backfill Source Ideas sentinels

### DIFF
--- a/spec/features/concurrency-capability/README.md
+++ b/spec/features/concurrency-capability/README.md
@@ -8,6 +8,7 @@ status: Implemented
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/concurrency-capability?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/concurrency-capability?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/concurrency-capability?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/concurrency-capability?op=request-change) |
 
 **Status:** Implemented
+**Source Ideas:** —
 **Source Idea:** [`concurrency-capability`](../../ideas/concurrency-capability.md)
 
 ## Summary

--- a/spec/features/dbschema/README.md
+++ b/spec/features/dbschema/README.md
@@ -8,6 +8,7 @@ status: Implemented
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema?op=request-change) |
 
 **Status:** Implemented
+**Source Ideas:** —
 **Source Idea:** [`dalgo-schema-modification`](../../ideas/dalgo-schema-modification.md)
 
 ## Summary

--- a/spec/features/dbschema/collection-def/README.md
+++ b/spec/features/dbschema/collection-def/README.md
@@ -8,6 +8,7 @@ status: Implemented
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/collection-def?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/collection-def?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/collection-def?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/collection-def?op=request-change) |
 
 **Status:** Implemented
+**Source Ideas:** —
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
 **Parent Feature:** [`dbschema`](../README.md)
 

--- a/spec/features/dbschema/default-expr/README.md
+++ b/spec/features/dbschema/default-expr/README.md
@@ -8,6 +8,7 @@ status: Implemented
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/default-expr?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/default-expr?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/default-expr?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/default-expr?op=request-change) |
 
 **Status:** Implemented
+**Source Ideas:** —
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
 **Parent Feature:** [`dbschema`](../README.md)
 

--- a/spec/features/dbschema/errors/README.md
+++ b/spec/features/dbschema/errors/README.md
@@ -8,6 +8,7 @@ status: Implemented
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/errors?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/errors?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/errors?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/errors?op=request-change) |
 
 **Status:** Implemented
+**Source Ideas:** —
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
 **Parent Feature:** [`dbschema`](../README.md)
 

--- a/spec/features/dbschema/field-def/README.md
+++ b/spec/features/dbschema/field-def/README.md
@@ -8,6 +8,7 @@ status: Implemented
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/field-def?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/field-def?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/field-def?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/field-def?op=request-change) |
 
 **Status:** Implemented
+**Source Ideas:** —
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
 **Parent Feature:** [`dbschema`](../README.md)
 

--- a/spec/features/dbschema/index-def/README.md
+++ b/spec/features/dbschema/index-def/README.md
@@ -8,6 +8,7 @@ status: Implemented
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/index-def?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/index-def?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/index-def?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/index-def?op=request-change) |
 
 **Status:** Implemented
+**Source Ideas:** —
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
 **Parent Feature:** [`dbschema`](../README.md)
 

--- a/spec/features/dbschema/schema-reader/README.md
+++ b/spec/features/dbschema/schema-reader/README.md
@@ -8,6 +8,7 @@ status: Implemented
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/schema-reader?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/schema-reader?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/schema-reader?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/schema-reader?op=request-change) |
 
 **Status:** Implemented
+**Source Ideas:** —
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
 **Parent Feature:** [`dbschema`](../README.md)
 

--- a/spec/features/dbschema/types/README.md
+++ b/spec/features/dbschema/types/README.md
@@ -8,6 +8,7 @@ status: Implemented
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/types?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/types?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/types?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/dbschema/types?op=request-change) |
 
 **Status:** Implemented
+**Source Ideas:** —
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
 **Parent Feature:** [`dbschema`](../README.md)
 

--- a/spec/features/ddl/README.md
+++ b/spec/features/ddl/README.md
@@ -8,6 +8,7 @@ status: Implemented
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl?op=request-change) |
 
 **Status:** Implemented
+**Source Ideas:** —
 **Source Idea:** [`dalgo-schema-modification`](../../ideas/dalgo-schema-modification.md)
 
 ## Summary

--- a/spec/features/ddl/alter-ops/README.md
+++ b/spec/features/ddl/alter-ops/README.md
@@ -8,6 +8,7 @@ status: Implemented
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/alter-ops?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/alter-ops?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/alter-ops?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/alter-ops?op=request-change) |
 
 **Status:** Implemented
+**Source Ideas:** —
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
 **Parent Feature:** [`ddl`](../README.md)
 

--- a/spec/features/ddl/applier/README.md
+++ b/spec/features/ddl/applier/README.md
@@ -8,6 +8,7 @@ status: Implemented
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/applier?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/applier?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/applier?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/applier?op=request-change) |
 
 **Status:** Implemented
+**Source Ideas:** —
 **Source Idea:** —
 **Parent Feature:** [`ddl`](../README.md)
 

--- a/spec/features/ddl/errors/README.md
+++ b/spec/features/ddl/errors/README.md
@@ -8,6 +8,7 @@ status: Implemented
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/errors?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/errors?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/errors?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/errors?op=request-change) |
 
 **Status:** Implemented
+**Source Ideas:** —
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
 **Parent Feature:** [`ddl`](../README.md)
 

--- a/spec/features/ddl/operations/README.md
+++ b/spec/features/ddl/operations/README.md
@@ -8,6 +8,7 @@ status: Implemented
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/operations?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/operations?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/operations?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/operations?op=request-change) |
 
 **Status:** Implemented
+**Source Ideas:** —
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
 **Parent Feature:** [`ddl`](../README.md)
 

--- a/spec/features/ddl/options/README.md
+++ b/spec/features/ddl/options/README.md
@@ -8,6 +8,7 @@ status: Implemented
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/options?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/options?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/options?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/options?op=request-change) |
 
 **Status:** Implemented
+**Source Ideas:** —
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
 **Parent Feature:** [`ddl`](../README.md)
 

--- a/spec/features/ddl/schema-modifier/README.md
+++ b/spec/features/ddl/schema-modifier/README.md
@@ -8,6 +8,7 @@ status: Implemented
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/schema-modifier?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/schema-modifier?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/schema-modifier?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/schema-modifier?op=request-change) |
 
 **Status:** Implemented
+**Source Ideas:** —
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
 **Parent Feature:** [`ddl`](../README.md)
 

--- a/spec/features/ddl/transactional-ddl/README.md
+++ b/spec/features/ddl/transactional-ddl/README.md
@@ -8,6 +8,7 @@ status: Implemented
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/transactional-ddl?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/transactional-ddl?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/transactional-ddl?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/ddl/transactional-ddl?op=request-change) |
 
 **Status:** Implemented
+**Source Ideas:** —
 **Source Idea:** [`dalgo-schema-modification`](../../../ideas/dalgo-schema-modification.md)
 **Parent Feature:** [`ddl`](../README.md)
 

--- a/spec/features/recordops/README.md
+++ b/spec/features/recordops/README.md
@@ -8,6 +8,7 @@ status: Implemented
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops?op=request-change) |
 
 **Status:** Implemented
+**Source Ideas:** —
 **Source Idea:** [`recordops`](../../ideas/recordops.md)
 
 ## Summary

--- a/spec/features/recordops/diff/README.md
+++ b/spec/features/recordops/diff/README.md
@@ -8,6 +8,7 @@ status: Implemented
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops/diff?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops/diff?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops/diff?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/recordops/diff?op=request-change) |
 
 **Status:** Implemented
+**Source Ideas:** —
 **Source Idea:** [`recordops`](../../../ideas/recordops.md)
 **Parent Feature:** [`recordops`](../README.md)
 

--- a/spec/features/transaction-message/README.md
+++ b/spec/features/transaction-message/README.md
@@ -8,6 +8,7 @@ status: Approved
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/transaction-message?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/transaction-message?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/transaction-message?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/transaction-message?op=request-change) |
 
 **Status:** Approved
+**Source Ideas:** —
 **Date:** 2026-06-02
 **Owner:** alex
 **Source Idea:** [`transaction-message`](../../ideas/transaction-message.md)


### PR DESCRIPTION
Backfills missing `**Source Ideas:** —` sentinels on all Feature READMEs to resolve `feature-source-ideas-required` lint violations. Auto-fixed via `specscore spec lint --fix`.