### PR TITLE
ci: run on push to main only (drop branches-ignore renovate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: Go CI
 
 on:
   push:
-    branches-ignore:
-      - renovate/**
+    branches:
+      - main
     tags:
       - 'v[0-9]+\.[0-9]+\.[0-9]+' # Push events to matching v*, i.e. v20.15.10
   pull_request:

--- a/.github/workflows/dtql.yml
+++ b/.github/workflows/dtql.yml
@@ -7,8 +7,8 @@ name: DTQL
 
 on:
   push:
-    branches-ignore:
-      - renovate/**
+    branches:
+      - main
   pull_request:
     branches:
       - '**'


### PR DESCRIPTION
Scopes the push trigger to `main` + tags so PRs run the workflow once (via `pull_request`) instead of twice (branch push + `pull_request`). Applies to both `ci.yml` and `dtql.yml`.

Direct push to `main` was rejected (protected branch), so this goes via PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)