### PR TITLE
feat(dal): typed id read accessors + GetRecordWithIDIntoData factory variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,11 @@ func demo(ctx context.Context, db dal.DB) error {
 The handle exposes the common operations as typed terminals:
 
 - **Reads:** `GetData` (one record → `T`), `GetRecord` (→ `dal.Record`),
-  `All` (whole collection → `[]T`), `First`, `Count`, `Exists`. For a typed
-  id+record pair use `record.GetWithID(ctx, coll, s, id)` (a free function in
-  package `record`, since `dal` stays free of any `record` import).
+  `GetRecordWithID` (→ `dal.RecordWithID[K]`), `GetRecordWithDataAndID`
+  (→ `dal.RecordWithDataAndID[K, *T]`), `All` (whole collection → `[]T`),
+  `First`, `Count`, `Exists`. For interface-typed model data created by a
+  factory, use the free function `dal.GetRecordWithIDIntoData(ctx, s, key, id,
+  data)`, which decodes into the value you pass.
 - **Writes:** `Insert` (generated id → `*dal.Key`), `InsertWithID` (known id),
   `InsertRecord`, `SetByID` (upsert), `SetRecord`, `UpdateByID`, `UpdateByKey`,
   `DeleteByID`, `DeleteByKey`, and batch `InsertMany` via the opt-in

--- a/dal/collection.go
+++ b/dal/collection.go
@@ -53,6 +53,16 @@ type Collection[K comparable, T any] interface {
 	// the not-found error from the session Get call.
 	GetRecord(ctx context.Context, s ReadSession, id K) (Record, error)
 
+	// GetRecordWithID reads id and returns a typed RecordWithID[K] (id + key +
+	// record, no typed data). On not-found it returns the zero value and the
+	// session's not-found error.
+	GetRecordWithID(ctx context.Context, s ReadSession, id K) (RecordWithID[K], error)
+
+	// GetRecordWithDataAndID reads id and returns a RecordWithDataAndID[K, *T]
+	// whose Data is the decoded *T (the same pointer held by the Record). On
+	// not-found it returns the zero value and the session's not-found error.
+	GetRecordWithDataAndID(ctx context.Context, s ReadSession, id K) (RecordWithDataAndID[K, *T], error)
+
 	// All returns every record in the collection, each decoded into a freshly
 	// allocated value so results never alias. It surfaces ErrNotSupported from
 	// backends that cannot run the query.
@@ -230,6 +240,25 @@ func (c collection[K, T]) GetData(ctx context.Context, s ReadSession, id K) (T, 
 		return zero, err
 	}
 	return *record.Data().(*T), nil
+}
+
+func (c collection[K, T]) GetRecordWithID(ctx context.Context, s ReadSession, id K) (RecordWithID[K], error) {
+	record, err := c.GetRecord(ctx, s, id)
+	if err != nil {
+		return RecordWithID[K]{}, err
+	}
+	return RecordWithID[K]{ID: id, Key: record.Key(), Record: record}, nil
+}
+
+func (c collection[K, T]) GetRecordWithDataAndID(ctx context.Context, s ReadSession, id K) (RecordWithDataAndID[K, *T], error) {
+	record, err := c.GetRecord(ctx, s, id)
+	if err != nil {
+		return RecordWithDataAndID[K, *T]{}, err
+	}
+	return RecordWithDataAndID[K, *T]{
+		RecordWithID: RecordWithID[K]{ID: id, Key: record.Key(), Record: record},
+		Data:         record.Data().(*T),
+	}, nil
 }
 
 func (c collection[K, T]) Get(ctx context.Context, s ReadSession, id K) (T, error) {

--- a/dal/get_record_with_id_into_data.go
+++ b/dal/get_record_with_id_into_data.go
@@ -1,0 +1,21 @@
+package dal
+
+import "context"
+
+// GetRecordWithIDIntoData fetches the record at key, decoding it INTO the
+// caller-supplied data value, and returns a typed RecordWithDataAndID[K, D].
+//
+// Unlike Collection.GetRecordWithDataAndID (which allocates new(T) and therefore
+// needs a concrete T), this takes the data value from the caller, so D may be an
+// interface holding a concrete pointer (the factory pattern used by frameworks
+// whose model types are interfaces). It is a free function because Go forbids
+// type parameters on methods, so the decoupled data type D cannot be expressed
+// as a Collection[K, T] method.
+//
+// data must be a non-nil pointer or interface referencing a struct or a map (see
+// NewRecordWithDataAndID, which validates it). On not-found it returns the built
+// value together with the session's not-found error.
+func GetRecordWithIDIntoData[K comparable, D any](ctx context.Context, s ReadSession, key *Key, id K, data D) (RecordWithDataAndID[K, D], error) {
+	rec := NewRecordWithDataAndID(id, key, data)
+	return rec, s.Get(ctx, rec.Record)
+}

--- a/dal/record_accessors_test.go
+++ b/dal/record_accessors_test.go
@@ -1,0 +1,97 @@
+package dal_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollection_GetRecordWithID(t *testing.T) {
+	ctx := context.Background()
+	db := newMemoryDB(t)
+	users := dal.CollectionOf[string, User]()
+
+	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return users.SetByID(ctx, tx, "u1", User{Name: "Alice"})
+	})
+
+	got, err := users.GetRecordWithID(ctx, db, "u1")
+	require.NoError(t, err)
+	assert.Equal(t, "u1", got.ID)
+	require.NotNil(t, got.Key)
+	assert.Equal(t, "users/u1", got.Key.String())
+	require.NotNil(t, got.Record)
+	assert.Equal(t, "Alice", got.Record.Data().(*User).Name)
+
+	// not-found returns the zero value + the session not-found error.
+	missing, err := users.GetRecordWithID(ctx, db, "missing")
+	require.Error(t, err)
+	assert.True(t, dal.IsNotFound(err))
+	assert.Equal(t, dal.RecordWithID[string]{}, missing)
+}
+
+func TestCollection_GetRecordWithDataAndID(t *testing.T) {
+	ctx := context.Background()
+	db := newMemoryDB(t)
+	users := dal.CollectionOf[string, User]()
+
+	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return users.SetByID(ctx, tx, "u1", User{Name: "Alice"})
+	})
+
+	got, err := users.GetRecordWithDataAndID(ctx, db, "u1")
+	require.NoError(t, err)
+	assert.Equal(t, "u1", got.ID)
+	assert.Equal(t, "users/u1", got.Key.String())
+	require.NotNil(t, got.Data)
+	assert.Equal(t, "Alice", got.Data.Name)
+	// Data is the same *T the Record holds (no copy).
+	assert.Same(t, got.Data, got.Record.Data().(*User))
+
+	// not-found returns the zero value + the session not-found error.
+	missing, err := users.GetRecordWithDataAndID(ctx, db, "missing")
+	require.Error(t, err)
+	assert.True(t, dal.IsNotFound(err))
+	assert.Equal(t, dal.RecordWithDataAndID[string, *User]{}, missing)
+}
+
+func TestGetRecordWithIDIntoData(t *testing.T) {
+	ctx := context.Background()
+	db := newMemoryDB(t)
+	users := dal.CollectionOf[string, User]()
+
+	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return users.SetByID(ctx, tx, "u1", User{Name: "Alice"})
+	})
+
+	key := dal.NewKeyWithID("users", "u1")
+
+	// Concrete pointer data: decoded INTO the provided value.
+	into := &User{}
+	got, err := dal.GetRecordWithIDIntoData(ctx, db, key, "u1", into)
+	require.NoError(t, err)
+	assert.Equal(t, "u1", got.ID)
+	assert.Same(t, into, got.Data, "must decode into the caller-supplied value")
+	assert.Equal(t, "Alice", into.Name)
+
+	// Interface data (factory pattern): D is an interface holding a concrete
+	// pointer — exactly the case Collection.GetRecordWithDataAndID cannot serve.
+	var iface any = &User{}
+	gotIface, err := dal.GetRecordWithIDIntoData(ctx, db, key, "u1", iface)
+	require.NoError(t, err)
+	assert.Equal(t, "Alice", gotIface.Data.(*User).Name)
+
+	// not-found returns the built value + the session not-found error.
+	_, err = dal.GetRecordWithIDIntoData(ctx, db, dal.NewKeyWithID("users", "missing"), "missing", &User{})
+	require.Error(t, err)
+	assert.True(t, dal.IsNotFound(err))
+
+	// invalid data (not a pointer/interface to struct/map) panics via
+	// NewRecordWithDataAndID.
+	assert.Panics(t, func() {
+		_, _ = dal.GetRecordWithIDIntoData(ctx, db, key, "u1", User{})
+	})
+}

--- a/record/get_with_id.go
+++ b/record/get_with_id.go
@@ -7,20 +7,13 @@ import (
 )
 
 // GetWithID reads the record stored at id from collection c and returns it as a
-// typed WithID[K]. The decoded value of type T is reachable via the returned
-// WithID's Record (Record.Data() is a *T).
+// typed WithID[K] (an alias for dal.RecordWithID[K]). The decoded value of type T
+// is reachable via the returned record (Record.Data() is a *T).
 //
-// It lives in package record (not as a Collection[K, T] method) because it
-// returns record.WithID[K]: package dal must stay free of any import of the
-// record package, so the typed-with-id accessor is provided here as a free
-// function over the dal.Collection[K, T] handle.
-//
-// On not-found it returns the zero WithID[K] together with the not-found error
-// from the underlying Get (use dal.IsNotFound to test it).
+// Deprecated: use c.GetRecordWithID(ctx, s, id) directly. Now that the
+// RecordWithID type and the accessor both live in package dal, this thin
+// collection-wrapping forwarder is redundant; it is retained only for backward
+// compatibility.
 func GetWithID[K comparable, T any](ctx context.Context, c dal.Collection[K, T], s dal.ReadSession, id K) (WithID[K], error) {
-	r, err := c.GetRecord(ctx, s, id)
-	if err != nil {
-		return WithID[K]{}, err
-	}
-	return WithID[K]{ID: id, Key: r.Key(), Record: r}, nil
+	return c.GetRecordWithID(ctx, s, id)
 }

--- a/record/get_with_id_test.go
+++ b/record/get_with_id_test.go
@@ -28,7 +28,7 @@ func TestGetWithID(t *testing.T) {
 
 	// Success: returns a typed WithID carrying the id, key, and decoded record.
 	// (K and T are inferred from the collection handle and id.)
-	got, err := record.GetWithID(ctx, users, db, "u1")
+	got, err := record.GetWithID(ctx, users, db, "u1") //nolint:staticcheck // covers the deprecated forwarder
 	require.NoError(t, err)
 	assert.Equal(t, "u1", got.ID)
 	require.NotNil(t, got.Key)
@@ -37,7 +37,7 @@ func TestGetWithID(t *testing.T) {
 	assert.Equal(t, "Alice", got.Record.Data().(*gwUser).Name)
 
 	// Not-found: returns the zero WithID and the not-found error.
-	missing, err := record.GetWithID(ctx, users, db, "missing")
+	missing, err := record.GetWithID(ctx, users, db, "missing") //nolint:staticcheck // covers the deprecated forwarder
 	require.Error(t, err)
 	assert.True(t, dal.IsNotFound(err))
 	assert.Equal(t, record.WithID[string]{}, missing)

--- a/spec/features/typed-collection/README.md
+++ b/spec/features/typed-collection/README.md
@@ -15,7 +15,7 @@ status: Approved
 
 ## Summary
 
-A session-less generic dal.Collection[K, T] handle in package dal with point-CRUD terminals keyed by a typed id K. Reads expose GetData/GetRecord (and a record.GetWithID free function); writes expose InsertWithID/InsertRecord/SetByID/SetRecord/UpdateByID/UpdateByKey/DeleteByID/DeleteByKey, with deprecated Get/Set/Update/Delete aliases. Key options (composite keys, parent) are configured on the constructor via WithKeyOptions. Built additively over the existing dal session interfaces. Generated Insert and batch are separate Features.
+A session-less generic dal.Collection[K, T] handle in package dal with point-CRUD terminals keyed by a typed id K. Reads expose GetData/GetRecord plus the typed id accessors GetRecordWithID/GetRecordWithDataAndID and the dal.GetRecordWithIDIntoData factory function (with a deprecated record.GetWithID forwarder); writes expose InsertWithID/InsertRecord/SetByID/SetRecord/UpdateByID/UpdateByKey/DeleteByID/DeleteByKey, with deprecated Get/Set/Update/Delete aliases. Key options (composite keys, parent) are configured on the constructor via WithKeyOptions. Built additively over the existing dal session interfaces. Generated Insert and batch are separate Features.
 
 ## Problem
 
@@ -43,7 +43,15 @@ Every point terminal that takes an id MUST take a strongly typed `id K` argument
 
 #### REQ: typed-get-record
 
-`Collection[K, T]` MUST provide `GetRecord(ctx, s ReadSession, id K) (dal.Record, error)` that returns the underlying `dal.Record` (its `Data()` is a `*T`). It is the read primitive `GetData` delegates to. Package `record` MUST additionally provide a free function `GetWithID[K comparable, T any](ctx, c dal.Collection[K, T], s dal.ReadSession, id K) (record.WithID[K], error)` returning a typed id+record pair — it lives in `record` (not as a method) so `dal` introduces no `record` import.
+`Collection[K, T]` MUST provide `GetRecord(ctx, s ReadSession, id K) (dal.Record, error)` that returns the underlying `dal.Record` (its `Data()` is a `*T`). It is the read primitive the other read accessors delegate to.
+
+`Collection[K, T]` MUST additionally provide typed id-bearing accessors built over `GetRecord`:
+- `GetRecordWithID(ctx, s ReadSession, id K) (dal.RecordWithID[K], error)` — id + key + record (no typed data).
+- `GetRecordWithDataAndID(ctx, s ReadSession, id K) (dal.RecordWithDataAndID[K, *T], error)` — adds the decoded `*T` (the same pointer the Record holds).
+
+For models whose data type is an interface created by a factory (so `new(T)` cannot allocate it), `dal` MUST provide a free function `GetRecordWithIDIntoData[K comparable, D any](ctx, s ReadSession, key *dal.Key, id K, data D) (dal.RecordWithDataAndID[K, D], error)` that decodes INTO the caller-supplied `data` value. It is a free function (not a method) because Go forbids type parameters on methods, so the decoupled data type `D` cannot be a `Collection[K, T]` method.
+
+For backward compatibility package `record` MUST keep `GetWithID[K comparable, T any](...) (record.WithID[K], error)` as a deprecated thin forwarder to `Collection.GetRecordWithID` (`record.WithID` is an alias for `dal.RecordWithID`).
 
 #### REQ: typed-all
 
@@ -120,8 +128,8 @@ The layer MUST live in package `dal`, implemented over the existing session inte
 ### AC: get-record-and-with-id (verifies REQ:typed-get-record)
 
 **Given** a `User{Name:"Alice"}` stored at id `"u1"`
-**When** `GetRecord(ctx, db, "u1")` and `record.GetWithID(ctx, coll, db, "u1")` are called
-**Then** `GetRecord` returns a `dal.Record` whose `Data()` is a `*User` with `Name=="Alice"`, and `GetWithID` returns a `record.WithID[string]` carrying id `"u1"`, the key, and that record; on not-found both return the not-found error.
+**When** `GetRecord`, `GetRecordWithID`, `GetRecordWithDataAndID`, and `dal.GetRecordWithIDIntoData` (and the deprecated `record.GetWithID` forwarder) are called for `"u1"`
+**Then** `GetRecord` returns a `dal.Record` whose `Data()` is a `*User` with `Name=="Alice"`; `GetRecordWithID` returns a `dal.RecordWithID[string]` carrying id/key/record; `GetRecordWithDataAndID` additionally exposes `Data` as the `*User` the Record holds; `GetRecordWithIDIntoData` decodes into a caller-supplied value (including an interface value); and on not-found each returns the session's not-found error.
 
 ### AC: typed-all-distinct (verifies REQ:typed-all)
 
@@ -185,12 +193,13 @@ The layer MUST live in package `dal`, implemented over the existing session inte
 
 ## Architecture & Components
 
-- **`dal.Collection[K, T]` (interface)** — the typed contract: `GetData`/`Get`(deprecated)/`GetRecord`/`All`/`InsertWithID`/`InsertRecord`/`SetByID`/`Set`(deprecated)/`SetRecord`/`UpdateByID`/`Update`(deprecated)/`UpdateByKey`/`DeleteByID`/`Delete`(deprecated)/`DeleteByKey`/`In`. Lives in `dal` (the contracts package), alongside `ReadSession`/`Getter`/etc.
+- **`dal.Collection[K, T]` (interface)** — the typed contract: `GetData`/`Get`(deprecated)/`GetRecord`/`GetRecordWithID`/`GetRecordWithDataAndID`/`All`/`InsertWithID`/`InsertRecord`/`SetByID`/`Set`(deprecated)/`SetRecord`/`UpdateByID`/`Update`(deprecated)/`UpdateByKey`/`DeleteByID`/`Delete`(deprecated)/`DeleteByKey`/`In`. Lives in `dal` (the contracts package), alongside `ReadSession`/`Getter`/etc.
+- **`dal.GetRecordWithIDIntoData[K, D]` (free function)** — decodes into a caller-supplied `data` value, so `D` may be an interface (factory pattern); a free function because Go forbids method type parameters.
 - **unexported impl (in `dal`)** — a small value composing a `dal.CollectionRef` (name + optional parent), the configured `[]KeyOption`, and the phantom `K, T`. `idToKey(id K)` builds a `Key` from the handle's `CollectionRef`, sets `Key.ID = id`, applies the collection's key options via `setKeyOptions`, then guards the parent chain. Each terminal wraps `new(T)`/`&value` with `NewRecordWithData`, calls the matching session method, and returns the typed value / key / error. `*ByID` terminals delegate to the corresponding `*ByKey`/`*Record` primitive.
 - **`CollectionOption` + `WithKeyOptions`** — a constructor option carrying collection-level `dal.KeyOption`s.
 - **`CollectionNamer` (interface)** — `CollectionName() string`; a constraint on `CollectionOf`.
 - **Constructors** — `CollectionOf[K comparable, T CollectionNamer](opts ...CollectionOption)` and `CollectionAt[K comparable, T any](name string, opts ...CollectionOption)`, both returning `dal.Collection[K, T]`.
-- **`record.GetWithID[K, T]` (free function)** — returns `record.WithID[K]` over a `dal.Collection[K, T]`; lives in `record` to keep `dal` free of any `record` import.
+- **`record.GetWithID[K, T]` (deprecated free function)** — a thin forwarder to `Collection.GetRecordWithID`, kept for backward compatibility (`record.WithID` aliases `dal.RecordWithID`).
 - **Dependencies** — existing `dal` session interfaces (`ReadSession`/`WriteSession`), `Key`/`CollectionRef`, and the `update` package. No new external dependency; no `record` import in `dal`.
 
 Data flow (GetData): `id K` → `Key` (handle `CollectionRef` + id + key options) → `GetRecord` → `NewRecordWithData(key, new(T))` → `ReadSession.Get` → return `*new(T)`, mapping the call's not-found error to `(zero T, err)`.

--- a/spec/plans/typed-collection.md
+++ b/spec/plans/typed-collection.md
@@ -84,13 +84,13 @@ Implement `In(parent *dal.Key) dal.Collection[T]` composing the `CollectionRef` 
 
 Confirm the layer is additive: run the full pre-existing `dal` + `dalgo2memory` + `end2end` suites and keep them green with no existing call-site changes, and add a test/assertion that `dal` still does not import the `record` package.
 
-### Task 9: GetRecord primitive and record.GetWithID
+### Task 9: GetRecord primitive and typed id accessors
 
 **Verifies:** typed-collection#ac:get-record-and-with-id
 **Depends-On:** 3
 **Status:** done
 
-Add `GetRecord(ctx, ReadSession, id K) (dal.Record, error)` as the read primitive `GetData` delegates to, and the free function `record.GetWithID[K, T](ctx, c, s, id) (record.WithID[K], error)` in package `record` (keeping `dal` free of any `record` import). Both surface the session not-found error.
+Add `GetRecord(ctx, ReadSession, id K) (dal.Record, error)` as the read primitive the other read accessors delegate to. Add the typed id accessors `GetRecordWithID(...) (dal.RecordWithID[K], error)` and `GetRecordWithDataAndID(...) (dal.RecordWithDataAndID[K, *T], error)` as `Collection` methods, plus the free function `dal.GetRecordWithIDIntoData[K, D](ctx, s, key, id, data) (dal.RecordWithDataAndID[K, D], error)` for interface/factory data (decoding into a caller-supplied value). Keep `record.GetWithID` as a deprecated thin forwarder to `Collection.GetRecordWithID`. All surface the session not-found error.
 
 ## Open Questions
 


### PR DESCRIPTION
## What

Adds the typed id-bearing read accessors discussed in review, now that `RecordWithID`/`RecordWithDataAndID` live in `dal` (the import-cycle constraint is gone):

- **`Collection.GetRecordWithID(ctx, s, id) (RecordWithID[K], error)`** — id + key + record.
- **`Collection.GetRecordWithDataAndID(ctx, s, id) (RecordWithDataAndID[K, *T], error)`** — adds the decoded `*T` (the **same pointer** the Record holds; no copy, type invariant intact).
- **`dal.GetRecordWithIDIntoData[K, D](ctx, s, key, id, data D) (RecordWithDataAndID[K, D], error)`** — decodes **into** the caller-supplied `data`, so `D` may be an interface holding a concrete pointer (the factory pattern frameworks like bots-fw need). A **free function** because Go forbids type parameters on methods, so the decoupled `D` can't be a `Collection` method.

`record.GetWithID` becomes a **deprecated** thin forwarder to `Collection.GetRecordWithID`.

## Naming
Per review: `GetRecordWithID` / `GetRecordWithDataAndID` mirror the type names; the factory variant is `GetRecordWithIDIntoData` (the `Into` signals "decode into your value"; reads well and is easy to grep).

## Verification
- ✅ `go build`/`vet` clean · `golangci-lint` **0 issues** · 17 packages pass
- ✅ **100% coverage** on all new code (incl. the deprecated forwarder via `//nolint:staticcheck`)
- ✅ `dal` still does **not** import `record`
- ✅ `specscore spec lint` 0 violations · README + typed-collection Feature/Plan specs updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)