### PR TITLE
chore(spec): apply specscore lint --fix

### DIFF
--- a/spec/plans/2026-06-02-recordset-computed-columns.md
+++ b/spec/plans/2026-06-02-recordset-computed-columns.md
@@ -1,6 +1,6 @@
 # Plan: Computed Columns in recordset (neutral evaluator contract)
 
-**Status:** Completed
+**Status:** Implemented
 **Source Feature:** recordset-computed-columns
 **Date:** 2026-06-02
 **Owner:** alex

--- a/spec/plans/2026-06-05-qualified-orderby-resolution.md
+++ b/spec/plans/2026-06-05-qualified-orderby-resolution.md
@@ -1,6 +1,6 @@
 # Plan: Source-qualified, multi-key ORDER BY resolution in dalgo2memory
 
-**Status:** Completed
+**Status:** Implemented
 **Source Feature:** qualified-orderby-resolution
 **Date:** 2026-06-05
 **Owner:** alex

--- a/spec/plans/2026-06-05-query-column-projection.md
+++ b/spec/plans/2026-06-05-query-column-projection.md
@@ -1,6 +1,6 @@
 # Plan: Column selection in the query builder, projected by dalgo2memory
 
-**Status:** Completed
+**Status:** Implemented
 **Source Feature:** query-column-projection
 **Date:** 2026-06-05
 **Owner:** alex

--- a/spec/plans/2026-06-05-query-group-by-aggregation.md
+++ b/spec/plans/2026-06-05-query-group-by-aggregation.md
@@ -1,6 +1,6 @@
 # Plan: GROUP BY with aggregation in the query builder, executed by dalgo2memory
 
-**Status:** Completed
+**Status:** Implemented
 **Source Feature:** query-group-by-aggregation
 **Date:** 2026-06-05
 **Owner:** alex

--- a/spec/plans/2026-06-05-query-joins.md
+++ b/spec/plans/2026-06-05-query-joins.md
@@ -1,6 +1,6 @@
 # Plan: First-class INNER/LEFT joins in dal's query model
 
-**Status:** Completed
+**Status:** Implemented
 **Source Feature:** query-joins
 **Date:** 2026-06-05
 **Owner:** alex

--- a/spec/plans/2026-06-06-columnar-mixed-mode-maps.md
+++ b/spec/plans/2026-06-06-columnar-mixed-mode-maps.md
@@ -1,6 +1,6 @@
 # Plan: Mixed-mode columnar storage for map[string]any collections (dalgo2memory)
 
-**Status:** Completed
+**Status:** Implemented
 **Source Feature:** columnar-mixed-mode-maps
 **Date:** 2026-06-06
 **Owner:** alex

--- a/spec/plans/2026-06-06-columnar-storage.md
+++ b/spec/plans/2026-06-06-columnar-storage.md
@@ -1,6 +1,6 @@
 # Plan: Columnar storage engine (dalgo2memory)
 
-**Status:** Completed
+**Status:** Implemented
 **Source Feature:** columnar-storage
 **Date:** 2026-06-06
 **Owner:** alex

--- a/spec/plans/2026-06-06-serialized-storage.md
+++ b/spec/plans/2026-06-06-serialized-storage.md
@@ -1,6 +1,6 @@
 # Plan: Serialized storage engine (dalgo2memory default)
 
-**Status:** Completed
+**Status:** Implemented
 **Source Feature:** serialized-storage
 **Date:** 2026-06-06
 **Owner:** alex

--- a/spec/plans/2026-06-06-storage-engine-seam.md
+++ b/spec/plans/2026-06-06-storage-engine-seam.md
@@ -1,6 +1,6 @@
 # Plan: Pluggable per-collection storage engine seam (dalgo2memory)
 
-**Status:** Completed
+**Status:** Implemented
 **Source Feature:** storage-engine-seam
 **Date:** 2026-06-06
 **Owner:** alex

--- a/spec/plans/collection-generated-insert.md
+++ b/spec/plans/collection-generated-insert.md
@@ -4,7 +4,7 @@ status: Draft
 ---
 # Plan: Collection Generated Insert
 
-**Status:** Approved
+**Status:** Implemented
 **Source Feature:** collection-generated-insert
 **Date:** 2026-06-07
 **Owner:** alexandertrakhimenok

--- a/spec/plans/typed-collection-extras.md
+++ b/spec/plans/typed-collection-extras.md
@@ -4,7 +4,7 @@ status: Draft
 ---
 # Plan: Typed Collection Extras
 
-**Status:** Approved
+**Status:** Implemented
 **Source Feature:** typed-collection-extras
 **Date:** 2026-06-07
 **Owner:** alexandertrakhimenok

--- a/spec/plans/typed-collection.md
+++ b/spec/plans/typed-collection.md
@@ -4,7 +4,7 @@ status: Draft
 ---
 # Plan: Typed Collection
 
-**Status:** Approved
+**Status:** Implemented
 **Source Feature:** typed-collection
 **Date:** 2026-06-07
 **Owner:** alexandertrakhimenok


### PR DESCRIPTION
Automated `specscore spec lint --fix` run by `all-repos specscore-lint --fix` (canonical status-vocabulary migration).