### PR TITLE
feat(dal): add InsertRecordWithDataAndID (write twin of GetRecordWithIDIntoData)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,9 @@ The handle exposes the common operations as typed terminals:
 - **Writes:** `Insert` (generated id → `*dal.Key`), `InsertWithID` (known id),
   `InsertRecord`, `SetByID` (upsert), `SetRecord`, `UpdateByID`, `UpdateByKey`,
   `DeleteByID`, `DeleteByKey`, and batch `InsertMany` via the opt-in
-  `dal.ManyInserter[K, T]` interface.
+  `dal.ManyInserter[K, T]` interface. For interface-typed model data, insert via
+  the free function `dal.InsertRecordWithDataAndID(ctx, s, key, id, data)` (the
+  write twin of `GetRecordWithIDIntoData`).
 - **Composite / multi-field keys:** pass `dal.WithKeyOptions(...)` to the
   constructor, or build a `*dal.Key` with `dal.NewKeyWithFields` and use the
   `*ByKey` terminals.

--- a/dal/insert_record_with_data_and_id.go
+++ b/dal/insert_record_with_data_and_id.go
@@ -1,0 +1,20 @@
+package dal
+
+import "context"
+
+// InsertRecordWithDataAndID inserts the caller-supplied data value at key (under
+// id) and returns a typed RecordWithDataAndID[K, D].
+//
+// It is the write twin of GetRecordWithIDIntoData: data is used as-is (never
+// new(T)), so D may be an interface holding a concrete pointer — the factory
+// pattern used by frameworks whose model types are interfaces. It is a free
+// function because Go forbids type parameters on methods, so the decoupled data
+// type D cannot be expressed as a Collection[K, T] method.
+//
+// data must be a non-nil pointer or interface referencing a struct or a map (see
+// NewRecordWithDataAndID, which validates it). On failure it returns the built
+// value together with the session Insert error.
+func InsertRecordWithDataAndID[K comparable, D any](ctx context.Context, s WriteSession, key *Key, id K, data D) (RecordWithDataAndID[K, D], error) {
+	rec := NewRecordWithDataAndID(id, key, data)
+	return rec, s.Insert(ctx, rec.Record)
+}

--- a/dal/insert_record_with_data_and_id_test.go
+++ b/dal/insert_record_with_data_and_id_test.go
@@ -1,0 +1,58 @@
+package dal_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInsertRecordWithDataAndID(t *testing.T) {
+	ctx := context.Background()
+	db := newMemoryDB(t)
+	users := dal.CollectionOf[string, User]()
+
+	// Concrete pointer data.
+	var got dal.RecordWithDataAndID[string, *User]
+	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		var err error
+		got, err = dal.InsertRecordWithDataAndID(ctx, tx, dal.NewKeyWithID("users", "u1"), "u1", &User{Name: "Alice"})
+		return err
+	})
+	assert.Equal(t, "u1", got.ID)
+	require.NotNil(t, got.Data)
+	assert.Equal(t, "Alice", got.Data.Name)
+	stored, err := users.GetData(ctx, db, "u1")
+	require.NoError(t, err)
+	assert.Equal(t, "Alice", stored.Name)
+
+	// Interface data (factory pattern): D is an interface holding a concrete
+	// pointer — the case Collection.InsertWithID can't serve cleanly.
+	var iface any = &User{Name: "Bob"}
+	write(t, db, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		_, err := dal.InsertRecordWithDataAndID(ctx, tx, dal.NewKeyWithID("users", "u2"), "u2", iface)
+		return err
+	})
+	stored2, err := users.GetData(ctx, db, "u2")
+	require.NoError(t, err)
+	assert.Equal(t, "Bob", stored2.Name)
+
+	// Insert error path: inserting again at an existing id surfaces the session
+	// Insert error.
+	err = db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		_, e := dal.InsertRecordWithDataAndID(ctx, tx, dal.NewKeyWithID("users", "u1"), "u1", &User{Name: "Dup"})
+		return e
+	})
+	require.Error(t, err)
+
+	// Invalid data (not a pointer/interface to struct/map) panics via
+	// NewRecordWithDataAndID.
+	assert.Panics(t, func() {
+		_ = db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+			_, e := dal.InsertRecordWithDataAndID(ctx, tx, dal.NewKeyWithID("users", "u3"), "u3", User{})
+			return e
+		})
+	})
+}

--- a/spec/features/typed-collection/README.md
+++ b/spec/features/typed-collection/README.md
@@ -15,7 +15,7 @@ status: Approved
 
 ## Summary
 
-A session-less generic dal.Collection[K, T] handle in package dal with point-CRUD terminals keyed by a typed id K. Reads expose GetData/GetRecord plus the typed id accessors GetRecordWithID/GetRecordWithDataAndID and the dal.GetRecordWithIDIntoData factory function (with a deprecated record.GetWithID forwarder); writes expose InsertWithID/InsertRecord/SetByID/SetRecord/UpdateByID/UpdateByKey/DeleteByID/DeleteByKey, with deprecated Get/Set/Update/Delete aliases. Key options (composite keys, parent) are configured on the constructor via WithKeyOptions. Built additively over the existing dal session interfaces. Generated Insert and batch are separate Features.
+A session-less generic dal.Collection[K, T] handle in package dal with point-CRUD terminals keyed by a typed id K. Reads expose GetData/GetRecord plus the typed id accessors GetRecordWithID/GetRecordWithDataAndID and the dal.GetRecordWithIDIntoData factory function (with a deprecated record.GetWithID forwarder); writes expose InsertWithID/InsertRecord/SetByID/SetRecord/UpdateByID/UpdateByKey/DeleteByID/DeleteByKey plus the dal.InsertRecordWithDataAndID factory function, with deprecated Get/Set/Update/Delete aliases. Key options (composite keys, parent) are configured on the constructor via WithKeyOptions. Built additively over the existing dal session interfaces. Generated Insert and batch are separate Features.
 
 ## Problem
 
@@ -62,6 +62,8 @@ For backward compatibility package `record` MUST keep `GetWithID[K comparable, T
 #### REQ: insert-with-id
 
 `Collection[K, T]` MUST provide `InsertWithID(ctx, s WriteSession, id K, value T) (*dal.Key, error)` that inserts a new record at a KNOWN id and returns the record's key. It MUST delegate to the record primitive `InsertRecord(ctx, s WriteSession, r dal.Record, opts ...dal.InsertOption) error`. (Generated ids are out of scope for this Feature.)
+
+For models whose data type is an interface created by a factory (the write twin of `GetRecordWithIDIntoData`), `dal` MUST provide a free function `InsertRecordWithDataAndID[K comparable, D any](ctx, s WriteSession, key *dal.Key, id K, data D) (dal.RecordWithDataAndID[K, D], error)` that inserts the caller-supplied `data` value as-is (so `D` may be an interface) and returns the typed wrapper. It is a free function because Go forbids type parameters on methods.
 
 #### REQ: typed-set
 
@@ -147,7 +149,7 @@ The layer MUST live in package `dal`, implemented over the existing session inte
 
 **Given** a `Collection[string, User]` and a writable transaction `tx`
 **When** `InsertWithID(ctx, tx, "u1", User{Name:"Alice"})` is called
-**Then** a record exists at id `"u1"` and the returned `*dal.Key` has ID `"u1"` and a nil error; a direct `InsertRecord` with a caller-built record stores it the same way.
+**Then** a record exists at id `"u1"` and the returned `*dal.Key` has ID `"u1"` and a nil error; a direct `InsertRecord` with a caller-built record stores it the same way; and `dal.InsertRecordWithDataAndID(ctx, tx, key, id, data)` inserts a caller-supplied (possibly interface) data value and returns the typed `RecordWithDataAndID`.
 
 ### AC: set-upserts (verifies REQ:typed-set)
 
@@ -195,6 +197,7 @@ The layer MUST live in package `dal`, implemented over the existing session inte
 
 - **`dal.Collection[K, T]` (interface)** — the typed contract: `GetData`/`Get`(deprecated)/`GetRecord`/`GetRecordWithID`/`GetRecordWithDataAndID`/`All`/`InsertWithID`/`InsertRecord`/`SetByID`/`Set`(deprecated)/`SetRecord`/`UpdateByID`/`Update`(deprecated)/`UpdateByKey`/`DeleteByID`/`Delete`(deprecated)/`DeleteByKey`/`In`. Lives in `dal` (the contracts package), alongside `ReadSession`/`Getter`/etc.
 - **`dal.GetRecordWithIDIntoData[K, D]` (free function)** — decodes into a caller-supplied `data` value, so `D` may be an interface (factory pattern); a free function because Go forbids method type parameters.
+- **`dal.InsertRecordWithDataAndID[K, D]` (free function)** — the write twin: inserts the caller-supplied `data` value as-is (interface-friendly) and returns the typed `RecordWithDataAndID[K, D]`.
 - **unexported impl (in `dal`)** — a small value composing a `dal.CollectionRef` (name + optional parent), the configured `[]KeyOption`, and the phantom `K, T`. `idToKey(id K)` builds a `Key` from the handle's `CollectionRef`, sets `Key.ID = id`, applies the collection's key options via `setKeyOptions`, then guards the parent chain. Each terminal wraps `new(T)`/`&value` with `NewRecordWithData`, calls the matching session method, and returns the typed value / key / error. `*ByID` terminals delegate to the corresponding `*ByKey`/`*Record` primitive.
 - **`CollectionOption` + `WithKeyOptions`** — a constructor option carrying collection-level `dal.KeyOption`s.
 - **`CollectionNamer` (interface)** — `CollectionName() string`; a constraint on `CollectionOf`.

--- a/spec/plans/typed-collection.md
+++ b/spec/plans/typed-collection.md
@@ -58,7 +58,7 @@ Implement `All(ctx, ReadSession) ([]T, error)` building a `StructuredQuery` over
 **Depends-On:** 2
 **Status:** done
 
-Implement `InsertWithID(ctx, WriteSession, id, value) (*dal.Key, error)` and `Set(ctx, WriteSession, id, value) error`, delegating to the session `Inserter`/`Setter` with a record built from the resolved key; `InsertWithID` returns that key.
+Implement `InsertWithID(ctx, WriteSession, id, value) (*dal.Key, error)` and `Set(ctx, WriteSession, id, value) error`, delegating to the session `Inserter`/`Setter` with a record built from the resolved key; `InsertWithID` returns that key. Also add the free function `dal.InsertRecordWithDataAndID[K, D](ctx, s, key, id, data) (dal.RecordWithDataAndID[K, D], error)` — the write twin of `GetRecordWithIDIntoData` — which inserts a caller-supplied (possibly interface) data value and returns the typed wrapper.
 
 ### Task 6: Update and Delete terminals
 


### PR DESCRIPTION
## What
Adds the standalone typed **insert** helper, the write counterpart to `GetRecordWithIDIntoData`:

```go
func InsertRecordWithDataAndID[K comparable, D any](
    ctx context.Context, s WriteSession, key *Key, id K, data D,
) (RecordWithDataAndID[K, D], error)
```

It inserts the **caller-supplied `data` value as-is** (never `new(T)`), so `D` may be an interface holding a concrete pointer — the factory pattern needed for writes by frameworks whose model types are interfaces (e.g. bots-fw). Free function because Go forbids type parameters on methods.

## Why a new helper
The existing write methods don't serve the interface-data case:
- `Collection.InsertRecord` ≡ `guardParent + s.Insert` — no gain when the caller already has the key.
- `Collection.InsertWithID` does `NewRecordWithData(key, &value)`, i.e. `*interface` for interface `T` — a serialization-shape change. `InsertRecordWithDataAndID` passes the value directly, matching today's behavior.

This unblocks migrating bots-fw's `CreatePlatformUserRecord` (a follow-up PR there).

## Verification
- ✅ `go build`/`vet` clean · `golangci-lint` **0 issues** · 17 packages pass
- ✅ **100% coverage** on the new function (concrete + interface + insert-error paths)
- ✅ `dal` still does not import `record`
- ✅ `specscore spec lint` 0 violations · README + Feature/Plan specs updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)