### PR TITLE
feat: firestore-parity WHERE evaluation in dalgo2memory + array-contains query builders

### DIFF
--- a/adapters/dalgo2memory/database.go
+++ b/adapters/dalgo2memory/database.go
@@ -387,23 +387,121 @@ func keyID(key *dal.Key) string {
 	return fmt.Sprint(key.ID)
 }
 
+// matchesWhere evaluates the WHERE condition shapes that dalgo2firestore
+// translates to native Firestore filters, so memory-backed tests behave like
+// the Firestore adapter:
+//
+//   - FieldRef op Constant for ==, >, >=, <, <=
+//   - Constant In FieldRef    → Firestore's "array-contains"
+//   - FieldRef op dal.Array   → Firestore's "array-contains-any"
+//   - GroupCondition with AND → all sub-conditions must match
+//
+// Any other shape (including OR groups, which dalgo2firestore rejects) does
+// not match.
 func matchesWhere(data map[string]any, condition dal.Condition) bool {
 	if condition == nil {
 		return true
 	}
-	comparison, ok := condition.(dal.Comparison)
-	if !ok || comparison.Operator != dal.Equal {
+	switch cond := condition.(type) {
+	case dal.GroupCondition:
+		if cond.Operator() != dal.And {
+			return false
+		}
+		for _, c := range cond.Conditions() {
+			if !matchesWhere(data, c) {
+				return false
+			}
+		}
+		return true
+	case dal.Comparison:
+		return matchesComparison(data, cond)
+	default:
 		return false
 	}
-	field, ok := comparison.Left.(dal.FieldRef)
-	if !ok {
+}
+
+func matchesComparison(data map[string]any, comparison dal.Comparison) bool {
+	switch left := comparison.Left.(type) {
+	case dal.FieldRef:
+		switch right := comparison.Right.(type) {
+		case dal.Constant:
+			switch comparison.Operator {
+			case dal.Equal:
+				return data[left.Name()] == right.Value
+			case dal.GreaterThen, dal.GreaterOrEqual, dal.LessThen, dal.LessOrEqual:
+				value, ok := data[left.Name()]
+				if !ok {
+					return false
+				}
+				return compareOp(comparison.Operator, value, right.Value)
+			default:
+				return false
+			}
+		case dal.Array:
+			// dalgo2firestore maps FieldRef vs dal.Array to "array-contains-any"
+			// regardless of the operator; mirror that.
+			return fieldContainsAny(data[left.Name()], right.Value)
+		default:
+			return false
+		}
+	case dal.Constant:
+		// dalgo2firestore maps Constant In FieldRef to "array-contains".
+		right, ok := comparison.Right.(dal.FieldRef)
+		if !ok || comparison.Operator != dal.In {
+			return false
+		}
+		return fieldContains(data[right.Name()], left.Value)
+	default:
 		return false
 	}
-	constant, ok := comparison.Right.(dal.Constant)
-	if !ok {
+}
+
+// fieldContains reports whether the record field's value is a slice or array
+// containing v. Serialized rows decode JSON arrays as []any, so elements are
+// matched per elementEquals.
+func fieldContains(fieldValue, v any) bool {
+	rv := reflect.ValueOf(fieldValue)
+	if !rv.IsValid() || (rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array) {
 		return false
 	}
-	return data[field.Name()] == constant.Value
+	for i := 0; i < rv.Len(); i++ {
+		if elementEquals(rv.Index(i).Interface(), v) {
+			return true
+		}
+	}
+	return false
+}
+
+// fieldContainsAny reports whether the record field's value is a slice or
+// array containing at least one element of values ("array-contains-any").
+func fieldContainsAny(fieldValue, values any) bool {
+	rv := reflect.ValueOf(values)
+	if !rv.IsValid() || (rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array) {
+		return false
+	}
+	for i := 0; i < rv.Len(); i++ {
+		if fieldContains(fieldValue, rv.Index(i).Interface()) {
+			return true
+		}
+	}
+	return false
+}
+
+// elementEquals matches an array element against a constant. Numbers are
+// compared by value because serialized rows decode all JSON numbers as
+// float64; everything else uses Go equality (uncomparable values never match).
+func elementEquals(a, b any) bool {
+	if af, ok := number(a); ok {
+		bf, ok := number(b)
+		return ok && af == bf
+	}
+	if t := reflect.TypeOf(a); t != nil && !t.Comparable() {
+		return false
+	}
+	if t := reflect.TypeOf(b); t != nil && !t.Comparable() {
+		return false
+	}
+	return a == b
 }
 
 func compare(a, b any) int {

--- a/adapters/dalgo2memory/database.go
+++ b/adapters/dalgo2memory/database.go
@@ -209,7 +209,14 @@ func (s session) SetMulti(ctx context.Context, records []dal.Record) error {
 const insertWithGeneratorMaxAttempts = 100
 
 func (s session) Insert(ctx context.Context, record dal.Record, opts ...dal.InsertOption) error {
-	if gen := dal.NewInsertOptions(opts...).IDGenerator(); gen != nil {
+	options := dal.NewInsertOptions(opts...)
+	gen := options.IDGenerator()
+	if gen == nil && options.PreferAdapterGeneratedID() {
+		// The in-memory backend has no native ID generation mechanism, so per the
+		// dal.WithAdapterGeneratedID contract fall back to the default random-string generator.
+		gen = dal.NewInsertOptions(dal.WithRandomStringKey(dal.DefaultRandomStringIDLength, 5)).IDGenerator()
+	}
+	if gen != nil {
 		return dal.InsertWithIdGenerator(ctx, record, gen, insertWithGeneratorMaxAttempts,
 			func(key *dal.Key) error {
 				if s.db.engine(key.Collection()).exists(keyID(key)) {

--- a/adapters/dalgo2memory/generated_insert_test.go
+++ b/adapters/dalgo2memory/generated_insert_test.go
@@ -80,6 +80,54 @@ func TestSession_Insert_GeneratesViaInsertOption(t *testing.T) {
 	assert.Equal(t, "Alice", out.Name)
 }
 
+// TestSession_Insert_WithAdapterGeneratedID verifies that
+// dal.WithAdapterGeneratedID is honored by dalgo2memory: the in-memory backend
+// has no native ID generation, so per the option's contract it falls back to
+// the default random-string generator and the record is retrievable by the
+// generated id.
+func TestSession_Insert_WithAdapterGeneratedID(t *testing.T) {
+	ctx := context.Background()
+	db := dalgo2memory.NewDB()
+
+	var record dal.Record
+	require.NoError(t, db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		record = dal.NewRecordWithIncompleteKey("users", reflect.String, &genUser{Name: "Alice"})
+		return tx.Insert(ctx, record, dal.WithAdapterGeneratedID())
+	}))
+
+	id, ok := record.Key().ID.(string)
+	require.True(t, ok, "generated id must be a string")
+	require.NotEmpty(t, id)
+	assert.Len(t, id, dal.DefaultRandomStringIDLength)
+
+	// Retrievable by the generated id.
+	out := &genUser{}
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(dal.NewKeyWithID("users", id), out)))
+	assert.Equal(t, "Alice", out.Name)
+}
+
+// TestSession_Insert_WithAdapterGeneratedID_ExplicitGeneratorWins verifies that
+// when dal.WithAdapterGeneratedID is combined with an explicit generator
+// option, the explicit generator wins (a 24-char id, not the 16-char default).
+func TestSession_Insert_WithAdapterGeneratedID_ExplicitGeneratorWins(t *testing.T) {
+	ctx := context.Background()
+	db := dalgo2memory.NewDB()
+
+	var record dal.Record
+	require.NoError(t, db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		record = dal.NewRecordWithIncompleteKey("users", reflect.String, &genUser{Name: "Bob"})
+		return tx.Insert(ctx, record, dal.WithAdapterGeneratedID(), dal.WithRandomStringKey(24, 5))
+	}))
+
+	id, ok := record.Key().ID.(string)
+	require.True(t, ok, "generated id must be a string")
+	assert.Len(t, id, 24, "explicit generator must win over WithAdapterGeneratedID")
+
+	out := &genUser{}
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(dal.NewKeyWithID("users", id), out)))
+	assert.Equal(t, "Bob", out.Name)
+}
+
 // TestSession_Insert_GenerationPrecedesStorage_NoNilID verifies (part of AC
 // generation-precedes-storage) that a generated insert never stores under a
 // "<nil>" id.

--- a/adapters/dalgo2memory/where_test.go
+++ b/adapters/dalgo2memory/where_test.go
@@ -1,0 +1,232 @@
+package dalgo2memory
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchesWhere(t *testing.T) {
+	data := map[string]any{
+		"Name":   "Alice",
+		"Age":    42,
+		"Tags":   []string{"a", "b"},
+		"AnyTag": []any{"x", "y", float64(7)},
+		"Bad":    []any{[]any{"nested"}},
+	}
+	fieldRef := dal.Field
+	cmp := func(left dal.Expression, op dal.Operator, right dal.Expression) dal.Comparison {
+		return dal.Comparison{Left: left, Operator: op, Right: right}
+	}
+	for _, tt := range []struct {
+		name      string
+		condition dal.Condition
+		want      bool
+	}{
+		{"nil_condition", nil, true},
+		{"unsupported_condition_type", notComparison{}, false},
+
+		// FieldRef op Constant
+		{"equal_match", cmp(fieldRef("Name"), dal.Equal, dal.Constant{Value: "Alice"}), true},
+		{"equal_mismatch", cmp(fieldRef("Name"), dal.Equal, dal.Constant{Value: "Bob"}), false},
+		{"greater_true", cmp(fieldRef("Age"), dal.GreaterThen, dal.Constant{Value: 41}), true},
+		{"greater_false", cmp(fieldRef("Age"), dal.GreaterThen, dal.Constant{Value: 42}), false},
+		{"greater_or_equal_true", cmp(fieldRef("Age"), dal.GreaterOrEqual, dal.Constant{Value: 42}), true},
+		{"greater_or_equal_false", cmp(fieldRef("Age"), dal.GreaterOrEqual, dal.Constant{Value: 43}), false},
+		{"less_true", cmp(fieldRef("Age"), dal.LessThen, dal.Constant{Value: 43}), true},
+		{"less_false", cmp(fieldRef("Age"), dal.LessThen, dal.Constant{Value: 42}), false},
+		{"less_or_equal_true", cmp(fieldRef("Age"), dal.LessOrEqual, dal.Constant{Value: 42}), true},
+		{"less_or_equal_false", cmp(fieldRef("Age"), dal.LessOrEqual, dal.Constant{Value: 41}), false},
+		{"ordering_missing_field", cmp(fieldRef("Missing"), dal.GreaterThen, dal.Constant{Value: 0}), false},
+		{"unsupported_operator", cmp(fieldRef("Age"), dal.In, dal.Constant{Value: 42}), false},
+		{"unsupported_right_operand", cmp(fieldRef("Age"), dal.Equal, fieldRef("Name")), false},
+
+		// Constant In FieldRef → array-contains
+		{"array_contains_typed_slice", cmp(dal.Constant{Value: "a"}, dal.In, fieldRef("Tags")), true},
+		{"array_contains_any_slice", cmp(dal.Constant{Value: "x"}, dal.In, fieldRef("AnyTag")), true},
+		{"array_contains_numeric_coercion", cmp(dal.Constant{Value: 7}, dal.In, fieldRef("AnyTag")), true},
+		{"array_contains_no_match", cmp(dal.Constant{Value: "z"}, dal.In, fieldRef("Tags")), false},
+		{"array_contains_missing_field", cmp(dal.Constant{Value: "a"}, dal.In, fieldRef("Missing")), false},
+		{"array_contains_non_slice_field", cmp(dal.Constant{Value: "Alice"}, dal.In, fieldRef("Name")), false},
+		{"array_contains_uncomparable_element", cmp(dal.Constant{Value: "nested"}, dal.In, fieldRef("Bad")), false},
+		{"array_contains_uncomparable_constant", cmp(dal.Constant{Value: []string{"a"}}, dal.In, fieldRef("Tags")), false},
+		{"array_contains_number_vs_string", cmp(dal.Constant{Value: 1}, dal.In, fieldRef("Tags")), false},
+		{"constant_left_wrong_operator", cmp(dal.Constant{Value: "a"}, dal.Equal, fieldRef("Tags")), false},
+		{"constant_left_wrong_right_operand", cmp(dal.Constant{Value: "a"}, dal.In, dal.Constant{Value: "a"}), false},
+
+		// FieldRef op dal.Array → array-contains-any
+		{"array_contains_any_match", cmp(fieldRef("Tags"), dal.In, dal.Array{Value: []string{"z", "b"}}), true},
+		{"array_contains_any_no_match", cmp(fieldRef("Tags"), dal.In, dal.Array{Value: []string{"y", "z"}}), false},
+		{"array_contains_any_non_slice_field", cmp(fieldRef("Name"), dal.In, dal.Array{Value: []string{"Alice"}}), false},
+		{"array_contains_any_non_slice_values", cmp(fieldRef("Tags"), dal.In, dal.Array{Value: "a"}), false},
+		{"array_contains_any_nil_values", cmp(fieldRef("Tags"), dal.In, dal.Array{}), false},
+
+		// unsupported left operand
+		{"unsupported_left_operand", cmp(dal.Array{Value: []string{"a"}}, dal.In, fieldRef("Tags")), false},
+
+		// group conditions
+		{"group_and_all_match", dal.NewGroupCondition(dal.And,
+			cmp(fieldRef("Name"), dal.Equal, dal.Constant{Value: "Alice"}),
+			cmp(dal.Constant{Value: "b"}, dal.In, fieldRef("Tags")),
+		), true},
+		{"group_and_one_fails", dal.NewGroupCondition(dal.And,
+			cmp(fieldRef("Name"), dal.Equal, dal.Constant{Value: "Alice"}),
+			cmp(fieldRef("Age"), dal.Equal, dal.Constant{Value: 1}),
+		), false},
+		{"group_or_unsupported", dal.NewGroupCondition(dal.Or,
+			cmp(fieldRef("Name"), dal.Equal, dal.Constant{Value: "Alice"}),
+		), false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, matchesWhere(data, tt.condition))
+		})
+	}
+}
+
+func TestElementEquals(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		a, b any
+		want bool
+	}{
+		{"equal_strings", "a", "a", true},
+		{"different_strings", "a", "b", false},
+		{"numbers_cross_type", float64(7), 7, true},
+		{"numbers_unequal", float64(7), 8, false},
+		{"number_vs_string", 7, "7", false},
+		{"string_vs_number", "7", 7, false},
+		{"uncomparable_element", []any{"x"}, "x", false},
+		{"uncomparable_constant", "x", []any{"x"}, false},
+		{"both_nil", nil, nil, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, elementEquals(tt.a, tt.b))
+		})
+	}
+}
+
+type taggedThing struct {
+	Name string
+	Rank int
+	Tags []string
+}
+
+// queryTaggedThings runs a keys-only query over the "tagged" collection and
+// returns the sorted matched IDs.
+func queryTaggedThings(t *testing.T, db *database, where func(qb *dal.QueryBuilder) dal.IQueryBuilder) []string {
+	t.Helper()
+	q := where(dal.From(dal.NewRootCollectionRef("tagged", "")).NewQuery()).
+		SelectKeysOnly(reflect.String)
+	reader, err := db.ExecuteQueryToRecordsReader(context.Background(), q)
+	require.NoError(t, err)
+	ids := make([]string, 0)
+	for _, record := range readAll(t, reader) {
+		ids = append(ids, record.Key().ID.(string))
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func insertTaggedThings(t *testing.T, db *database) {
+	t.Helper()
+	ctx := context.Background()
+	for id, data := range map[string]*taggedThing{
+		"t1": {Name: "first", Rank: 1, Tags: []string{"red", "blue"}},
+		"t2": {Name: "second", Rank: 2, Tags: []string{"blue", "green"}},
+		"t3": {Name: "third", Rank: 3, Tags: nil},
+	} {
+		key := dal.NewKeyWithID("tagged", id)
+		require.NoError(t, db.Insert(ctx, dal.NewRecordWithData(key, data)))
+	}
+}
+
+// TestQueryWhereArrayContainsEndToEnd exercises the firestore "array-contains"
+// shape end to end: records persisted with a []string field (the serialized
+// engine decodes it back as []any of string) matched via WhereArrayContains.
+func TestQueryWhereArrayContainsEndToEnd(t *testing.T) {
+	db := NewDB().(*database)
+	insertTaggedThings(t, db)
+
+	for _, tt := range []struct {
+		value string
+		want  []string
+	}{
+		{"blue", []string{"t1", "t2"}},
+		{"green", []string{"t2"}},
+		{"purple", []string{}},
+	} {
+		t.Run(tt.value, func(t *testing.T) {
+			ids := queryTaggedThings(t, db, func(qb *dal.QueryBuilder) dal.IQueryBuilder {
+				return qb.WhereArrayContains("Tags", tt.value)
+			})
+			require.Equal(t, tt.want, ids)
+		})
+	}
+}
+
+// TestQueryWhereArrayContainsAnyEndToEnd exercises the firestore
+// "array-contains-any" shape end to end.
+func TestQueryWhereArrayContainsAnyEndToEnd(t *testing.T) {
+	db := NewDB().(*database)
+	insertTaggedThings(t, db)
+
+	for _, tt := range []struct {
+		name   string
+		values []string
+		want   []string
+	}{
+		{"one_common", []string{"green", "purple"}, []string{"t2"}},
+		{"matches_all_tagged", []string{"red", "green"}, []string{"t1", "t2"}},
+		{"no_match", []string{"purple"}, []string{}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ids := queryTaggedThings(t, db, func(qb *dal.QueryBuilder) dal.IQueryBuilder {
+				return qb.WhereArrayContainsAny("Tags", tt.values)
+			})
+			require.Equal(t, tt.want, ids)
+		})
+	}
+}
+
+// TestQueryWhereOperatorsEndToEnd exercises ordering operators end to end.
+func TestQueryWhereOperatorsEndToEnd(t *testing.T) {
+	db := NewDB().(*database)
+	insertTaggedThings(t, db)
+
+	for _, tt := range []struct {
+		name     string
+		operator dal.Operator
+		value    int
+		want     []string
+	}{
+		{"greater", dal.GreaterThen, 1, []string{"t2", "t3"}},
+		{"greater_or_equal", dal.GreaterOrEqual, 2, []string{"t2", "t3"}},
+		{"less", dal.LessThen, 3, []string{"t1", "t2"}},
+		{"less_or_equal", dal.LessOrEqual, 1, []string{"t1"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ids := queryTaggedThings(t, db, func(qb *dal.QueryBuilder) dal.IQueryBuilder {
+				return qb.WhereField("Rank", tt.operator, tt.value)
+			})
+			require.Equal(t, tt.want, ids)
+		})
+	}
+}
+
+// TestQueryWhereMultipleConditionsEndToEnd verifies that multiple Where
+// conditions (compiled into an AND GroupCondition) are all applied.
+func TestQueryWhereMultipleConditionsEndToEnd(t *testing.T) {
+	db := NewDB().(*database)
+	insertTaggedThings(t, db)
+
+	ids := queryTaggedThings(t, db, func(qb *dal.QueryBuilder) dal.IQueryBuilder {
+		return qb.
+			WhereArrayContains("Tags", "blue").
+			WhereField("Rank", dal.GreaterThen, 1)
+	})
+	require.Equal(t, []string{"t2"}, ids)
+}

--- a/dal/q_builder.go
+++ b/dal/q_builder.go
@@ -19,6 +19,8 @@ type IQueryBuilder interface {
 	Where(conditions ...Condition) IQueryBuilder
 	WhereField(name string, operator Operator, v any) IQueryBuilder
 	WhereInArrayField(name string, v any) IQueryBuilder
+	WhereArrayContains(name string, v any) IQueryBuilder
+	WhereArrayContainsAny(name string, values any) IQueryBuilder
 	GroupBy(expressions ...Expression) IQueryBuilder
 	Having(conditions ...Condition) IQueryBuilder
 	OrderBy(expressions ...OrderExpression) IQueryBuilder
@@ -105,6 +107,25 @@ func (s *QueryBuilder) WhereField(name string, operator Operator, v any) IQueryB
 
 func (s *QueryBuilder) WhereInArrayField(name string, v any) IQueryBuilder {
 	s.conditions = append(s.conditions, Comparison{Left: Constant{Value: v}, Operator: In, Right: FieldRef{name: name}})
+	return s
+}
+
+// WhereArrayContains adds a condition that an array field contains the given value.
+// Adapters translate it to the platform's array membership operator,
+// e.g. Firestore's "array-contains". It is an alias for WhereInArrayField.
+func (s *QueryBuilder) WhereArrayContains(name string, v any) IQueryBuilder {
+	return s.WhereInArrayField(name, v)
+}
+
+// WhereArrayContainsAny adds a condition that an array field contains at least one
+// element of the given values, e.g. Firestore's "array-contains-any".
+// The values must be a dal.Array or a slice type supported by NewArray.
+func (s *QueryBuilder) WhereArrayContainsAny(name string, values any) IQueryBuilder {
+	arr, ok := values.(Array)
+	if !ok {
+		arr = NewArray(values)
+	}
+	s.conditions = append(s.conditions, Comparison{Left: FieldRef{name: name}, Operator: In, Right: arr})
 	return s
 }
 

--- a/dal/q_builder_test.go
+++ b/dal/q_builder_test.go
@@ -67,6 +67,53 @@ func TestQueryBuilder(t *testing.T) {
 		}
 	})
 
+	t.Run("with_where_array_contains", func(t *testing.T) {
+		qb2 := qb.Clone().WhereArrayContains("tags", "important")
+		q := qb2.SelectIntoRecord(newRecord)
+		assertQuery(t, q)
+
+		// Same shape as WhereInArrayField: value In field, what dalgo2firestore
+		// translates to "array-contains".
+		if comparison, ok := q.Where().(Comparison); ok {
+			assert.Equal(t, In, comparison.Operator)
+			assert.Equal(t, Constant{Value: "important"}, comparison.Left)
+			assert.Equal(t, FieldRef{name: "tags"}, comparison.Right)
+		} else {
+			t.Errorf("Expected Comparison condition, got %T", q.Where())
+		}
+	})
+
+	t.Run("with_where_array_contains_any", func(t *testing.T) {
+		qb2 := qb.Clone().WhereArrayContainsAny("tags", []string{"a", "b"})
+		q := qb2.SelectIntoRecord(newRecord)
+		assertQuery(t, q)
+
+		// Shape: field In array, what dalgo2firestore translates to
+		// "array-contains-any".
+		if comparison, ok := q.Where().(Comparison); ok {
+			assert.Equal(t, In, comparison.Operator)
+			assert.Equal(t, FieldRef{name: "tags"}, comparison.Left)
+			assert.Equal(t, Array{Value: []string{"a", "b"}}, comparison.Right)
+		} else {
+			t.Errorf("Expected Comparison condition, got %T", q.Where())
+		}
+	})
+
+	t.Run("with_where_array_contains_any_passing_array", func(t *testing.T) {
+		arr := Array{Value: []int{1, 2}}
+		qb2 := qb.Clone().WhereArrayContainsAny("nums", arr)
+		q := qb2.SelectIntoRecord(newRecord)
+		assertQuery(t, q)
+
+		if comparison, ok := q.Where().(Comparison); ok {
+			assert.Equal(t, In, comparison.Operator)
+			assert.Equal(t, FieldRef{name: "nums"}, comparison.Left)
+			assert.Equal(t, arr, comparison.Right)
+		} else {
+			t.Errorf("Expected Comparison condition, got %T", q.Where())
+		}
+	})
+
 	t.Run("SelectIntoRecordset", func(t *testing.T) {
 		q := qb.Clone().SelectIntoRecordset()
 		assert.NotNil(t, q)

--- a/dal/tx_inserter.go
+++ b/dal/tx_inserter.go
@@ -24,14 +24,23 @@ type IDGenerator = func(ctx context.Context, record Record) error
 // InsertOptions defines interface for insert options
 type InsertOptions interface {
 	IDGenerator() IDGenerator
+
+	// PreferAdapterGeneratedID reports whether WithAdapterGeneratedID was passed.
+	// See WithAdapterGeneratedID for the contract adapters must follow.
+	PreferAdapterGeneratedID() bool
 }
 
 type insertOptions struct {
-	idGenerator IDGenerator
+	idGenerator              IDGenerator
+	preferAdapterGeneratedID bool
 }
 
 func (v insertOptions) IDGenerator() IDGenerator {
 	return v.idGenerator
+}
+
+func (v insertOptions) PreferAdapterGeneratedID() bool {
+	return v.preferAdapterGeneratedID
 }
 
 var _ InsertOptions = (*insertOptions)(nil)
@@ -47,6 +56,26 @@ func NewInsertOptions(opts ...InsertOption) InsertOptions {
 
 // InsertOption defines a contract for an insert option
 type InsertOption func(options *insertOptions)
+
+// WithAdapterGeneratedID requests that the storage adapter generates the record
+// ID natively (e.g. Firestore's client-side auto-generated 20-char document IDs).
+//
+// Contract for adapters:
+//   - An adapter SHOULD use its backend's native ID generation mechanism if it has one.
+//   - An adapter that has no native mechanism MUST fall back to the default
+//     random-string generator (WithRandomStringKey(DefaultRandomStringIDLength, 5)),
+//     so this option never fails on a compliant adapter.
+//   - If an explicit ID generator option (e.g. WithRandomStringKey) is supplied
+//     alongside this option, the explicit generator wins: adapters must check
+//     InsertOptions.IDGenerator() first and only consult
+//     InsertOptions.PreferAdapterGeneratedID() when it is nil.
+//
+// Adapters introspect this option via InsertOptions.PreferAdapterGeneratedID().
+func WithAdapterGeneratedID() InsertOption {
+	return func(options *insertOptions) {
+		options.preferAdapterGeneratedID = true
+	}
+}
 
 type randomStringOptions struct {
 	length int

--- a/dal/tx_inserter_test.go
+++ b/dal/tx_inserter_test.go
@@ -167,6 +167,23 @@ func TestInsertOptions_IDGenerator(t *testing.T) {
 	assert.Equal(t, err, io.IDGenerator()(context.Background(), nil))
 }
 
+func TestWithAdapterGeneratedID(t *testing.T) {
+	t.Run("default_is_false", func(t *testing.T) {
+		io := NewInsertOptions()
+		assert.False(t, io.PreferAdapterGeneratedID())
+	})
+	t.Run("option_sets_flag", func(t *testing.T) {
+		io := NewInsertOptions(WithAdapterGeneratedID())
+		assert.True(t, io.PreferAdapterGeneratedID())
+		assert.Nil(t, io.IDGenerator())
+	})
+	t.Run("explicit_generator_is_preserved_alongside_flag", func(t *testing.T) {
+		io := NewInsertOptions(WithAdapterGeneratedID(), WithRandomStringKey(10, 5))
+		assert.True(t, io.PreferAdapterGeneratedID())
+		assert.NotNil(t, io.IDGenerator(), "explicit generator must win: adapters check IDGenerator() first")
+	})
+}
+
 func TestNewInsertOptions(t *testing.T) {
 	called := false
 	o := func(options *insertOptions) {


### PR DESCRIPTION
## Why

Consumer code queries Firestore array fields (e.g. `BothCounterpartyIDs []string`) via conditions that `dalgo2firestore` translates to native Firestore filters, while `adapters/dalgo2memory` — used as the test double for that code — evaluated only `FieldRef == Constant` and silently matched nothing for every other condition shape. This PR brings the memory adapter's WHERE evaluation to parity with the `dalgo2firestore` translation rules and adds query-builder conveniences for the array-membership shapes.

## Condition shapes now supported by `dalgo2memory` WHERE

Mirroring `dalgo2firestore`'s `applyWhere`:

| Shape | Firestore translation | Memory evaluation |
|---|---|---|
| `FieldRef == Constant` | `Where(field, "==", v)` | unchanged (Go `==`, backward compatible) |
| `FieldRef >/>=/</<= Constant` | `Where(field, op, v)` | shared `compareOp` comparator (same semantics as HAVING) |
| `Constant In FieldRef` | `Where(field, "array-contains", v)` | field decodes to slice/array containing the constant (handles both `[]string` and JSON-decoded `[]any`; numbers compared by value since JSON decodes numbers as `float64`) |
| `FieldRef <any op> dal.Array` | `Where(field, "array-contains-any", v)` | true if any element of the constant array is contained (operator ignored, as in firestore) |
| `GroupCondition` with `AND` | each comparison applied | all sub-conditions must match (recursive) — this also fixes multiple `.Where(...)` conditions, which the builder compiles into an AND group and which previously matched nothing |

## Intentionally NOT supported (still no match)

- `OR` group conditions — `dalgo2firestore` returns an error for them; supporting them only in memory would let tests pass against code that fails on Firestore.
- `FieldRef In Constant` (Firestore's "In") and any other operand shapes — unchanged behavior, no match.
- Join queries keep their separate `matchesJoinCondition` evaluator unchanged.

## Safety of the fast paths

- The columnar engine's `candidateSlots` only has an opinion for the single `FieldRef == Constant` predicate; every new shape (including AND groups) yields "no opinion", so those queries conservatively fall back to a full scan and are filtered by `matchesWhere` — no wrongly narrowed candidates.
- `Equal` keeps the exact prior `data[field] == constant.Value` semantics, staying consistent with the columnar `EqualSlots` strategy.

## New public API

```go
// on dal.IQueryBuilder / *dal.QueryBuilder
WhereArrayContains(name string, v any) IQueryBuilder        // alias for WhereInArrayField: Constant In FieldRef → "array-contains"
WhereArrayContainsAny(name string, values any) IQueryBuilder // FieldRef In dal.Array → "array-contains-any"

// package dal — insert options
WithAdapterGeneratedID() InsertOption                 // "let the backend generate the ID natively"
InsertOptions.PreferAdapterGeneratedID() bool         // introspection accessor for adapters
```

## `dal.WithAdapterGeneratedID()` insert option

Lets consumers say "I don't care what the ID is — let the storage backend generate it natively" (e.g. Firestore's client-side auto-generated 20-char document IDs). Contract (documented in the godoc):

- An adapter SHOULD use its backend's native ID generation mechanism if it has one.
- An adapter without a native mechanism MUST fall back to the default random-string generator (`WithRandomStringKey(DefaultRandomStringIDLength, 5)`), so the option never fails on a compliant adapter.
- An explicit generator option always wins: adapters check `InsertOptions.IDGenerator()` first and only consult `PreferAdapterGeneratedID()` when it is `nil`.

`dalgo2memory` implements the option via the fallback path (it has no native ID mechanism).

## Tests

- Table-driven unit tests covering every branch of the new evaluation code (`matchesWhere`, `matchesComparison`, `fieldContains`, `fieldContainsAny`, `elementEquals` all at 100% statement coverage).
- End-to-end tests: records inserted with a `[]string` field, queried via `WhereArrayContains` / `WhereArrayContainsAny` / `WhereField` with `>`, `>=`, `<`, `<=`, and a multi-condition (AND) query.
- `WithAdapterGeneratedID`: introspection accessor unit tests plus dalgo2memory end-to-end tests (option alone → non-empty 16-char string ID, record retrievable; option + explicit generator → explicit generator wins). New code at 100% statement coverage.
- `go test ./...`, `go vet ./...`, and `golangci-lint run` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
