### PR TITLE
feat(dal): type Collection by id (Collection[K,T]) + record/by-key accessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ func main() {
 
 For everyday point CRUD you usually do not need to build keys, wrap records, and
 type-assert data by hand. DALgo provides a generic, session-less
-`dal.Collection[T]` handle that returns typed values directly. It is additive
-over the core API, uses no reflection of its own, and works with every adapter.
+`dal.Collection[K, T]` handle (id type `K`, record type `T`) that returns typed
+values directly. It is additive over the core API, uses no reflection of its
+own, and works with every adapter.
 
 ```go
 type User struct {
@@ -96,21 +97,21 @@ type User struct {
 // CollectionName (value receiver) names the collection.
 func (User) CollectionName() string { return "users" }
 
-// A Collection[T] holds no session, so declare it once and reuse it
-// (e.g. as a package-level var).
-var Users = dal.CollectionOf[User]()
+// A Collection[K, T] holds no session, so declare it once and reuse it
+// (e.g. as a package-level var). Here ids are strings (K = string).
+var Users = dal.CollectionOf[string, User]()
 
 func demo(ctx context.Context, db dal.DB) error {
 	// Writes go through a read-write transaction. Because dal.DB is not a
 	// WriteSession, calling a write terminal with a plain db is a compile error.
 	if err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
-		return Users.Set(ctx, tx, "u1", User{Name: "Ada Lovelace", Email: "ada@example.com"})
+		return Users.SetByID(ctx, tx, "u1", User{Name: "Ada Lovelace", Email: "ada@example.com"})
 	}); err != nil {
 		return err
 	}
 
 	// Reads take a dal.ReadSession (a plain dal.DB satisfies it) and return T.
-	user, err := Users.Get(ctx, db, "u1")
+	user, err := Users.GetData(ctx, db, "u1")
 	if err != nil {
 		return err // not-found is reported via dal.IsNotFound(err)
 	}
@@ -121,11 +122,19 @@ func demo(ctx context.Context, db dal.DB) error {
 
 The handle exposes the common operations as typed terminals:
 
-- **Reads:** `Get` (one record → `T`), `All` (whole collection → `[]T`),
-  `First`, `Count`, `Exists`.
+- **Reads:** `GetData` (one record → `T`), `GetRecord` (→ `dal.Record`),
+  `All` (whole collection → `[]T`), `First`, `Count`, `Exists`. For a typed
+  id+record pair use `record.GetWithID(ctx, coll, s, id)` (a free function in
+  package `record`, since `dal` stays free of any `record` import).
 - **Writes:** `Insert` (generated id → `*dal.Key`), `InsertWithID` (known id),
-  `Set` (upsert), `Update`, `Delete`, and batch `InsertMany` via the opt-in
-  `dal.ManyInserter[T]` interface.
+  `InsertRecord`, `SetByID` (upsert), `SetRecord`, `UpdateByID`, `UpdateByKey`,
+  `DeleteByID`, `DeleteByKey`, and batch `InsertMany` via the opt-in
+  `dal.ManyInserter[K, T]` interface.
+- **Composite / multi-field keys:** pass `dal.WithKeyOptions(...)` to the
+  constructor, or build a `*dal.Key` with `dal.NewKeyWithFields` and use the
+  `*ByKey` terminals.
+- **Deprecated aliases:** `Get`/`Set`/`Update`/`Delete` remain as thin
+  delegators to `GetData`/`SetByID`/`UpdateByID`/`DeleteByID`.
 - **Nesting:** `In(parentKey)` scopes the handle to a subcollection such as
   `users/u1/contacts`.
 - **Compile-time safety:** read terminals take `dal.ReadSession` and write
@@ -174,10 +183,10 @@ type User struct {
 
 func (User) CollectionName() string { return "users" }
 
-var Users = dal.CollectionOf[User]()
+var Users = dal.CollectionOf[string, User]()
 
 func GetUser(ctx context.Context, db dal.DB, id string) (User, error) {
-	return Users.Get(ctx, db, id)
+	return Users.GetData(ctx, db, id)
 }
 ```
 

--- a/adapters/dalgo2memory/generated_insert_test.go
+++ b/adapters/dalgo2memory/generated_insert_test.go
@@ -23,7 +23,7 @@ type genUser struct {
 func TestCollection_Insert_EndToEnd(t *testing.T) {
 	ctx := context.Background()
 	db := dalgo2memory.NewDB()
-	users := dal.CollectionAt[genUser]("e2eusers")
+	users := dal.CollectionAt[string, genUser]("e2eusers")
 
 	// Default generator (no options).
 	var k1 *dal.Key
@@ -36,7 +36,7 @@ func TestCollection_Insert_EndToEnd(t *testing.T) {
 	id1, ok := k1.ID.(string)
 	require.True(t, ok)
 	require.NotEmpty(t, id1)
-	got1, err := users.Get(ctx, db, id1)
+	got1, err := users.GetData(ctx, db, id1)
 	require.NoError(t, err)
 	assert.Equal(t, "Alice", got1.Name)
 
@@ -50,7 +50,7 @@ func TestCollection_Insert_EndToEnd(t *testing.T) {
 	id2, ok := k2.ID.(string)
 	require.True(t, ok)
 	assert.Len(t, id2, 24)
-	got2, err := users.Get(ctx, db, id2)
+	got2, err := users.GetData(ctx, db, id2)
 	require.NoError(t, err)
 	assert.Equal(t, "Bob", got2.Name)
 }

--- a/dal/collection.go
+++ b/dal/collection.go
@@ -9,7 +9,7 @@ import (
 	"github.com/dal-go/dalgo/update"
 )
 
-// ErrInsertOptionNotHonored is returned by Collection[T].Insert when the
+// ErrInsertOptionNotHonored is returned by Collection[K, T].Insert when the
 // underlying WriteSession reports success but leaves the record's key without an
 // id — i.e. the adapter ignored the InsertOption generator. It makes a generated
 // Insert fail LOUDLY on a non-honoring adapter instead of reporting a false
@@ -18,24 +18,40 @@ var ErrInsertOptionNotHonored = errors.New("dal: insert option not honored: reco
 
 // CollectionNamer is implemented by a record type that knows its own collection
 // name. The CollectionName method MUST be declared on a value receiver so that
-// CollectionOf[T]() can resolve the name from the zero value of T.
+// CollectionOf[K, T]() can resolve the name from the zero value of T.
 type CollectionNamer interface {
 	CollectionName() string
 }
 
 // Collection is a session-less, generic, reusable handle to a collection of
-// records of type T. It carries only path identity (a composed CollectionRef)
-// and the phantom type T — it holds no session or connection, so a single value
-// can be declared once (e.g. a package-level var) and reused across calls.
+// records of type T keyed by id type K. It carries only path identity (a
+// composed CollectionRef) and the phantom types K, T — it holds no session or
+// connection, so a single value can be declared once (e.g. a package-level var)
+// and reused across calls.
+//
+// K is the (scalar) id type — id arguments are strongly typed as K rather than
+// any. Composite / multi-field keys are addressed through the *ByKey terminals
+// (build a *Key with NewKeyWithFields).
 //
 // Read terminals take a ReadSession; write terminals take a WriteSession.
 // Because dal.DB satisfies ReadSession but not WriteSession, calling a write
 // terminal with a plain DB is a compile error — writes go through a
 // read-write transaction handle (see RunReadwriteTransaction).
-type Collection[T any] interface {
-	// Get returns the record stored at id decoded as a T. On not-found it
-	// returns the zero T and the not-found error from the session Get call.
-	Get(ctx context.Context, s ReadSession, id any) (T, error)
+type Collection[K comparable, T any] interface {
+	// GetData returns the record stored at id decoded as a T. On not-found it
+	// returns the zero T and the not-found error from the session Get call (use
+	// IsNotFound to test it).
+	GetData(ctx context.Context, s ReadSession, id K) (T, error)
+
+	// Get is a deprecated alias for GetData.
+	//
+	// Deprecated: use GetData.
+	Get(ctx context.Context, s ReadSession, id K) (T, error)
+
+	// GetRecord returns the underlying Record stored at id, with its Data set to
+	// a *T. On not-found it returns the record (Exists() == false) together with
+	// the not-found error from the session Get call.
+	GetRecord(ctx context.Context, s ReadSession, id K) (Record, error)
 
 	// All returns every record in the collection, each decoded into a freshly
 	// allocated value so results never alias. It surfaces ErrNotSupported from
@@ -49,7 +65,7 @@ type Collection[T any] interface {
 
 	// Exists reports whether a record exists at id. A not-found result maps to
 	// (false, nil); any other failure is returned as (false, err).
-	Exists(ctx context.Context, s ReadSession, id any) (bool, error)
+	Exists(ctx context.Context, s ReadSession, id K) (bool, error)
 
 	// First returns the first record in the collection (an underlying limit-1
 	// query). An empty collection yields (zero T, false, nil); an incapable
@@ -63,72 +79,120 @@ type Collection[T any] interface {
 	Insert(ctx context.Context, s WriteSession, value T, opts ...InsertOption) (*Key, error)
 
 	// InsertWithID inserts value at a known id and returns the record's key.
-	InsertWithID(ctx context.Context, s WriteSession, id any, value T) (*Key, error)
+	InsertWithID(ctx context.Context, s WriteSession, id K, value T) (*Key, error)
 
-	// Set stores (upserts) value at id.
-	Set(ctx context.Context, s WriteSession, id any, value T) error
+	// InsertRecord inserts a caller-built record. It is the shared primitive the
+	// other inserts delegate to; opts carry an id generator for generated inserts.
+	InsertRecord(ctx context.Context, s WriteSession, r Record, opts ...InsertOption) error
 
-	// Update applies field-level updates to the record at id.
-	Update(ctx context.Context, s WriteSession, id any, updates []update.Update, preconditions ...Precondition) error
+	// SetByID stores (upserts) value at id.
+	SetByID(ctx context.Context, s WriteSession, id K, value T) error
 
-	// Delete deletes the record at id.
-	Delete(ctx context.Context, s WriteSession, id any) error
+	// Set is a deprecated alias for SetByID.
+	//
+	// Deprecated: use SetByID.
+	Set(ctx context.Context, s WriteSession, id K, value T) error
+
+	// SetRecord stores (upserts) a caller-built record.
+	SetRecord(ctx context.Context, s WriteSession, r Record) error
+
+	// UpdateByID applies field-level updates to the record at id.
+	UpdateByID(ctx context.Context, s WriteSession, id K, updates []update.Update, preconditions ...Precondition) error
+
+	// Update is a deprecated alias for UpdateByID.
+	//
+	// Deprecated: use UpdateByID.
+	Update(ctx context.Context, s WriteSession, id K, updates []update.Update, preconditions ...Precondition) error
+
+	// UpdateByKey applies field-level updates to the record at an explicit key.
+	UpdateByKey(ctx context.Context, s WriteSession, k *Key, updates []update.Update, preconditions ...Precondition) error
+
+	// DeleteByID deletes the record at id.
+	DeleteByID(ctx context.Context, s WriteSession, id K) error
+
+	// Delete is a deprecated alias for DeleteByID.
+	//
+	// Deprecated: use DeleteByID.
+	Delete(ctx context.Context, s WriteSession, id K) error
+
+	// DeleteByKey deletes the record at an explicit key.
+	DeleteByKey(ctx context.Context, s WriteSession, k *Key) error
 
 	// In returns a handle scoped under parent (one level of nesting).
-	In(parent *Key) Collection[T]
+	In(parent *Key) Collection[K, T]
 }
 
-// Item is a dal-native id+value pair for batch insert. ID follows the same
-// id any = plain value | WithID/WithFields convention as the point terminals.
-// Item deliberately does NOT reference the record package, so the batch API adds
-// no dal -> record import.
-type Item[T any] struct {
-	ID    any
+// Item is a dal-native id+value pair for batch insert. Item deliberately does
+// NOT reference the record package, so the batch API adds no dal -> record
+// import.
+type Item[K comparable, T any] struct {
+	ID    K
 	Value T
 }
 
 // ManyInserter is the opt-in batch-insert interface, mirroring dalgo's
-// Inserter/MultiInserter split. The concrete Collection[T] value satisfies it
-// (obtain it via a type assertion: c.(dal.ManyInserter[T])).
-type ManyInserter[T any] interface {
+// Inserter/MultiInserter split. The concrete Collection[K, T] value satisfies it
+// (obtain it via a type assertion: c.(dal.ManyInserter[K, T])).
+type ManyInserter[K comparable, T any] interface {
 	// InsertMany inserts each item at its known id and returns the keys in
 	// input order.
-	InsertMany(ctx context.Context, s WriteSession, items ...Item[T]) (keys []*Key, err error)
+	InsertMany(ctx context.Context, s WriteSession, items ...Item[K, T]) (keys []*Key, err error)
 }
 
-// collection is the unexported implementation of Collection[T]. It is a small
-// value composing a CollectionRef and the phantom type T.
-type collection[T any] struct {
-	ref CollectionRef
+// CollectionOption configures a Collection at construction time.
+type CollectionOption func(*collectionOptions)
+
+type collectionOptions struct {
+	keyOptions []KeyOption
 }
 
-// CollectionOf returns a Collection[T] whose name is resolved from T's
-// value-receiver CollectionName method.
-func CollectionOf[T CollectionNamer]() Collection[T] {
-	var t T
-	return collection[T]{ref: NewRootCollectionRef(t.CollectionName(), "")}
-}
-
-// CollectionAt returns a Collection[T] with an explicit collection name.
-func CollectionAt[T any](name string) Collection[T] {
-	return collection[T]{ref: NewRootCollectionRef(name, "")}
-}
-
-// keyForID turns the id argument (a plain value OR an eager KeyOption such as
-// WithID/WithFields) into a *Key built from the handle's CollectionRef. It
-// returns a descriptive error when the handle is scoped under an incomplete
-// parent key.
-func (c collection[T]) keyForID(id any) (*Key, error) {
-	var key *Key
-	if opt, ok := id.(KeyOption); ok {
-		var err error
-		if key, err = NewKeyWithOptions(c.ref.Name(), opt); err != nil {
-			return nil, err
-		}
-	} else {
-		key = &Key{collection: c.ref.Name(), ID: id}
+// WithKeyOptions configures KeyOptions applied to every key the collection
+// builds from a typed id (e.g. WithFields for composite keys, a parent key, or
+// a custom IDKind). The id passed to a terminal is set first; these options are
+// applied after, so an option may augment or override the resulting key.
+func WithKeyOptions(keyOptions ...KeyOption) CollectionOption {
+	return func(o *collectionOptions) {
+		o.keyOptions = append(o.keyOptions, keyOptions...)
 	}
-	key.parent = c.ref.Parent()
+}
+
+func newCollectionOptions(opts ...CollectionOption) collectionOptions {
+	var co collectionOptions
+	for _, opt := range opts {
+		opt(&co)
+	}
+	return co
+}
+
+// collection is the unexported implementation of Collection[K, T]. It is a small
+// value composing a CollectionRef, the configured key options, and the phantom
+// types K, T.
+type collection[K comparable, T any] struct {
+	ref        CollectionRef
+	keyOptions []KeyOption
+}
+
+// CollectionOf returns a Collection[K, T] whose name is resolved from T's
+// value-receiver CollectionName method.
+func CollectionOf[K comparable, T CollectionNamer](opts ...CollectionOption) Collection[K, T] {
+	var t T
+	return collection[K, T]{ref: NewRootCollectionRef(t.CollectionName(), ""), keyOptions: newCollectionOptions(opts...).keyOptions}
+}
+
+// CollectionAt returns a Collection[K, T] with an explicit collection name.
+func CollectionAt[K comparable, T any](name string, opts ...CollectionOption) Collection[K, T] {
+	return collection[K, T]{ref: NewRootCollectionRef(name, ""), keyOptions: newCollectionOptions(opts...).keyOptions}
+}
+
+// idToKey turns the typed id into a *Key built from the handle's CollectionRef
+// and the collection's configured key options (KeyOption-sniffing logic). It
+// returns a descriptive error when an option fails or the handle is scoped under
+// an incomplete parent key.
+func (c collection[K, T]) idToKey(id K) (*Key, error) {
+	key := &Key{collection: c.ref.Name(), ID: id, parent: c.ref.Parent()}
+	if err := setKeyOptions(key, c.keyOptions...); err != nil {
+		return nil, err
+	}
 	if err := c.guardParent(key); err != nil {
 		return nil, err
 	}
@@ -138,7 +202,7 @@ func (c collection[T]) keyForID(id any) (*Key, error) {
 // guardParent returns a descriptive error if any ancestor of key is an
 // incomplete key (a parent with no id), rather than letting a terminal proceed
 // with a malformed path.
-func (c collection[T]) guardParent(key *Key) error {
+func (c collection[K, T]) guardParent(key *Key) error {
 	for p := key.parent; p != nil; p = p.Parent() {
 		if p.ID == nil {
 			return fmt.Errorf("dal: collection %q is scoped under an incomplete parent key for collection %q (id is missing)", c.ref.Name(), p.Collection())
@@ -147,21 +211,32 @@ func (c collection[T]) guardParent(key *Key) error {
 	return nil
 }
 
-func (c collection[T]) Get(ctx context.Context, s ReadSession, id any) (T, error) {
-	var value T
-	key, err := c.keyForID(id)
+func (c collection[K, T]) GetRecord(ctx context.Context, s ReadSession, id K) (Record, error) {
+	key, err := c.idToKey(id)
 	if err != nil {
-		return value, err
+		return nil, err
 	}
-	record := NewRecordWithData(key, &value)
+	record := NewRecordWithData(key, new(T))
 	if err = s.Get(ctx, record); err != nil {
+		return record, err
+	}
+	return record, nil
+}
+
+func (c collection[K, T]) GetData(ctx context.Context, s ReadSession, id K) (T, error) {
+	record, err := c.GetRecord(ctx, s, id)
+	if err != nil {
 		var zero T
 		return zero, err
 	}
-	return value, nil
+	return *record.Data().(*T), nil
 }
 
-func (c collection[T]) All(ctx context.Context, s ReadSession) ([]T, error) {
+func (c collection[K, T]) Get(ctx context.Context, s ReadSession, id K) (T, error) {
+	return c.GetData(ctx, s, id)
+}
+
+func (c collection[K, T]) All(ctx context.Context, s ReadSession) ([]T, error) {
 	query := NewQueryBuilder(From(c.ref)).SelectIntoRecord(func() Record {
 		return NewRecordWithIncompleteKey(c.ref.Name(), reflect.String, new(T))
 	})
@@ -176,16 +251,13 @@ func (c collection[T]) All(ctx context.Context, s ReadSession) ([]T, error) {
 	return values, nil
 }
 
-func (c collection[T]) Insert(ctx context.Context, s WriteSession, value T, opts ...InsertOption) (*Key, error) {
+func (c collection[K, T]) Insert(ctx context.Context, s WriteSession, value T, opts ...InsertOption) (*Key, error) {
 	key := NewIncompleteKey(c.ref.Name(), reflect.String, c.ref.Parent())
-	if err := c.guardParent(key); err != nil {
-		return nil, err
-	}
 	record := NewRecordWithData(key, &value)
 	if len(opts) == 0 {
 		opts = []InsertOption{WithRandomStringKey(DefaultRandomStringIDLength, 5)}
 	}
-	if err := s.Insert(ctx, record, opts...); err != nil {
+	if err := c.InsertRecord(ctx, s, record, opts...); err != nil {
 		return nil, err
 	}
 	if id := record.Key().ID; id == nil || id == "" {
@@ -194,7 +266,7 @@ func (c collection[T]) Insert(ctx context.Context, s WriteSession, value T, opts
 	return record.Key(), nil
 }
 
-func (c collection[T]) Count(ctx context.Context, s ReadSession) (int, error) {
+func (c collection[K, T]) Count(ctx context.Context, s ReadSession) (int, error) {
 	query := NewQueryBuilder(From(c.ref)).SelectKeysOnly(reflect.String)
 	records, err := ExecuteQueryAndReadAllToRecords(ctx, query, s)
 	if err != nil {
@@ -203,8 +275,8 @@ func (c collection[T]) Count(ctx context.Context, s ReadSession) (int, error) {
 	return len(records), nil
 }
 
-func (c collection[T]) Exists(ctx context.Context, s ReadSession, id any) (bool, error) {
-	key, err := c.keyForID(id)
+func (c collection[K, T]) Exists(ctx context.Context, s ReadSession, id K) (bool, error) {
+	key, err := c.idToKey(id)
 	if err != nil {
 		return false, err
 	}
@@ -218,7 +290,7 @@ func (c collection[T]) Exists(ctx context.Context, s ReadSession, id any) (bool,
 	return true, nil
 }
 
-func (c collection[T]) First(ctx context.Context, s ReadSession) (T, bool, error) {
+func (c collection[K, T]) First(ctx context.Context, s ReadSession) (T, bool, error) {
 	var zero T
 	query := NewQueryBuilder(From(c.ref)).Limit(1).SelectIntoRecord(func() Record {
 		return NewRecordWithIncompleteKey(c.ref.Name(), reflect.String, new(T))
@@ -233,54 +305,94 @@ func (c collection[T]) First(ctx context.Context, s ReadSession) (T, bool, error
 	return *records[0].Data().(*T), true, nil
 }
 
-func (c collection[T]) InsertWithID(ctx context.Context, s WriteSession, id any, value T) (*Key, error) {
-	key, err := c.keyForID(id)
+func (c collection[K, T]) InsertRecord(ctx context.Context, s WriteSession, r Record, opts ...InsertOption) error {
+	if err := c.guardParent(r.Key()); err != nil {
+		return err
+	}
+	return s.Insert(ctx, r, opts...)
+}
+
+func (c collection[K, T]) InsertWithID(ctx context.Context, s WriteSession, id K, value T) (*Key, error) {
+	key, err := c.idToKey(id)
 	if err != nil {
 		return nil, err
 	}
 	record := NewRecordWithData(key, &value)
-	if err = s.Insert(ctx, record); err != nil {
+	if err = c.InsertRecord(ctx, s, record); err != nil {
 		return nil, err
 	}
 	return record.Key(), nil
 }
 
-func (c collection[T]) Set(ctx context.Context, s WriteSession, id any, value T) error {
-	key, err := c.keyForID(id)
+func (c collection[K, T]) SetRecord(ctx context.Context, s WriteSession, r Record) error {
+	if err := c.guardParent(r.Key()); err != nil {
+		return err
+	}
+	return s.Set(ctx, r)
+}
+
+func (c collection[K, T]) SetByID(ctx context.Context, s WriteSession, id K, value T) error {
+	key, err := c.idToKey(id)
 	if err != nil {
 		return err
 	}
-	return s.Set(ctx, NewRecordWithData(key, &value))
+	return c.SetRecord(ctx, s, NewRecordWithData(key, &value))
 }
 
-func (c collection[T]) Update(ctx context.Context, s WriteSession, id any, updates []update.Update, preconditions ...Precondition) error {
-	key, err := c.keyForID(id)
+func (c collection[K, T]) Set(ctx context.Context, s WriteSession, id K, value T) error {
+	return c.SetByID(ctx, s, id, value)
+}
+
+func (c collection[K, T]) UpdateByKey(ctx context.Context, s WriteSession, k *Key, updates []update.Update, preconditions ...Precondition) error {
+	if err := c.guardParent(k); err != nil {
+		return err
+	}
+	return s.Update(ctx, k, updates, preconditions...)
+}
+
+func (c collection[K, T]) UpdateByID(ctx context.Context, s WriteSession, id K, updates []update.Update, preconditions ...Precondition) error {
+	key, err := c.idToKey(id)
 	if err != nil {
 		return err
 	}
-	return s.Update(ctx, key, updates, preconditions...)
+	return c.UpdateByKey(ctx, s, key, updates, preconditions...)
 }
 
-func (c collection[T]) Delete(ctx context.Context, s WriteSession, id any) error {
-	key, err := c.keyForID(id)
+func (c collection[K, T]) Update(ctx context.Context, s WriteSession, id K, updates []update.Update, preconditions ...Precondition) error {
+	return c.UpdateByID(ctx, s, id, updates, preconditions...)
+}
+
+func (c collection[K, T]) DeleteByKey(ctx context.Context, s WriteSession, k *Key) error {
+	if err := c.guardParent(k); err != nil {
+		return err
+	}
+	return s.Delete(ctx, k)
+}
+
+func (c collection[K, T]) DeleteByID(ctx context.Context, s WriteSession, id K) error {
+	key, err := c.idToKey(id)
 	if err != nil {
 		return err
 	}
-	return s.Delete(ctx, key)
+	return c.DeleteByKey(ctx, s, key)
 }
 
-func (c collection[T]) In(parent *Key) Collection[T] {
-	return collection[T]{ref: NewCollectionRef(c.ref.Name(), "", parent)}
+func (c collection[K, T]) Delete(ctx context.Context, s WriteSession, id K) error {
+	return c.DeleteByID(ctx, s, id)
+}
+
+func (c collection[K, T]) In(parent *Key) Collection[K, T] {
+	return collection[K, T]{ref: NewCollectionRef(c.ref.Name(), "", parent)}
 }
 
 // InsertMany inserts each item at its known id, delegating to the session's
 // MultiInserter (every WriteSession provides one), and returns the keys in input
 // order.
-func (c collection[T]) InsertMany(ctx context.Context, s WriteSession, items ...Item[T]) ([]*Key, error) {
+func (c collection[K, T]) InsertMany(ctx context.Context, s WriteSession, items ...Item[K, T]) ([]*Key, error) {
 	records := make([]Record, len(items))
 	keys := make([]*Key, len(items))
 	for i, item := range items {
-		key, err := c.keyForID(item.ID)
+		key, err := c.idToKey(item.ID)
 		if err != nil {
 			return nil, err
 		}

--- a/dal/collection_nocompile_example_test.go
+++ b/dal/collection_nocompile_example_test.go
@@ -10,7 +10,7 @@
 //
 //	go vet -tags dalgo_collection_nocompile ./dal/
 //
-// which MUST fail with a type error on the Set call below (dal.DB does not
+// which MUST fail with a type error on the SetByID call below (dal.DB does not
 // implement dal.WriteSession). Removing the call would make this file compile,
 // which is exactly what the AC forbids.
 package dal_test
@@ -22,26 +22,27 @@ import (
 )
 
 func writeTerminalRejectsPlainDB(ctx context.Context, db dal.DB) {
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 	// COMPILE ERROR (expected): dal.DB does not satisfy dal.WriteSession.
-	_ = users.Set(ctx, db, "u1", User{Name: "Alice"})
+	_ = users.SetByID(ctx, db, "u1", User{Name: "Alice"})
 }
 
 // generatorRejectedByIDTakingTerminals is the NEGATIVE-COMPILE proof for AC
 // generator-not-accepted-elsewhere: only the bare Insert accepts
-// ...dal.InsertOption; the id-taking terminals (InsertWithID/Get/Set/Update/
-// Delete) MUST NOT, so passing a generator to them is a compile error.
+// ...dal.InsertOption; the id-taking terminals (InsertWithID/GetData/SetByID/
+// UpdateByID/DeleteByID) MUST NOT, so passing a generator to them is a compile
+// error.
 func generatorRejectedByIDTakingTerminals(ctx context.Context, tx dal.ReadwriteTransaction) {
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 	gen := dal.WithRandomStringKey(16, 5)
 
 	// Each line below is an expected COMPILE ERROR: these terminals take no
 	// InsertOption.
 	_, _ = users.InsertWithID(ctx, tx, "u1", User{}, gen)
-	_, _ = users.Get(ctx, tx, "u1", gen)
-	_ = users.Set(ctx, tx, "u1", User{}, gen)
-	_ = users.Update(ctx, tx, "u1", nil, gen)
-	_ = users.Delete(ctx, tx, "u1", gen)
+	_, _ = users.GetData(ctx, tx, "u1", gen)
+	_ = users.SetByID(ctx, tx, "u1", User{}, gen)
+	_ = users.UpdateByID(ctx, tx, "u1", nil, gen)
+	_ = users.DeleteByID(ctx, tx, "u1", gen)
 
 	// The bare Insert, by contrast, DOES accept it (this line is valid).
 	_, _ = users.Insert(ctx, tx, User{}, gen)

--- a/dal/collection_test.go
+++ b/dal/collection_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // User is a record type that knows its own collection name via a value-receiver
-// CollectionName method (so dal.CollectionOf[User]() works without *User).
+// CollectionName method (so dal.CollectionOf[string, User]() works without *User).
 type User struct {
 	Name string `json:"name"`
 }
@@ -52,7 +52,7 @@ func TestCollectionOf_ConstructByConvention(t *testing.T) {
 	ctx := context.Background()
 	db := newMemoryDB(t)
 
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
 	// The handle is a reusable value: insert two records via the same handle.
 	var key1, key2 *dal.Key
@@ -71,10 +71,10 @@ func TestCollectionOf_ConstructByConvention(t *testing.T) {
 	assert.Equal(t, "users/u2", key2.String())
 
 	// The same reusable handle round-trips both records.
-	got1, err := users.Get(ctx, db, "u1")
+	got1, err := users.GetData(ctx, db, "u1")
 	require.NoError(t, err)
 	assert.Equal(t, "Alice", got1.Name)
-	got2, err := users.Get(ctx, db, "u2")
+	got2, err := users.GetData(ctx, db, "u2")
 	require.NoError(t, err)
 	assert.Equal(t, "Bob", got2.Name)
 }
@@ -82,7 +82,7 @@ func TestCollectionOf_ConstructByConvention(t *testing.T) {
 func TestCollectionAt_ConstructByExplicitName(t *testing.T) {
 	db := newMemoryDB(t)
 
-	things := dal.CollectionAt[thing]("things")
+	things := dal.CollectionAt[string, thing]("things")
 
 	var key *dal.Key
 	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
@@ -98,13 +98,13 @@ func TestCollectionAt_ConstructByExplicitName(t *testing.T) {
 func TestCollection_GetRoundtrip(t *testing.T) {
 	ctx := context.Background()
 	db := newMemoryDB(t)
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
 	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
-		return users.Set(ctx, tx, "u1", User{Name: "Alice"})
+		return users.SetByID(ctx, tx, "u1", User{Name: "Alice"})
 	})
 
-	got, err := users.Get(ctx, db, "u1")
+	got, err := users.GetData(ctx, db, "u1")
 	require.NoError(t, err)
 	assert.Equal(t, "Alice", got.Name)
 }
@@ -112,52 +112,88 @@ func TestCollection_GetRoundtrip(t *testing.T) {
 func TestCollection_GetNotFound(t *testing.T) {
 	ctx := context.Background()
 	db := newMemoryDB(t)
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
-	got, err := users.Get(ctx, db, "missing")
+	got, err := users.GetData(ctx, db, "missing")
 	require.Error(t, err)
 	assert.True(t, dal.IsNotFound(err), "error must be a not-found error from the Get call")
 	assert.Equal(t, User{}, got, "must return the zero value on not-found")
 }
 
-func TestCollection_IDPlainOrKeyOption(t *testing.T) {
+func TestCollection_GetRecord(t *testing.T) {
 	ctx := context.Background()
 	db := newMemoryDB(t)
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
-	// Store once using a plain id value.
 	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
-		return users.Set(ctx, tx, "u1", User{Name: "Alice"})
+		return users.SetByID(ctx, tx, "u1", User{Name: "Alice"})
 	})
 
-	// The same record is addressable by the plain value AND by dal.WithID.
-	byPlain, err := users.Get(ctx, db, "u1")
+	rec, err := users.GetRecord(ctx, db, "u1")
 	require.NoError(t, err)
-	byOption, err := users.Get(ctx, db, dal.WithID("u1"))
-	require.NoError(t, err)
-	assert.Equal(t, byPlain, byOption)
-	assert.Equal(t, "Alice", byPlain.Name)
+	require.NotNil(t, rec)
+	assert.Equal(t, "users/u1", rec.Key().String())
+	assert.Equal(t, "Alice", rec.Data().(*User).Name)
 
-	// A composite-key record is addressable by dal.WithFields.
-	composite := dal.WithFields([]dal.FieldVal{{Name: "tenant", Value: "t1"}, {Name: "id", Value: "u9"}})
+	// Not-found returns the record together with the not-found error.
+	rec2, err := users.GetRecord(ctx, db, "missing")
+	require.Error(t, err)
+	assert.True(t, dal.IsNotFound(err))
+	require.NotNil(t, rec2)
+
+	// idToKey error path (incomplete parent) propagates as a nil record + error.
+	nested := dal.CollectionOf[string, Contact]().In(dal.NewIncompleteKey("users", reflect.String, nil))
+	rec3, err := nested.GetRecord(ctx, db, "c1")
+	require.Error(t, err)
+	assert.Nil(t, rec3)
+}
+
+func TestCollection_WithKeyOptions(t *testing.T) {
+	ctx := context.Background()
+	db := newMemoryDB(t)
+
+	// Collection-level key options are applied to every key the handle builds.
+	parent := dal.NewKeyWithID("tenants", "t1")
+	users := dal.CollectionOf[string, User](dal.WithKeyOptions(dal.WithParentKey(parent)))
+
+	var key *dal.Key
 	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
-		return users.Set(ctx, tx, composite, User{Name: "Carol"})
+		var err error
+		key, err = users.InsertWithID(ctx, tx, "u1", User{Name: "Alice"})
+		return err
 	})
-	got, err := users.Get(ctx, db, dal.WithFields([]dal.FieldVal{{Name: "tenant", Value: "t1"}, {Name: "id", Value: "u9"}}))
+	assert.Equal(t, "tenants/t1/users/u1", key.String())
+
+	// The same option is applied on reads, so the record round-trips.
+	got, err := users.GetData(ctx, db, "u1")
 	require.NoError(t, err)
-	assert.Equal(t, "Carol", got.Name)
+	assert.Equal(t, "Alice", got.Name)
+}
+
+func TestCollection_KeyOptionError(t *testing.T) {
+	ctx := context.Background()
+	db := newMemoryDB(t)
+
+	// A failing collection-level key option is surfaced by every terminal's id
+	// resolution.
+	badOpt := func(*dal.Key) error { return errors.New("boom") }
+	users := dal.CollectionOf[string, User](dal.WithKeyOptions(badOpt))
+
+	_, err := users.GetData(ctx, db, "u1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "boom")
 }
 
 func TestCollection_AllDistinct(t *testing.T) {
 	ctx := context.Background()
 	db := newMemoryDB(t)
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
 	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
-		if err := users.Set(ctx, tx, "u1", User{Name: "Alice"}); err != nil {
+		if err := users.SetByID(ctx, tx, "u1", User{Name: "Alice"}); err != nil {
 			return err
 		}
-		return users.Set(ctx, tx, "u2", User{Name: "Bob"})
+		return users.SetByID(ctx, tx, "u2", User{Name: "Bob"})
 	})
 
 	all, err := users.All(ctx, db)
@@ -194,7 +230,7 @@ var _ dal.ReadSession = unsupportedReadSession{}
 
 func TestCollection_AllUnsupportedSurfacesError(t *testing.T) {
 	ctx := context.Background()
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
 	all, err := users.All(ctx, unsupportedReadSession{})
 	require.ErrorIs(t, err, dal.ErrNotSupported)
@@ -204,7 +240,7 @@ func TestCollection_AllUnsupportedSurfacesError(t *testing.T) {
 func TestCollection_InsertGeneratesKey(t *testing.T) {
 	ctx := context.Background()
 	db := newMemoryDB(t)
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
 	var key *dal.Key
 	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
@@ -218,14 +254,14 @@ func TestCollection_InsertGeneratesKey(t *testing.T) {
 	require.True(t, ok)
 	require.NotEmpty(t, id, "id must be a non-empty generated string")
 
-	got, err := users.Get(ctx, db, id)
+	got, err := users.GetData(ctx, db, id)
 	require.NoError(t, err)
 	assert.Equal(t, "Alice", got.Name)
 }
 
 func TestCollection_InsertWithExplicitOption(t *testing.T) {
 	db := newMemoryDB(t)
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
 	var key *dal.Key
 	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
@@ -240,7 +276,7 @@ func TestCollection_InsertWithExplicitOption(t *testing.T) {
 }
 
 // stubWriteSession is a WriteSession whose Insert behavior is supplied per test;
-// every other method is an unused no-op. It lets us drive Collection[T].Insert's
+// every other method is an unused no-op. It lets us drive Collection.Insert's
 // loud-failure guard and the underlying-insert error path without a real backend.
 type stubWriteSession struct {
 	insert func(ctx context.Context, record dal.Record, opts ...dal.InsertOption) error
@@ -272,7 +308,7 @@ var _ dal.WriteSession = stubWriteSession{}
 
 func TestCollection_InsertLoudFailureOnNonHonoringAdapter(t *testing.T) {
 	ctx := context.Background()
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
 	// A WriteSession that ignores InsertOption leaves the key incomplete.
 	dropping := stubWriteSession{insert: func(context.Context, dal.Record, ...dal.InsertOption) error {
@@ -287,7 +323,7 @@ func TestCollection_InsertLoudFailureOnNonHonoringAdapter(t *testing.T) {
 
 func TestCollection_InsertUnderlyingErrorPassthrough(t *testing.T) {
 	ctx := context.Background()
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
 	boom := errors.New("insert failed")
 	failing := stubWriteSession{insert: func(context.Context, dal.Record, ...dal.InsertOption) error {
@@ -302,7 +338,7 @@ func TestCollection_InsertUnderlyingErrorPassthrough(t *testing.T) {
 func TestCollection_InsertWithIDReturnsKey(t *testing.T) {
 	ctx := context.Background()
 	db := newMemoryDB(t)
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
 	var key *dal.Key
 	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
@@ -314,66 +350,188 @@ func TestCollection_InsertWithIDReturnsKey(t *testing.T) {
 	require.NotNil(t, key)
 	assert.Equal(t, "u1", key.ID)
 
-	got, err := users.Get(ctx, db, "u1")
+	got, err := users.GetData(ctx, db, "u1")
 	require.NoError(t, err)
 	assert.Equal(t, "Alice", got.Name)
+}
+
+func TestCollection_InsertRecord(t *testing.T) {
+	ctx := context.Background()
+	db := newMemoryDB(t)
+	users := dal.CollectionOf[string, User]()
+
+	// Direct record insert (the primitive the other inserts delegate to).
+	rec := dal.NewRecordWithData(dal.NewKeyWithID("users", "u1"), &User{Name: "Alice"})
+	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return users.InsertRecord(ctx, tx, rec)
+	})
+	got, err := users.GetData(ctx, db, "u1")
+	require.NoError(t, err)
+	assert.Equal(t, "Alice", got.Name)
+
+	// guardParent error path: a record whose key has an incomplete parent.
+	badKey := dal.NewKeyWithParentAndID(dal.NewIncompleteKey("users", reflect.String, nil), "contacts", "c1")
+	badRec := dal.NewRecordWithData(badKey, &Contact{Email: "x@example.com"})
+	err = db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return users.InsertRecord(ctx, tx, badRec)
+	})
+	require.Error(t, err)
 }
 
 func TestCollection_SetUpserts(t *testing.T) {
 	ctx := context.Background()
 	db := newMemoryDB(t)
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
-	// Set with no pre-existing record (insert).
+	// SetByID with no pre-existing record (insert).
 	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
-		return users.Set(ctx, tx, "u1", User{Name: "Alice"})
+		return users.SetByID(ctx, tx, "u1", User{Name: "Alice"})
 	})
-	got, err := users.Get(ctx, db, "u1")
+	got, err := users.GetData(ctx, db, "u1")
 	require.NoError(t, err)
 	assert.Equal(t, User{Name: "Alice"}, got)
 
-	// Set again over the existing record (overwrite).
+	// SetByID again over the existing record (overwrite).
 	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
-		return users.Set(ctx, tx, "u1", User{Name: "Bob"})
+		return users.SetByID(ctx, tx, "u1", User{Name: "Bob"})
 	})
-	got, err = users.Get(ctx, db, "u1")
+	got, err = users.GetData(ctx, db, "u1")
 	require.NoError(t, err)
 	assert.Equal(t, User{Name: "Bob"}, got)
+}
+
+func TestCollection_SetRecord(t *testing.T) {
+	ctx := context.Background()
+	db := newMemoryDB(t)
+	users := dal.CollectionOf[string, User]()
+
+	rec := dal.NewRecordWithData(dal.NewKeyWithID("users", "u1"), &User{Name: "Alice"})
+	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return users.SetRecord(ctx, tx, rec)
+	})
+	got, err := users.GetData(ctx, db, "u1")
+	require.NoError(t, err)
+	assert.Equal(t, "Alice", got.Name)
+
+	// guardParent error path.
+	badKey := dal.NewKeyWithParentAndID(dal.NewIncompleteKey("users", reflect.String, nil), "users", "u2")
+	badRec := dal.NewRecordWithData(badKey, &User{})
+	err = db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return users.SetRecord(ctx, tx, badRec)
+	})
+	require.Error(t, err)
 }
 
 func TestCollection_UpdateAppliesFields(t *testing.T) {
 	ctx := context.Background()
 	db := newMemoryDB(t)
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
 	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
-		return users.Set(ctx, tx, "u1", User{Name: "Alice"})
+		return users.SetByID(ctx, tx, "u1", User{Name: "Alice"})
 	})
 
 	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
-		return users.Update(ctx, tx, "u1", []update.Update{update.ByFieldName("name", "Bob")})
+		return users.UpdateByID(ctx, tx, "u1", []update.Update{update.ByFieldName("name", "Bob")})
 	})
 
-	got, err := users.Get(ctx, db, "u1")
+	got, err := users.GetData(ctx, db, "u1")
 	require.NoError(t, err)
 	assert.Equal(t, "Bob", got.Name)
+}
+
+func TestCollection_UpdateByKey(t *testing.T) {
+	ctx := context.Background()
+	db := newMemoryDB(t)
+	users := dal.CollectionOf[string, User]()
+
+	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return users.SetByID(ctx, tx, "u1", User{Name: "Alice"})
+	})
+
+	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return users.UpdateByKey(ctx, tx, dal.NewKeyWithID("users", "u1"), []update.Update{update.ByFieldName("name", "Bob")})
+	})
+	got, err := users.GetData(ctx, db, "u1")
+	require.NoError(t, err)
+	assert.Equal(t, "Bob", got.Name)
+
+	// guardParent error path.
+	badKey := dal.NewKeyWithParentAndID(dal.NewIncompleteKey("users", reflect.String, nil), "users", "u2")
+	err = db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return users.UpdateByKey(ctx, tx, badKey, []update.Update{update.ByFieldName("name", "X")})
+	})
+	require.Error(t, err)
 }
 
 func TestCollection_DeleteRemoves(t *testing.T) {
 	ctx := context.Background()
 	db := newMemoryDB(t)
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
 	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
-		return users.Set(ctx, tx, "u1", User{Name: "Alice"})
+		return users.SetByID(ctx, tx, "u1", User{Name: "Alice"})
 	})
 
 	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
-		return users.Delete(ctx, tx, "u1")
+		return users.DeleteByID(ctx, tx, "u1")
 	})
 
-	_, err := users.Get(ctx, db, "u1")
+	_, err := users.GetData(ctx, db, "u1")
 	assert.True(t, dal.IsNotFound(err), "record must be gone after Delete")
+}
+
+func TestCollection_DeleteByKey(t *testing.T) {
+	ctx := context.Background()
+	db := newMemoryDB(t)
+	users := dal.CollectionOf[string, User]()
+
+	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return users.SetByID(ctx, tx, "u1", User{Name: "Alice"})
+	})
+
+	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return users.DeleteByKey(ctx, tx, dal.NewKeyWithID("users", "u1"))
+	})
+	_, err := users.GetData(ctx, db, "u1")
+	assert.True(t, dal.IsNotFound(err))
+
+	// guardParent error path.
+	badKey := dal.NewKeyWithParentAndID(dal.NewIncompleteKey("users", reflect.String, nil), "users", "u2")
+	err = db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return users.DeleteByKey(ctx, tx, badKey)
+	})
+	require.Error(t, err)
+}
+
+// TestCollection_DeprecatedAliasesDelegate exercises the deprecated Get/Set/
+// Update/Delete aliases so they remain covered while delegating to the canonical
+// GetData/SetByID/UpdateByID/DeleteByID terminals.
+func TestCollection_DeprecatedAliasesDelegate(t *testing.T) {
+	ctx := context.Background()
+	db := newMemoryDB(t)
+	users := dal.CollectionOf[string, User]()
+
+	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return users.Set(ctx, tx, "u1", User{Name: "Alice"}) //nolint:staticcheck // exercises deprecated alias
+	})
+
+	got, err := users.Get(ctx, db, "u1") //nolint:staticcheck // exercises deprecated alias
+	require.NoError(t, err)
+	assert.Equal(t, "Alice", got.Name)
+
+	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return users.Update(ctx, tx, "u1", []update.Update{update.ByFieldName("name", "Bob")}) //nolint:staticcheck // exercises deprecated alias
+	})
+	got, err = users.GetData(ctx, db, "u1")
+	require.NoError(t, err)
+	assert.Equal(t, "Bob", got.Name)
+
+	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return users.Delete(ctx, tx, "u1") //nolint:staticcheck // exercises deprecated alias
+	})
+	_, err = users.GetData(ctx, db, "u1")
+	assert.True(t, dal.IsNotFound(err))
 }
 
 func TestCollection_NestedGet(t *testing.T) {
@@ -381,7 +539,7 @@ func TestCollection_NestedGet(t *testing.T) {
 	db := newMemoryDB(t)
 
 	parentKey := dal.NewKeyWithID("users", "u1")
-	contacts := dal.CollectionOf[Contact]().In(parentKey)
+	contacts := dal.CollectionOf[string, Contact]().In(parentKey)
 
 	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
 		key, err := contacts.InsertWithID(ctx, tx, "c1", Contact{Email: "a@example.com"})
@@ -392,7 +550,7 @@ func TestCollection_NestedGet(t *testing.T) {
 		return nil
 	})
 
-	got, err := contacts.Get(ctx, db, "c1")
+	got, err := contacts.GetData(ctx, db, "c1")
 	require.NoError(t, err)
 	assert.Equal(t, "a@example.com", got.Email)
 }
@@ -402,33 +560,19 @@ func TestCollection_NestedIncompleteParentErrors(t *testing.T) {
 	db := newMemoryDB(t)
 
 	incompleteParent := dal.NewIncompleteKey("users", reflect.String, nil)
-	contacts := dal.CollectionOf[Contact]().In(incompleteParent)
+	contacts := dal.CollectionOf[string, Contact]().In(incompleteParent)
 
 	assert.NotPanics(t, func() {
-		_, err := contacts.Get(ctx, db, "c1")
+		_, err := contacts.GetData(ctx, db, "c1")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "incomplete parent")
 	})
 }
 
-func TestCollection_KeyOptionError(t *testing.T) {
-	ctx := context.Background()
-	db := newMemoryDB(t)
-	users := dal.CollectionOf[User]()
-
-	// A KeyOption that fails is surfaced by every terminal's id resolution.
-	// (dal.KeyOption is an alias for func(*dal.Key) error, so this value's
-	// dynamic type matches the type switch in keyForID.)
-	badOpt := func(*dal.Key) error { return errors.New("boom") }
-	_, err := users.Get(ctx, db, badOpt)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "boom")
-}
-
 func TestCollection_InsertWithIDDuplicateErrors(t *testing.T) {
 	ctx := context.Background()
 	db := newMemoryDB(t)
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
 	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
 		_, err := users.InsertWithID(ctx, tx, "u1", User{Name: "Alice"})
@@ -447,7 +591,7 @@ func TestCollection_WriteTerminalsIncompleteParentError(t *testing.T) {
 	ctx := context.Background()
 	db := newMemoryDB(t)
 	incompleteParent := dal.NewIncompleteKey("users", reflect.String, nil)
-	contacts := dal.CollectionOf[Contact]().In(incompleteParent)
+	contacts := dal.CollectionOf[string, Contact]().In(incompleteParent)
 
 	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
 		if _, err := contacts.Insert(ctx, tx, Contact{}); err == nil {
@@ -456,14 +600,14 @@ func TestCollection_WriteTerminalsIncompleteParentError(t *testing.T) {
 		if _, err := contacts.InsertWithID(ctx, tx, "c1", Contact{}); err == nil {
 			return errors.New("InsertWithID must error under incomplete parent")
 		}
-		if err := contacts.Set(ctx, tx, "c1", Contact{}); err == nil {
-			return errors.New("Set must error under incomplete parent")
+		if err := contacts.SetByID(ctx, tx, "c1", Contact{}); err == nil {
+			return errors.New("SetByID must error under incomplete parent")
 		}
-		if err := contacts.Update(ctx, tx, "c1", []update.Update{update.ByFieldName("email", "x")}); err == nil {
-			return errors.New("Update must error under incomplete parent")
+		if err := contacts.UpdateByID(ctx, tx, "c1", []update.Update{update.ByFieldName("email", "x")}); err == nil {
+			return errors.New("UpdateByID must error under incomplete parent")
 		}
-		if err := contacts.Delete(ctx, tx, "c1"); err == nil {
-			return errors.New("Delete must error under incomplete parent")
+		if err := contacts.DeleteByID(ctx, tx, "c1"); err == nil {
+			return errors.New("DeleteByID must error under incomplete parent")
 		}
 		return nil
 	})
@@ -473,11 +617,11 @@ func TestCollection_WriteTerminalsIncompleteParentError(t *testing.T) {
 func TestCollection_CountReturnsTotal(t *testing.T) {
 	ctx := context.Background()
 	db := newMemoryDB(t)
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
 	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
 		for _, id := range []string{"u1", "u2", "u3"} {
-			if err := users.Set(ctx, tx, id, User{Name: id}); err != nil {
+			if err := users.SetByID(ctx, tx, id, User{Name: id}); err != nil {
 				return err
 			}
 		}
@@ -491,7 +635,7 @@ func TestCollection_CountReturnsTotal(t *testing.T) {
 
 func TestCollection_CountUnsupported(t *testing.T) {
 	ctx := context.Background()
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
 	n, err := users.Count(ctx, unsupportedReadSession{})
 	require.ErrorIs(t, err, dal.ErrNotSupported)
@@ -501,10 +645,10 @@ func TestCollection_CountUnsupported(t *testing.T) {
 func TestCollection_ExistsTrueFalse(t *testing.T) {
 	ctx := context.Background()
 	db := newMemoryDB(t)
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
 	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
-		return users.Set(ctx, tx, "u1", User{Name: "Alice"})
+		return users.SetByID(ctx, tx, "u1", User{Name: "Alice"})
 	})
 
 	exists, err := users.Exists(ctx, db, "u1")
@@ -515,15 +659,15 @@ func TestCollection_ExistsTrueFalse(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, exists, "not-found must map to (false, nil)")
 
-	// keyForID error path: incomplete parent.
-	nested := dal.CollectionOf[Contact]().In(dal.NewIncompleteKey("users", reflect.String, nil))
+	// idToKey error path: incomplete parent.
+	nested := dal.CollectionOf[string, Contact]().In(dal.NewIncompleteKey("users", reflect.String, nil))
 	_, err = nested.Exists(ctx, db, "c1")
 	require.Error(t, err)
 }
 
 func TestCollection_ExistsErrorPassthrough(t *testing.T) {
 	ctx := context.Background()
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
 	// A non-not-found lookup failure must be returned, not swallowed.
 	exists, err := users.Exists(ctx, unsupportedReadSession{}, "u1")
@@ -534,7 +678,7 @@ func TestCollection_ExistsErrorPassthrough(t *testing.T) {
 func TestCollection_FirstReturnsOrEmpty(t *testing.T) {
 	ctx := context.Background()
 	db := newMemoryDB(t)
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
 	// Empty collection: (zero, false, nil).
 	value, found, err := users.First(ctx, db)
@@ -544,7 +688,7 @@ func TestCollection_FirstReturnsOrEmpty(t *testing.T) {
 
 	// Non-empty collection: (value, true, nil).
 	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
-		return users.Set(ctx, tx, "u1", User{Name: "Alice"})
+		return users.SetByID(ctx, tx, "u1", User{Name: "Alice"})
 	})
 	value, found, err = users.First(ctx, db)
 	require.NoError(t, err)
@@ -554,7 +698,7 @@ func TestCollection_FirstReturnsOrEmpty(t *testing.T) {
 
 func TestCollection_FirstUnsupported(t *testing.T) {
 	ctx := context.Background()
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
 	value, found, err := users.First(ctx, unsupportedReadSession{})
 	require.ErrorIs(t, err, dal.ErrNotSupported)
@@ -563,27 +707,27 @@ func TestCollection_FirstUnsupported(t *testing.T) {
 }
 
 func TestCollection_ItemTypeShape(t *testing.T) {
-	// Item[T] is exactly {ID any; Value T}. (The no-record-import half of the AC
+	// Item[K, T] is exactly {ID K; Value T}. (The no-record-import half of the AC
 	// is enforced by TestDalDoesNotImportRecord.)
-	item := dal.Item[User]{ID: "u1", Value: User{Name: "Alice"}}
-	assert.Equal(t, any("u1"), item.ID)
+	item := dal.Item[string, User]{ID: "u1", Value: User{Name: "Alice"}}
+	assert.Equal(t, "u1", item.ID)
 	assert.Equal(t, User{Name: "Alice"}, item.Value)
 }
 
 func TestCollection_InsertManyRoundtrips(t *testing.T) {
 	ctx := context.Background()
 	db := newMemoryDB(t)
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
-	mi, ok := users.(dal.ManyInserter[User])
-	require.True(t, ok, "Collection[T] value must satisfy dal.ManyInserter[T]")
+	mi, ok := users.(dal.ManyInserter[string, User])
+	require.True(t, ok, "Collection[K, T] value must satisfy dal.ManyInserter[K, T]")
 
 	var keys []*dal.Key
 	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
 		var err error
 		keys, err = mi.InsertMany(ctx, tx,
-			dal.Item[User]{ID: "u1", Value: User{Name: "Alice"}},
-			dal.Item[User]{ID: "u2", Value: User{Name: "Bob"}},
+			dal.Item[string, User]{ID: "u1", Value: User{Name: "Alice"}},
+			dal.Item[string, User]{ID: "u2", Value: User{Name: "Bob"}},
 		)
 		return err
 	})
@@ -592,10 +736,10 @@ func TestCollection_InsertManyRoundtrips(t *testing.T) {
 	assert.Equal(t, "u1", keys[0].ID)
 	assert.Equal(t, "u2", keys[1].ID)
 
-	got1, err := users.Get(ctx, db, "u1")
+	got1, err := users.GetData(ctx, db, "u1")
 	require.NoError(t, err)
 	assert.Equal(t, "Alice", got1.Name)
-	got2, err := users.Get(ctx, db, "u2")
+	got2, err := users.GetData(ctx, db, "u2")
 	require.NoError(t, err)
 	assert.Equal(t, "Bob", got2.Name)
 }
@@ -604,23 +748,23 @@ func TestCollection_InsertManyErrorPaths(t *testing.T) {
 	ctx := context.Background()
 	db := newMemoryDB(t)
 
-	// keyForID error: incomplete parent.
+	// idToKey error: incomplete parent.
 	incompleteParent := dal.NewIncompleteKey("users", reflect.String, nil)
-	nested := dal.CollectionOf[Contact]().In(incompleteParent).(dal.ManyInserter[Contact])
+	nested := dal.CollectionOf[string, Contact]().In(incompleteParent).(dal.ManyInserter[string, Contact])
 	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
-		_, e := nested.InsertMany(ctx, tx, dal.Item[Contact]{ID: "c1", Value: Contact{}})
+		_, e := nested.InsertMany(ctx, tx, dal.Item[string, Contact]{ID: "c1", Value: Contact{}})
 		return e
 	})
 	require.Error(t, err)
 
 	// InsertMulti error: duplicate id within the same collection.
-	users := dal.CollectionOf[User]().(dal.ManyInserter[User])
+	users := dal.CollectionOf[string, User]().(dal.ManyInserter[string, User])
 	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
-		_, e := users.InsertMany(ctx, tx, dal.Item[User]{ID: "dup", Value: User{Name: "A"}})
+		_, e := users.InsertMany(ctx, tx, dal.Item[string, User]{ID: "dup", Value: User{Name: "A"}})
 		return e
 	})
 	err = db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
-		_, e := users.InsertMany(ctx, tx, dal.Item[User]{ID: "dup", Value: User{Name: "B"}})
+		_, e := users.InsertMany(ctx, tx, dal.Item[string, User]{ID: "dup", Value: User{Name: "B"}})
 		return e
 	})
 	require.Error(t, err)
@@ -629,18 +773,18 @@ func TestCollection_InsertManyErrorPaths(t *testing.T) {
 func TestCollection_WriteNeedsWriteSession(t *testing.T) {
 	// Positive half of AC write-needs-write-session: a write terminal compiles
 	// and commits when given a transaction handle (which satisfies
-	// WriteSession). The negative half — that Set(ctx, db, ...) with a plain DB
-	// does NOT compile — is proven by the build-tagged file
+	// WriteSession). The negative half — that SetByID(ctx, db, ...) with a plain
+	// DB does NOT compile — is proven by the build-tagged file
 	// collection_nocompile_example_test.go.
 	ctx := context.Background()
 	db := newMemoryDB(t)
-	users := dal.CollectionOf[User]()
+	users := dal.CollectionOf[string, User]()
 
 	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
-		return users.Set(ctx, tx, "u1", User{Name: "Alice"})
+		return users.SetByID(ctx, tx, "u1", User{Name: "Alice"})
 	})
 
-	got, err := users.Get(ctx, db, "u1")
+	got, err := users.GetData(ctx, db, "u1")
 	require.NoError(t, err)
 	assert.Equal(t, "Alice", got.Name)
 }

--- a/record/get_with_id.go
+++ b/record/get_with_id.go
@@ -1,0 +1,26 @@
+package record
+
+import (
+	"context"
+
+	"github.com/dal-go/dalgo/dal"
+)
+
+// GetWithID reads the record stored at id from collection c and returns it as a
+// typed WithID[K]. The decoded value of type T is reachable via the returned
+// WithID's Record (Record.Data() is a *T).
+//
+// It lives in package record (not as a Collection[K, T] method) because it
+// returns record.WithID[K]: package dal must stay free of any import of the
+// record package, so the typed-with-id accessor is provided here as a free
+// function over the dal.Collection[K, T] handle.
+//
+// On not-found it returns the zero WithID[K] together with the not-found error
+// from the underlying Get (use dal.IsNotFound to test it).
+func GetWithID[K comparable, T any](ctx context.Context, c dal.Collection[K, T], s dal.ReadSession, id K) (WithID[K], error) {
+	r, err := c.GetRecord(ctx, s, id)
+	if err != nil {
+		return WithID[K]{}, err
+	}
+	return WithID[K]{ID: id, Key: r.Key(), Record: r}, nil
+}

--- a/record/get_with_id_test.go
+++ b/record/get_with_id_test.go
@@ -1,0 +1,44 @@
+package record_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dal-go/dalgo/adapters/dalgo2memory"
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/record"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type gwUser struct {
+	Name string `json:"name"`
+}
+
+func (gwUser) CollectionName() string { return "gwusers" }
+
+func TestGetWithID(t *testing.T) {
+	ctx := context.Background()
+	db := dalgo2memory.NewDB()
+	users := dal.CollectionOf[string, gwUser]()
+
+	require.NoError(t, db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return users.SetByID(ctx, tx, "u1", gwUser{Name: "Alice"})
+	}))
+
+	// Success: returns a typed WithID carrying the id, key, and decoded record.
+	// (K and T are inferred from the collection handle and id.)
+	got, err := record.GetWithID(ctx, users, db, "u1")
+	require.NoError(t, err)
+	assert.Equal(t, "u1", got.ID)
+	require.NotNil(t, got.Key)
+	assert.Equal(t, "gwusers/u1", got.Key.String())
+	require.NotNil(t, got.Record)
+	assert.Equal(t, "Alice", got.Record.Data().(*gwUser).Name)
+
+	// Not-found: returns the zero WithID and the not-found error.
+	missing, err := record.GetWithID(ctx, users, db, "missing")
+	require.Error(t, err)
+	assert.True(t, dal.IsNotFound(err))
+	assert.Equal(t, record.WithID[string]{}, missing)
+}

--- a/spec/features/typed-collection/README.md
+++ b/spec/features/typed-collection/README.md
@@ -3,7 +3,7 @@ format: https://specscore.md/feature-specification
 status: Approved
 ---
 
-# Feature: Typed Collection[T] convenience layer (point CRUD)
+# Feature: Typed Collection[K, T] convenience layer (point CRUD)
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/typed-collection?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/typed-collection?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/typed-collection?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/typed-collection?op=request-change) |
 **Status:** Approved
@@ -15,11 +15,11 @@ status: Approved
 
 ## Summary
 
-A session-less generic dal.Collection[T] handle in package dal with point-CRUD terminals (Get/All/InsertWithID/Set/Update/Delete) and .In nesting, built additively over the existing dal session interfaces. Generated Insert and batch are separate Features.
+A session-less generic dal.Collection[K, T] handle in package dal with point-CRUD terminals keyed by a typed id K. Reads expose GetData/GetRecord (and a record.GetWithID free function); writes expose InsertWithID/InsertRecord/SetByID/SetRecord/UpdateByID/UpdateByKey/DeleteByID/DeleteByKey, with deprecated Get/Set/Update/Delete aliases. Key options (composite keys, parent) are configured on the constructor via WithKeyOptions. Built additively over the existing dal session interfaces. Generated Insert and batch are separate Features.
 
 ## Problem
 
-dalgo's record/key model is explicit and portable but verbose: reading or writing one typed record means constructing a `Key`, wrapping data with `NewRecordWithData`, calling a session method, then type-asserting the data back out. Every competitor (GORM generics, upper/db, Bun, ent) has converged on a typed, context-first convenience shape that returns `(T, error)` directly. This Feature adds that shape to dalgo for **point CRUD** — without reflection, codegen, or any change to the existing `dal` interfaces. Two findings from the source Idea constrain the API: Go forbids type parameters on methods (so the type parameter must enter via a free function or a generic type), and dalgo's `DB` satisfies `ReadSession` but not `WriteSession` (writes go through a transaction), which the design turns into compile-time read/write safety by passing the session per call. Generated-id `Insert` and batch are deliberately **separate Features** (the former needs adapter-side `InsertOption` support); this Feature is the additive, `dal`-only point-CRUD core.
+dalgo's record/key model is explicit and portable but verbose: reading or writing one typed record means constructing a `Key`, wrapping data with `NewRecordWithData`, calling a session method, then type-asserting the data back out. Every competitor (GORM generics, upper/db, Bun, ent) has converged on a typed, context-first convenience shape that returns `(T, error)` directly. This Feature adds that shape to dalgo for **point CRUD** — without reflection, codegen, or any change to the existing `dal` interfaces. Two findings from the source Idea constrain the API: Go forbids type parameters on methods (so a typed-with-id accessor that returns `record.WithID[K]` must be a free function in package `record`, keeping `dal` free of any `record` import), and dalgo's `DB` satisfies `ReadSession` but not `WriteSession` (writes go through a transaction), which the design turns into compile-time read/write safety by passing the session per call. The id type is a type parameter `K` so ids are statically typed rather than `any`. Generated-id `Insert` and batch are deliberately **separate Features** (the former needs adapter-side `InsertOption` support); this Feature is the additive, `dal`-only point-CRUD core.
 
 ## Behavior
 
@@ -27,41 +27,45 @@ dalgo's record/key model is explicit and portable but verbose: reading or writin
 
 #### REQ: session-less-handle
 
-`dal` MUST provide a session-less generic handle — the interface `dal.Collection[T]` — created two ways: `CollectionOf[T CollectionNamer]()` resolves the collection name from `T`'s `CollectionName() string` method (declared on a **value** receiver), and `CollectionAt[T any](name string)` takes an explicit name. Both return `dal.Collection[T]`. The handle MUST carry only path identity — a composed `dal.CollectionRef` (name plus an optional parent) and the phantom type `T` — and MUST hold no session or connection, so it is a reusable value that can be declared once (e.g. a package-level `var`).
+`dal` MUST provide a session-less generic handle — the interface `dal.Collection[K comparable, T any]` — created two ways: `CollectionOf[K comparable, T CollectionNamer](opts ...CollectionOption)` resolves the collection name from `T`'s `CollectionName() string` method (declared on a **value** receiver), and `CollectionAt[K comparable, T any](name string, opts ...CollectionOption)` takes an explicit name. Both return `dal.Collection[K, T]`. The handle MUST carry only path identity — a composed `dal.CollectionRef` (name plus an optional parent) — the configured key options, and the phantom types `K, T`, and MUST hold no session or connection, so it is a reusable value that can be declared once (e.g. a package-level `var`).
 
 ### Identifier argument
 
 #### REQ: id-argument
 
-Every point terminal MUST take an `id any` argument that is EITHER a plain id value (matching the core's `Key.ID any`) OR an eager `dal.KeyOption` that sets a concrete id (`WithID` for a single id, `WithFields` for a composite id). No new id type is introduced. Id-generating options are NOT accepted here (see Not Doing — generated `Insert` is a separate Feature).
+Every point terminal that takes an id MUST take a strongly typed `id K` argument (a scalar value such as `string` or `int`), matching the core's `Key.ID`. KeyOptions MUST NOT be passed in the id slot; instead, collection-level key configuration (e.g. `WithFields` for a composite id, or a parent key) is supplied to the constructor via `dal.WithKeyOptions(...dal.KeyOption)` and applied when each key is built. Composite / per-record keys are addressed through the `*ByKey` terminals (build a `*dal.Key` with `NewKeyWithFields`). Id-generating options are NOT accepted here (see Not Doing — generated `Insert` is a separate Feature).
 
 ### Read terminals
 
 #### REQ: typed-get
 
-`Collection[T]` MUST provide `Get(ctx, s ReadSession, id any) (T, error)` that returns the decoded value of type `T`. On not-found it MUST return the zero value of `T` together with the not-found error returned by the underlying session `Get` CALL — it MUST NOT rely on `record.Error()` (which is nil for not-found by design) or `record.Exists()` (which can panic if the record was never fetched).
+`Collection[K, T]` MUST provide `GetData(ctx, s ReadSession, id K) (T, error)` that returns the decoded value of type `T`. On not-found it MUST return the zero value of `T` together with the not-found error returned by the underlying session `Get` CALL — it MUST NOT rely on `record.Error()` (which is nil for not-found by design) or `record.Exists()` (which can panic if the record was never fetched). A deprecated `Get(ctx, s ReadSession, id K) (T, error)` alias MUST remain, delegating to `GetData`.
+
+#### REQ: typed-get-record
+
+`Collection[K, T]` MUST provide `GetRecord(ctx, s ReadSession, id K) (dal.Record, error)` that returns the underlying `dal.Record` (its `Data()` is a `*T`). It is the read primitive `GetData` delegates to. Package `record` MUST additionally provide a free function `GetWithID[K comparable, T any](ctx, c dal.Collection[K, T], s dal.ReadSession, id K) (record.WithID[K], error)` returning a typed id+record pair — it lives in `record` (not as a method) so `dal` introduces no `record` import.
 
 #### REQ: typed-all
 
-`Collection[T]` MUST provide `All(ctx, s ReadSession) ([]T, error)` returning every record in the collection, each decoded into a freshly allocated value so that no two results alias the same backing struct. Where the backend cannot execute the query, `All` MUST surface `dal.ErrNotSupported` rather than silently returning an empty slice.
+`Collection[K, T]` MUST provide `All(ctx, s ReadSession) ([]T, error)` returning every record in the collection, each decoded into a freshly allocated value so that no two results alias the same backing struct. Where the backend cannot execute the query, `All` MUST surface `dal.ErrNotSupported` rather than silently returning an empty slice.
 
 ### Write terminals
 
 #### REQ: insert-with-id
 
-`Collection[T]` MUST provide `InsertWithID(ctx, s WriteSession, id any, value T) (*dal.Key, error)` that inserts a new record at a KNOWN id and returns the record's key. (Generated ids are out of scope for this Feature.)
+`Collection[K, T]` MUST provide `InsertWithID(ctx, s WriteSession, id K, value T) (*dal.Key, error)` that inserts a new record at a KNOWN id and returns the record's key. It MUST delegate to the record primitive `InsertRecord(ctx, s WriteSession, r dal.Record, opts ...dal.InsertOption) error`. (Generated ids are out of scope for this Feature.)
 
 #### REQ: typed-set
 
-`Collection[T]` MUST provide `Set(ctx, s WriteSession, id any, value T) error` that stores (upserts) `value` at `id`.
+`Collection[K, T]` MUST provide `SetByID(ctx, s WriteSession, id K, value T) error` that stores (upserts) `value` at `id`, plus the record primitive `SetRecord(ctx, s WriteSession, r dal.Record) error` it delegates to. A deprecated `Set(ctx, s WriteSession, id K, value T) error` alias MUST remain, delegating to `SetByID`.
 
 #### REQ: typed-update
 
-`Collection[T]` MUST provide `Update(ctx, s WriteSession, id any, updates []update.Update, preconditions ...dal.Precondition) error` that applies field-level updates to the record at `id`, mirroring the existing `dal.Updater.Update` shape (updates slice + variadic preconditions).
+`Collection[K, T]` MUST provide `UpdateByID(ctx, s WriteSession, id K, updates []update.Update, preconditions ...dal.Precondition) error` and `UpdateByKey(ctx, s WriteSession, k *dal.Key, updates []update.Update, preconditions ...dal.Precondition) error`, mirroring the existing `dal.Updater.Update` shape (updates slice + variadic preconditions); `UpdateByID` delegates to `UpdateByKey`. A deprecated `Update(...)` alias MUST remain, delegating to `UpdateByID`.
 
 #### REQ: typed-delete
 
-`Collection[T]` MUST provide `Delete(ctx, s WriteSession, id any) error` that deletes the record at `id`.
+`Collection[K, T]` MUST provide `DeleteByID(ctx, s WriteSession, id K) error` and `DeleteByKey(ctx, s WriteSession, k *dal.Key) error` that delete the record at `id` / `k`; `DeleteByID` delegates to `DeleteByKey`. A deprecated `Delete(ctx, s WriteSession, id K) error` alias MUST remain, delegating to `DeleteByID`.
 
 ### Read/write session safety
 
@@ -73,45 +77,51 @@ Read terminals MUST take a `dal.ReadSession` and write terminals a `dal.WriteSes
 
 #### REQ: subcollection-nesting
 
-`Collection[T]` MUST provide `In(parent *dal.Key) dal.Collection[T]` that returns a handle scoped under `parent` by composing the existing `CollectionRef` parent chain (one level of nesting is in scope). If `parent` is an incomplete key (no id), a terminal on the resulting handle MUST return a descriptive error rather than panicking.
+`Collection[K, T]` MUST provide `In(parent *dal.Key) dal.Collection[K, T]` that returns a handle scoped under `parent` by composing the existing `CollectionRef` parent chain (one level of nesting is in scope), carrying over the configured key options. If `parent` is an incomplete key (no id), a terminal on the resulting handle MUST return a descriptive error rather than panicking.
 
 ### Additivity
 
 #### REQ: additive-no-core-changes
 
-The layer MUST live in package `dal`, implemented over the existing session interfaces and `Key`/`CollectionRef` (reused by composition, never generified). It MUST add no reflection of its own — value decoding remains the adapter's responsibility, exactly as today — MUST change no existing call site, and MUST NOT introduce a `dal` → `record` import (so no import cycle).
+The layer MUST live in package `dal`, implemented over the existing session interfaces and `Key`/`CollectionRef` (reused by composition, never generified). It MUST add no reflection of its own — value decoding remains the adapter's responsibility, exactly as today — and MUST NOT introduce a `dal` → `record` import (so no import cycle); the typed-with-id accessor lives in package `record` instead.
 
 ## Acceptance Criteria
 
 ### AC: construct-by-convention (verifies REQ:session-less-handle)
 
 **Given** a type `User` with a value-receiver method `CollectionName() string` returning `"users"`
-**When** `dal.CollectionOf[User]()` is called
-**Then** it returns a `dal.Collection[User]` whose collection path is `"users"` and which holds no session, and the same value can be reused across multiple calls.
+**When** `dal.CollectionOf[string, User]()` is called
+**Then** it returns a `dal.Collection[string, User]` whose collection path is `"users"` and which holds no session, and the same value can be reused across multiple calls.
 
 ### AC: construct-by-explicit-name (verifies REQ:session-less-handle)
 
 **Given** a type `T` that does not implement `CollectionNamer`
-**When** `dal.CollectionAt[T]("things")` is called
-**Then** it returns a `dal.Collection[T]` whose collection path is `"things"`.
+**When** `dal.CollectionAt[string, T]("things")` is called
+**Then** it returns a `dal.Collection[string, T]` whose collection path is `"things"`.
 
-### AC: id-plain-or-keyoption (verifies REQ:id-argument)
+### AC: key-options-on-constructor (verifies REQ:id-argument)
 
-**Given** a `Collection[User]` and a record stored at id `"u1"`
-**When** `Get` is called once with the plain value `"u1"` and once with `dal.WithID("u1")`
-**Then** both address the same record; and a record with a composite key is addressable by passing `dal.WithFields(...)` as the id.
+**Given** a `Collection[string, User]` constructed with `dal.WithKeyOptions(dal.WithParentKey(parent))`
+**When** a terminal builds a key from a typed id `"u1"`
+**Then** the configured key options are applied to the resulting key (e.g. the parent is set); and a failing key option is surfaced as an error from the terminal's id resolution.
 
 ### AC: typed-get-roundtrip (verifies REQ:typed-get)
 
 **Given** a `User{Name:"Alice"}` previously stored at id `"u1"`
-**When** `Get(ctx, db, "u1")` is called
-**Then** it returns the `User` value with `Name=="Alice"` and a nil error.
+**When** `GetData(ctx, db, "u1")` is called
+**Then** it returns the `User` value with `Name=="Alice"` and a nil error; the deprecated `Get` alias returns the same.
 
 ### AC: get-not-found (verifies REQ:typed-get)
 
 **Given** no record stored at id `"missing"`
-**When** `Get(ctx, db, "missing")` is called
+**When** `GetData(ctx, db, "missing")` is called
 **Then** it returns the zero `User` value and a not-found error obtained from the session `Get` call (not from `record.Error()`/`record.Exists()`).
+
+### AC: get-record-and-with-id (verifies REQ:typed-get-record)
+
+**Given** a `User{Name:"Alice"}` stored at id `"u1"`
+**When** `GetRecord(ctx, db, "u1")` and `record.GetWithID(ctx, coll, db, "u1")` are called
+**Then** `GetRecord` returns a `dal.Record` whose `Data()` is a `*User` with `Name=="Alice"`, and `GetWithID` returns a `record.WithID[string]` carrying id `"u1"`, the key, and that record; on not-found both return the not-found error.
 
 ### AC: typed-all-distinct (verifies REQ:typed-all)
 
@@ -127,38 +137,38 @@ The layer MUST live in package `dal`, implemented over the existing session inte
 
 ### AC: insert-with-id-returns-key (verifies REQ:insert-with-id)
 
-**Given** a `Collection[User]` and a writable transaction `tx`
+**Given** a `Collection[string, User]` and a writable transaction `tx`
 **When** `InsertWithID(ctx, tx, "u1", User{Name:"Alice"})` is called
-**Then** a record exists at id `"u1"` and the returned `*dal.Key` has ID `"u1"` and a nil error.
+**Then** a record exists at id `"u1"` and the returned `*dal.Key` has ID `"u1"` and a nil error; a direct `InsertRecord` with a caller-built record stores it the same way.
 
 ### AC: set-upserts (verifies REQ:typed-set)
 
-**Given** a `Collection[User]` and a writable transaction `tx`
-**When** `Set(ctx, tx, "u1", User{Name:"Bob"})` is called, whether or not a record already exists at `"u1"`
-**Then** the stored record at `"u1"` equals `User{Name:"Bob"}`.
+**Given** a `Collection[string, User]` and a writable transaction `tx`
+**When** `SetByID(ctx, tx, "u1", User{Name:"Bob"})` (or the deprecated `Set`) is called, whether or not a record already exists at `"u1"`
+**Then** the stored record at `"u1"` equals `User{Name:"Bob"}`; a direct `SetRecord` upserts the same way.
 
 ### AC: update-applies-fields (verifies REQ:typed-update)
 
 **Given** a `User{Name:"Alice"}` stored at `"u1"`
-**When** `Update(ctx, tx, "u1", []update.Update{update.ByFieldName("name","Bob")})` is called
+**When** `UpdateByID(ctx, tx, "u1", []update.Update{update.ByFieldName("name","Bob")})` is called (or `UpdateByKey` with the explicit key, or the deprecated `Update`)
 **Then** the stored record at `"u1"` has `Name=="Bob"`.
 
 ### AC: delete-removes (verifies REQ:typed-delete)
 
 **Given** a `User` stored at `"u1"`
-**When** `Delete(ctx, tx, "u1")` is called
-**Then** a subsequent `Get(ctx, db, "u1")` returns the not-found error.
+**When** `DeleteByID(ctx, tx, "u1")` is called (or `DeleteByKey` with the explicit key, or the deprecated `Delete`)
+**Then** a subsequent `GetData(ctx, db, "u1")` returns the not-found error.
 
 ### AC: write-needs-write-session (verifies REQ:session-type-safety)
 
 **Given** a plain `dal.DB` (which satisfies `ReadSession` but not `WriteSession`)
-**When** code attempts to call a write terminal such as `Set(ctx, db, "u1", value)`
+**When** code attempts to call a write terminal such as `SetByID(ctx, db, "u1", value)`
 **Then** it does not compile (verified by the method signatures and a non-compiling example), whereas the same call inside `RunReadwriteTransaction` (whose handle satisfies `WriteSession`) compiles and commits.
 
 ### AC: nested-get (verifies REQ:subcollection-nesting)
 
 **Given** a complete parent key for `users/u1` and a `Contact` stored at `users/u1/contacts/c1`
-**When** `dal.CollectionOf[Contact]().In(parentKey).Get(ctx, db, "c1")` is called
+**When** `dal.CollectionOf[string, Contact]().In(parentKey).GetData(ctx, db, "c1")` is called
 **Then** it resolves the path `users/u1/contacts` and returns the stored `Contact`.
 
 ### AC: nested-incomplete-parent-errors (verifies REQ:subcollection-nesting)
@@ -169,29 +179,31 @@ The layer MUST live in package `dal`, implemented over the existing session inte
 
 ### AC: additive-suite-stays-green (verifies REQ:additive-no-core-changes)
 
-**Given** the new `Collection[T]` layer added to package `dal`
+**Given** the new `Collection[K, T]` layer added to package `dal`
 **When** the full pre-existing `dal` + `dalgo2memory` + `end2end` test suites are run and the import graph is inspected
 **Then** every pre-existing test passes unchanged and `dal` still does not import the `record` package.
 
 ## Architecture & Components
 
-- **`dal.Collection[T]` (interface)** — the typed contract: `Get`/`All`/`InsertWithID`/`Set`/`Update`/`Delete`/`In`. Lives in `dal` (the contracts package), alongside `ReadSession`/`Getter`/etc.
-- **unexported impl (in `dal`)** — a small value composing a `dal.CollectionRef` (name + optional parent) and the phantom `T`. Each terminal builds a `Key` from the handle's `CollectionRef` + the `id` argument (via `NewKeyWithOptions` when the id is a `KeyOption`, else by setting `Key.ID` directly), wraps `new(T)` with `NewRecordWithData`, calls the matching session method, and returns the typed value / key / error.
+- **`dal.Collection[K, T]` (interface)** — the typed contract: `GetData`/`Get`(deprecated)/`GetRecord`/`All`/`InsertWithID`/`InsertRecord`/`SetByID`/`Set`(deprecated)/`SetRecord`/`UpdateByID`/`Update`(deprecated)/`UpdateByKey`/`DeleteByID`/`Delete`(deprecated)/`DeleteByKey`/`In`. Lives in `dal` (the contracts package), alongside `ReadSession`/`Getter`/etc.
+- **unexported impl (in `dal`)** — a small value composing a `dal.CollectionRef` (name + optional parent), the configured `[]KeyOption`, and the phantom `K, T`. `idToKey(id K)` builds a `Key` from the handle's `CollectionRef`, sets `Key.ID = id`, applies the collection's key options via `setKeyOptions`, then guards the parent chain. Each terminal wraps `new(T)`/`&value` with `NewRecordWithData`, calls the matching session method, and returns the typed value / key / error. `*ByID` terminals delegate to the corresponding `*ByKey`/`*Record` primitive.
+- **`CollectionOption` + `WithKeyOptions`** — a constructor option carrying collection-level `dal.KeyOption`s.
 - **`CollectionNamer` (interface)** — `CollectionName() string`; a constraint on `CollectionOf`.
-- **Constructors** — `CollectionOf[T CollectionNamer]()` and `CollectionAt[T any](name string)`, both returning `dal.Collection[T]`.
-- **Dependencies** — existing `dal` session interfaces (`ReadSession`/`WriteSession`), `Key`/`CollectionRef`, and the `update` package. No new external dependency; no `record` import.
+- **Constructors** — `CollectionOf[K comparable, T CollectionNamer](opts ...CollectionOption)` and `CollectionAt[K comparable, T any](name string, opts ...CollectionOption)`, both returning `dal.Collection[K, T]`.
+- **`record.GetWithID[K, T]` (free function)** — returns `record.WithID[K]` over a `dal.Collection[K, T]`; lives in `record` to keep `dal` free of any `record` import.
+- **Dependencies** — existing `dal` session interfaces (`ReadSession`/`WriteSession`), `Key`/`CollectionRef`, and the `update` package. No new external dependency; no `record` import in `dal`.
 
-Data flow (Get): `id` → `Key` (handle `CollectionRef` + id) → `NewRecordWithData(key, new(T))` → `ReadSession.Get` → return `*new(T)`, mapping the call's not-found error to `(zero T, err)`.
+Data flow (GetData): `id K` → `Key` (handle `CollectionRef` + id + key options) → `GetRecord` → `NewRecordWithData(key, new(T))` → `ReadSession.Get` → return `*new(T)`, mapping the call's not-found error to `(zero T, err)`.
 
-Error handling: not-found is taken from the session call's returned error; an incomplete `.In` parent yields a descriptive error; an unsupported `All` surfaces `dal.ErrNotSupported`.
+Error handling: not-found is taken from the session call's returned error; a failing key option or an incomplete `.In`/`*ByKey` parent yields a descriptive error; an unsupported `All` surfaces `dal.ErrNotSupported`.
 
 ## Not Doing / Out of Scope
 
 - **Generated-id `Insert`** (`Insert(ctx, ws, value, ...InsertOption)`) — needs adapter-side `InsertOption` support (approach C); it is the separate `collection-generated-insert` Feature.
-- **Batch** (`ManyInserter[T]`/`Item[T]`) and **`Count`/`Exists`/`First`** — a later Feature.
+- **Batch** (`ManyInserter[K, T]`/`Item[K, T]`) and **`Count`/`Exists`/`First`** — the separate `typed-collection-extras` Feature.
 - **Query filtering** (`Where`/typed query terminal, pagination) — borrow #4/#5, a separate Idea/Feature; `All` reads the whole collection here.
 - **Multi-level nesting** (3+ collection segments) — one level of `.In` is in scope.
-- **Compile-time typed ids** (`Collection[T, ID comparable]`) — `id any` matches the core's `Key.ID any`.
+- **Composite / struct ids in the typed `id K` slot** — `K` is a scalar id type; composite/multi-field keys go through `WithKeyOptions(WithFields(...))` or the `*ByKey` terminals, not a struct `K`.
 - **Adapter changes** — none; this Feature is `dal`-only and additive.
 
 ## Rehearse Integration
@@ -200,7 +212,7 @@ No Rehearse markdown stubs. Every AC has a concrete Go test surface (pure-functi
 
 ## Open Questions
 
-- **`CollectionName()` receiver convention** — pinned to **value** receiver (so `CollectionOf[User]()` works without `*User`); to be documented in the package doc.
+- **`CollectionName()` receiver convention** — pinned to **value** receiver (so `CollectionOf[string, User]()` works without `*User`); to be documented in the package doc.
 - **`All` ↔ future `Where`/`First` seam** — `All` should build its `StructuredQuery` through an internal helper that a later filtering terminal can reuse, so adding `Where`/`First` does not require a redesign.
 
 ---

--- a/spec/plans/typed-collection.md
+++ b/spec/plans/typed-collection.md
@@ -30,11 +30,11 @@ Define `dal.Collection[T]` (read methods take `ReadSession`, write methods take 
 
 ### Task 2: id-argument resolution
 
-**Verifies:** typed-collection#ac:id-plain-or-keyoption
+**Verifies:** typed-collection#ac:key-options-on-constructor
 **Depends-On:** 1
 **Status:** done
 
-Internal helper turning the `id any` argument into a `*dal.Key` from the handle's `CollectionRef`: a plain value sets `Key.ID`; a `dal.KeyOption` (`WithID`/`WithFields`) is applied via `NewKeyWithOptions`. Shared by every terminal.
+Internal `idToKey(id K)` helper turning the typed `id K` argument into a `*dal.Key` from the handle's `CollectionRef`: it sets `Key.ID = id`, then applies the collection's configured key options (`dal.WithKeyOptions(...)`, e.g. `WithFields`/parent) via `setKeyOptions`, and guards the parent chain. Shared by every `*ByID` terminal.
 
 ### Task 3: Get terminal with not-found mapping
 
@@ -83,6 +83,14 @@ Implement `In(parent *dal.Key) dal.Collection[T]` composing the `CollectionRef` 
 **Status:** done
 
 Confirm the layer is additive: run the full pre-existing `dal` + `dalgo2memory` + `end2end` suites and keep them green with no existing call-site changes, and add a test/assertion that `dal` still does not import the `record` package.
+
+### Task 9: GetRecord primitive and record.GetWithID
+
+**Verifies:** typed-collection#ac:get-record-and-with-id
+**Depends-On:** 3
+**Status:** done
+
+Add `GetRecord(ctx, ReadSession, id K) (dal.Record, error)` as the read primitive `GetData` delegates to, and the free function `record.GetWithID[K, T](ctx, c, s, id) (record.WithID[K], error)` in package `record` (keeping `dal` free of any `record` import). Both surface the session not-found error.
 
 ## Open Questions
 


### PR DESCRIPTION
## What

Evolves the typed convenience layer **`dal.Collection[T]` → `dal.Collection[K, T]`** (id type `K`, record type `T`) so ids are strongly typed instead of `any`, and adds the requested sibling accessors.

### Reads
- **`GetData(s, id)`** — canonical; **`Get`** is now a `// Deprecated:` alias delegating to it.
- **`GetRecord(s, id) (dal.Record, error)`** — the read primitive `GetData` delegates to.
- **`record.GetWithID[K,T](c, s, id) (record.WithID[K], error)`** — a free function in package `record` (so `dal` keeps zero `record` imports; `K`/`T` infer from the collection handle).

### Writes
- **`InsertRecord(s, r, opts...)`** — shared insert primitive (`Insert`/`InsertWithID` delegate to it).
- **`SetByID`** (deprecates `Set`) + **`SetRecord`**.
- **`UpdateByID`** (deprecates `Update`) + **`UpdateByKey`**.
- **`DeleteByID`** (deprecates `Delete`) + **`DeleteByKey`**.

### Key options
Key options move off the id slot onto the constructor via **`WithKeyOptions(...)`**, applied in `idToKey` (preserving the `WithFields`/`NewKeyWithOptions` path). Composite/multi-field keys go through `WithKeyOptions` or the `*ByKey` terminals. Scalar `K` only for now — struct/composite ids in the typed slot are **deferred**.

## Design decisions (agreed up front)
- `GetWithID` **must** live in `record`, not as a `Collection` method — `record` imports `dal`, so a method would create an import cycle.
- The `id any` dual-slot (plain value *or* `KeyOption`) is removed; the typed `id K` slot + `*ByKey` terminals replace it.
- Deprecated aliases retained to honor the pre-1.0 no-break guard.

## Verification
- ✅ `go build` / `go vet` clean
- ✅ `golangci-lint run ./...` → **0 issues**
- ✅ All 17 packages' tests pass
- ✅ **100% coverage** on every new/changed function (CI gate is 100%)
- ✅ Negative-compile proof (`-tags dalgo_collection_nocompile`) still fails to compile, as required
- ✅ `specscore spec lint` → 0 violations (Feature + Plan specs updated)
- ✅ README updated to the new surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)