### PR TITLE
refactor(dal): move WithID/DataWithID into dal as RecordWithID/RecordWithDataAndID

### DIFF
--- a/dal/record_with_data_and_id.go
+++ b/dal/record_with_data_and_id.go
@@ -1,0 +1,50 @@
+package dal
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// RecordWithDataAndID is a RecordWithID plus strongly typed Data.
+//
+// It lives in package dal (formerly record.DataWithID) so the typed Collection
+// layer can expose it without a dal -> record import cycle. record.DataWithID is
+// kept as a backward-compatible alias.
+type RecordWithDataAndID[K comparable, D any] struct {
+	RecordWithID[K]
+	Data D // we can't use *D here as consumer might want to pass an interface value instead of a pointer
+}
+
+// NewRecordWithDataAndID creates a RecordWithDataAndID. It panics unless data is
+// a non-nil pointer or interface referencing a struct or a map.
+func NewRecordWithDataAndID[K comparable, D any](id K, key *Key, data D) RecordWithDataAndID[K, D] {
+	if key == nil {
+		panic(fmt.Sprintf("key is nil for (id=%v)", id))
+	}
+	v := reflect.ValueOf(data)
+	kind := v.Kind()
+	switch kind {
+	case reflect.Pointer, reflect.Interface:
+		if v.IsNil() {
+			t := reflect.TypeOf(data)
+			panic(fmt.Sprintf("data of type %v is nil for (id=%v, key=%v)", t.String(), id, key))
+		}
+		elemType := v.Elem().Type()
+		switch elemType.Kind() {
+		case reflect.Struct, reflect.Map:
+			// OK - expected types
+		default:
+			panic("data should be a pointer to a struct or map, got " + elemType.String())
+		}
+	default:
+		t := reflect.TypeOf(data)
+		if t == nil {
+			panic(fmt.Sprintf("data is nil for (id=%v, key=%v)", id, key))
+		}
+		panic(fmt.Sprintf("data should be a pointer or an interface, got %v for (id=%v, key=%v)", t.String(), id, key))
+	}
+	return RecordWithDataAndID[K, D]{
+		RecordWithID: NewRecordWithID(id, key, data),
+		Data:         data,
+	}
+}

--- a/dal/record_with_data_and_id_test.go
+++ b/dal/record_with_data_and_id_test.go
@@ -1,0 +1,122 @@
+package dal_test
+
+import (
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRecordWithDataAndID(t *testing.T) {
+	type data struct {
+		Title string
+	}
+
+	type args[K comparable] struct {
+		id   K
+		key  *dal.Key
+		data *data
+	}
+
+	type testCase[K comparable] struct {
+		name         string
+		args         args[K]
+		want         dal.RecordWithDataAndID[K, *data]
+		expectsPanic string
+	}
+	d1 := data{Title: "test"}
+	tests := []testCase[string]{
+		{
+			name: "should_pass",
+			args: args[string]{
+				id:   "r1",
+				key:  dal.NewKeyWithID("r1", "SomeCollection"),
+				data: &data{Title: "test"},
+			},
+			want: dal.RecordWithDataAndID[string, *data]{
+				RecordWithID: dal.RecordWithID[string]{
+					ID:     "r1",
+					Key:    dal.NewKeyWithID("r1", "SomeCollection"),
+					Record: dal.NewRecordWithData(dal.NewKeyWithID("r1", "SomeCollection"), &d1),
+				},
+				Data: &d1,
+			},
+		},
+		{
+			name: "should_panic_on_nil_key",
+			args: args[string]{
+				id:   "r1",
+				key:  nil,
+				data: &data{Title: "test"},
+			},
+			expectsPanic: "key is nil for (id=r1)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.expectsPanic != "" {
+				assert.PanicsWithValue(t, tt.expectsPanic, func() {
+					dal.NewRecordWithDataAndID(tt.args.id, tt.args.key, tt.args.data)
+				})
+			} else {
+				got := dal.NewRecordWithDataAndID(tt.args.id, tt.args.key, tt.args.data)
+				assert.Equal(t, tt.want.ID, got.ID)
+				assert.Equal(t, tt.want.Key, got.Key)
+				assert.Equal(t, tt.want.Data, got.Data)
+				got.Record.SetError(nil)
+				assert.Equal(t, tt.want.Data, got.Record.Data())
+			}
+		})
+	}
+	t.Run("should_panic_on_pointer_to_a_pointer", func(t *testing.T) {
+		assert.Panics(t, func() {
+			d1 := data{Title: "test"}
+			d2 := &d1
+			d3 := &d2
+			dal.NewRecordWithDataAndID("r1", dal.NewKeyWithID("r1", "SomeCollection"), d3)
+		})
+	})
+	t.Run("should_panic_on_pointer_to_an_interface", func(t *testing.T) {
+		assert.Panics(t, func() {
+			d1 := data{Title: "test"}
+			var d2 any = &d1
+			var d3 = &d2
+			dal.NewRecordWithDataAndID("r1", dal.NewKeyWithID("r1", "SomeCollection"), d3)
+		})
+	})
+
+	t.Run("should_panic_on_nil_pointer", func(t *testing.T) {
+		assert.Panics(t, func() {
+			var d *data = nil
+			dal.NewRecordWithDataAndID("r1", dal.NewKeyWithID("r1", "SomeCollection"), d)
+		})
+	})
+
+	t.Run("should_panic_on_nil_interface", func(t *testing.T) {
+		assert.Panics(t, func() {
+			var d any = nil
+			dal.NewRecordWithDataAndID("r1", dal.NewKeyWithID("r1", "SomeCollection"), d)
+		})
+	})
+
+	t.Run("should_panic_on_non_pointer_data", func(t *testing.T) {
+		assert.Panics(t, func() {
+			d := data{Title: "test"}
+			dal.NewRecordWithDataAndID("r1", dal.NewKeyWithID("r1", "SomeCollection"), d)
+		})
+	})
+
+	t.Run("should_panic_on_pointer_to_non_struct_non_map", func(t *testing.T) {
+		assert.Panics(t, func() {
+			s := "test"
+			dal.NewRecordWithDataAndID("r1", dal.NewKeyWithID("r1", "SomeCollection"), &s)
+		})
+	})
+
+	t.Run("should_work_with_map", func(t *testing.T) {
+		m := map[string]any{"title": "test"}
+		result := dal.NewRecordWithDataAndID("r1", dal.NewKeyWithID("r1", "SomeCollection"), &m)
+		assert.Equal(t, "r1", result.ID)
+		assert.Equal(t, &m, result.Data)
+	})
+}

--- a/dal/record_with_id.go
+++ b/dal/record_with_id.go
@@ -1,0 +1,35 @@
+package dal
+
+import "fmt"
+
+// RecordWithID is a record with a strongly typed ID.
+//
+// It lives in package dal (formerly record.WithID) so that the typed Collection
+// layer can expose it without a dal -> record import cycle. record.WithID is
+// kept as a backward-compatible alias.
+type RecordWithID[K comparable] struct {
+	ID     K      `json:"id"`               // Unique id of the record in collection
+	FullID string `json:"fullID,omitempty"` // Custom id of the record fully unique across all DB collections
+	Key    *Key   `json:"-"`
+	Record Record `json:"-"`
+}
+
+// String returns string representation of a record with an ID
+func (v RecordWithID[K]) String() string {
+	if v.FullID == "" {
+		return fmt.Sprintf("{ID=%v, FullID=nil, Key=%v, Record=%v}", v.ID, v.Key, v.Record)
+	}
+	if id, ok := any(v.ID).(string); ok {
+		return fmt.Sprintf(`{ID="%s", FullID="%s", Key=%v, Record=%v}`, id, v.FullID, v.Key, v.Record)
+	}
+	return fmt.Sprintf(`{ID=%+v, FullID="%s", Key=%v, Record=%v}`, v.ID, v.FullID, v.Key, v.Record)
+}
+
+// NewRecordWithID creates a RecordWithID wrapping a Record built from key + data.
+func NewRecordWithID[T comparable](id T, key *Key, data any) RecordWithID[T] {
+	return RecordWithID[T]{
+		ID:     id,
+		Key:    key,
+		Record: NewRecordWithData(key, data),
+	}
+}

--- a/dal/record_with_id_test.go
+++ b/dal/record_with_id_test.go
@@ -1,0 +1,61 @@
+package dal_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+)
+
+func TestRecordWithID_String(t *testing.T) {
+	tests := []struct {
+		name  string
+		input fmt.Stringer
+		want  string
+	}{
+		{
+			name:  "Empty FullID",
+			input: dal.RecordWithID[string]{ID: "1", FullID: "", Key: nil, Record: nil},
+			want:  "{ID=1, FullID=nil, Key=<nil>, Record=<nil>}",
+		},
+		{
+			name:  "FullID is not empty, ID is string",
+			input: dal.RecordWithID[string]{ID: "1", FullID: "custom-1", Key: nil, Record: nil},
+			want:  `{ID="1", FullID="custom-1", Key=<nil>, Record=<nil>}`,
+		},
+		{
+			name:  "FullID is not empty, ID is integer",
+			input: dal.RecordWithID[int]{ID: 1, FullID: "custom-1", Key: nil, Record: nil},
+			want:  `{ID=1, FullID="custom-1", Key=<nil>, Record=<nil>}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.input.String()
+			if got != tt.want {
+				t.Errorf("RecordWithID.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewRecordWithID(t *testing.T) {
+	type data struct{ Title string }
+	key := dal.NewKeyWithID("things", "t1")
+	d := &data{Title: "x"}
+	got := dal.NewRecordWithID("t1", key, d)
+	if got.ID != "t1" {
+		t.Errorf("ID = %q, want t1", got.ID)
+	}
+	if got.Key != key {
+		t.Errorf("Key not set")
+	}
+	if got.Record == nil {
+		t.Fatalf("Record not set")
+	}
+	got.Record.SetError(nil)
+	if got.Record.Data() != d {
+		t.Errorf("Record data not wired")
+	}
+}

--- a/record/data_with_id.go
+++ b/record/data_with_id.go
@@ -1,48 +1,18 @@
 package record
 
 import (
-	"fmt"
-	"reflect"
-
 	"github.com/dal-go/dalgo/dal"
 )
 
-type DataWithID[K comparable, D any] struct {
-	WithID[K]
-	Data D // we can't use *D here as consumer might want to pass an interface value instead of a pointer
-}
+// DataWithID is a backward-compatible alias for dal.RecordWithDataAndID.
+//
+// The type now lives in package dal so the typed Collection layer can return it
+// without a dal -> record import cycle. New code should prefer
+// dal.RecordWithDataAndID.
+type DataWithID[K comparable, D any] = dal.RecordWithDataAndID[K, D]
 
+// NewDataWithID forwards to dal.NewRecordWithDataAndID, kept for backward
+// compatibility.
 func NewDataWithID[K comparable, D any](id K, key *dal.Key, data D) DataWithID[K, D] {
-	if key == nil {
-		panic(fmt.Sprintf("key is nil for (id=%v)", id))
-	}
-	//if data == nil {
-	//	panic(fmt.Sprintf("data is nil for (id=%v, key=%v)", id, key))
-	//}
-	v := reflect.ValueOf(data)
-	kind := v.Kind()
-	switch kind {
-	case reflect.Pointer, reflect.Interface:
-		if v.IsNil() {
-			t := reflect.TypeOf(data)
-			panic(fmt.Sprintf("data of type %v is nil for (id=%v, key=%v)", t.String(), id, key))
-		}
-		elemType := v.Elem().Type()
-		switch elemType.Kind() {
-		case reflect.Struct, reflect.Map:
-			// OK - expected types
-		default:
-			panic("data should be a pointer to a struct or map, got " + elemType.String())
-		}
-	default:
-		t := reflect.TypeOf(data)
-		if t == nil {
-			panic(fmt.Sprintf("data is nil for (id=%v, key=%v)", id, key))
-		}
-		panic(fmt.Sprintf("data should be a pointer or an interface, got %v for (id=%v, key=%v)", t.String(), id, key))
-	}
-	return DataWithID[K, D]{
-		WithID: NewWithID(id, key, data),
-		Data:   data,
-	}
+	return dal.NewRecordWithDataAndID(id, key, data)
 }

--- a/record/data_with_id_test.go
+++ b/record/data_with_id_test.go
@@ -1,122 +1,29 @@
-package record
+package record_test
 
 import (
 	"testing"
 
 	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/record"
 	"github.com/stretchr/testify/assert"
 )
 
+// TestNewDataWithID covers the backward-compatible record.NewDataWithID
+// forwarder. The full validation matrix is tested in package dal
+// (TestNewRecordWithDataAndID).
 func TestNewDataWithID(t *testing.T) {
-	type data struct {
-		Title string
-	}
+	type data struct{ Title string }
+	key := dal.NewKeyWithID("r1", "SomeCollection")
+	d := &data{Title: "test"}
 
-	type args[K comparable] struct {
-		id   K
-		key  *dal.Key
-		data *data
-	}
+	got := record.NewDataWithID("r1", key, d) // returns record.DataWithID = dal.RecordWithDataAndID alias
 
-	type testCase[K comparable] struct {
-		name         string
-		args         args[K]
-		want         DataWithID[K, *data]
-		expectsPanic string
-	}
-	d1 := data{Title: "test"}
-	tests := []testCase[string]{
-		{
-			name: "should_pass",
-			args: args[string]{
-				id:   "r1",
-				key:  dal.NewKeyWithID("r1", "SomeCollection"),
-				data: &data{Title: "test"},
-			},
-			want: DataWithID[string, *data]{
-				WithID: WithID[string]{
-					ID:     "r1",
-					Key:    dal.NewKeyWithID("r1", "SomeCollection"),
-					Record: dal.NewRecordWithData(dal.NewKeyWithID("r1", "SomeCollection"), &d1),
-				},
-				Data: &d1,
-			},
-		},
-		{
-			name: "should_panic_on_nil_key",
-			args: args[string]{
-				id:   "r1",
-				key:  nil,
-				data: &data{Title: "test"},
-			},
-			expectsPanic: "key is nil for (id=r1)",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.expectsPanic != "" {
-				assert.PanicsWithValue(t, tt.expectsPanic, func() {
-					NewDataWithID(tt.args.id, tt.args.key, tt.args.data)
-				})
-			} else {
-				got := NewDataWithID(tt.args.id, tt.args.key, tt.args.data)
-				assert.Equal(t, tt.want.ID, got.ID)
-				assert.Equal(t, tt.want.Key, got.Key)
-				assert.Equal(t, tt.want.Data, got.Data)
-				got.Record.SetError(nil)
-				assert.Equal(t, tt.want.Data, got.Record.Data())
-			}
-		})
-	}
-	t.Run("should_panic_on_pointer_to_a_pointer", func(t *testing.T) {
-		assert.Panics(t, func() {
-			d1 := data{Title: "test"}
-			d2 := &d1
-			d3 := &d2
-			NewDataWithID("r1", dal.NewKeyWithID("r1", "SomeCollection"), d3)
-		})
-	})
-	t.Run("should_panic_on_pointer_to_an_interface", func(t *testing.T) {
-		assert.Panics(t, func() {
-			d1 := data{Title: "test"}
-			var d2 any = &d1
-			var d3 = &d2
-			NewDataWithID("r1", dal.NewKeyWithID("r1", "SomeCollection"), d3)
-		})
-	})
+	assert.Equal(t, "r1", got.ID)
+	assert.Equal(t, key, got.Key)
+	assert.Equal(t, d, got.Data)
 
-	t.Run("should_panic_on_nil_pointer", func(t *testing.T) {
-		assert.Panics(t, func() {
-			var d *data = nil
-			NewDataWithID("r1", dal.NewKeyWithID("r1", "SomeCollection"), d)
-		})
-	})
-
-	t.Run("should_panic_on_nil_interface", func(t *testing.T) {
-		assert.Panics(t, func() {
-			var d any = nil
-			NewDataWithID("r1", dal.NewKeyWithID("r1", "SomeCollection"), d)
-		})
-	})
-
-	t.Run("should_panic_on_non_pointer_data", func(t *testing.T) {
-		assert.Panics(t, func() {
-			d := data{Title: "test"}
-			NewDataWithID("r1", dal.NewKeyWithID("r1", "SomeCollection"), d)
-		})
-	})
-
-	t.Run("should_panic_on_pointer_to_non_struct_non_map", func(t *testing.T) {
-		assert.Panics(t, func() {
-			s := "test"
-			NewDataWithID("r1", dal.NewKeyWithID("r1", "SomeCollection"), &s)
-		})
-	})
-
-	t.Run("should_work_with_map", func(t *testing.T) {
-		m := map[string]any{"title": "test"}
-		result := NewDataWithID("r1", dal.NewKeyWithID("r1", "SomeCollection"), &m)
-		assert.Equal(t, "r1", result.ID)
-		assert.Equal(t, &m, result.Data)
+	// The forwarder still applies dal's validation (nil key panics).
+	assert.PanicsWithValue(t, "key is nil for (id=r1)", func() {
+		record.NewDataWithID("r1", nil, d)
 	})
 }

--- a/record/with_id.go
+++ b/record/with_id.go
@@ -1,34 +1,16 @@
 package record
 
 import (
-	"fmt"
-
 	"github.com/dal-go/dalgo/dal"
 )
 
-// WithID is a record with a strongly typed ID
-type WithID[K comparable] struct {
-	ID     K          `json:"id"`               // Unique id of the record in collection
-	FullID string     `json:"fullID,omitempty"` // Custom id of the record fully unique across all DB collections
-	Key    *dal.Key   `json:"-"`
-	Record dal.Record `json:"-"`
-}
+// WithID is a backward-compatible alias for dal.RecordWithID.
+//
+// The type now lives in package dal so the typed Collection layer can return it
+// without a dal -> record import cycle. New code should prefer dal.RecordWithID.
+type WithID[K comparable] = dal.RecordWithID[K]
 
-// String returns string representation of a record with an ID
-func (v WithID[K]) String() string {
-	if v.FullID == "" {
-		return fmt.Sprintf("{ID=%v, FullID=nil, Key=%v, Record=%v}", v.ID, v.Key, v.Record)
-	}
-	if id, ok := any(v.ID).(string); ok {
-		return fmt.Sprintf(`{ID="%s", FullID="%s", Key=%v, Record=%v}`, id, v.FullID, v.Key, v.Record)
-	}
-	return fmt.Sprintf(`{ID=%+v, FullID="%s", Key=%v, Record=%v}`, v.ID, v.FullID, v.Key, v.Record)
-}
-
+// NewWithID forwards to dal.NewRecordWithID, kept for backward compatibility.
 func NewWithID[T comparable](id T, key *dal.Key, data any) WithID[T] {
-	return WithID[T]{
-		ID:     id,
-		Key:    key,
-		Record: dal.NewRecordWithData(key, data),
-	}
+	return dal.NewRecordWithID(id, key, data)
 }

--- a/record/with_id_test.go
+++ b/record/with_id_test.go
@@ -1,39 +1,25 @@
-package record
+package record_test
 
 import (
-	"fmt"
 	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/record"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestWithID_String(t *testing.T) {
-	tests := []struct {
-		name  string
-		input fmt.Stringer
-		want  string
-	}{
-		{
-			name:  "Empty FullID",
-			input: WithID[string]{ID: "1", FullID: "", Key: nil, Record: nil},
-			want:  "{ID=1, FullID=nil, Key=<nil>, Record=<nil>}",
-		},
-		{
-			name:  "FullID is not empty, ID is string",
-			input: WithID[string]{ID: "1", FullID: "custom-1", Key: nil, Record: nil},
-			want:  `{ID="1", FullID="custom-1", Key=<nil>, Record=<nil>}`,
-		},
-		{
-			name:  "FullID is not empty, ID is integer",
-			input: WithID[int]{ID: 1, FullID: "custom-1", Key: nil, Record: nil},
-			want:  `{ID=1, FullID="custom-1", Key=<nil>, Record=<nil>}`,
-		},
-	}
+// TestNewWithID covers the backward-compatible record.NewWithID forwarder.
+// The full RecordWithID behavior is tested in package dal.
+func TestNewWithID(t *testing.T) {
+	type data struct{ Title string }
+	key := dal.NewKeyWithID("things", "t1")
+	d := &data{Title: "x"}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.input.String()
-			if got != tt.want {
-				t.Errorf("WithID.String() = %v, want %v", got, tt.want)
-			}
-		})
-	}
+	got := record.NewWithID("t1", key, d) // returns record.WithID = dal.RecordWithID alias
+
+	assert.Equal(t, "t1", got.ID)
+	assert.Equal(t, key, got.Key)
+	assert.NotNil(t, got.Record)
+	got.Record.SetError(nil)
+	assert.Equal(t, d, got.Record.Data())
 }


### PR DESCRIPTION
## What

Relocates the typed record-id value types from package `record` into package `dal`, renamed:

- `record.WithID[K]` → **`dal.RecordWithID[K]`**
- `record.DataWithID[K, D]` → **`dal.RecordWithDataAndID[K, D]`**

## Why

These types only ever depended on `dal` (`Key`, `Record`, `NewRecordWithData`), so they're natural `dal` citizens. Moving them **dissolves the recurring `dal → record` import-cycle tax** — a follow-up can let `dal.Collection[K,T]` return them directly (today `record.GetWithID` must be a free function purely because of that cycle).

## Backward compatibility (kept)

- `record.WithID` / `record.DataWithID` remain as **type aliases** to the new `dal` types.
- `record.NewWithID` / `record.NewDataWithID` remain as **thin forwarders**.
- Result: `recordops` and external consumers (e.g. `bots-fw`) compile **unchanged**.
- The embedded-field rename (`DataWithID.WithID` → `RecordWithDataAndID.RecordWithID`) only touches the constructor + its tests (moved); no other code references the embedded field name.

Aliases are intentionally **not** marked `// Deprecated:` to avoid an SA1019 storm across `recordops`; deprecation + migration can be a later, separate pass.

## Verification

- ✅ `go build` / `go vet` clean
- ✅ `golangci-lint run ./...` → **0 issues**
- ✅ all 17 packages' tests pass
- ✅ **100% coverage** on moved code + forwarders (CI gate is 100%)
- ✅ `dal` still does **not** import `record` (invariant holds)
- ✅ `specscore spec lint` → 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)