### PR TITLE
fix(dalgo2memory): apply FieldPath updates and DeleteField sentinel

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Pre-push hook mirroring CI's coverage gate (strongo/go-ci-action):
+# the full test suite must keep total statement coverage at 100%.
+#
+# Enable once per clone:  git config core.hooksPath .githooks
+set -e
+
+echo "pre-push: running tests with coverage (CI requires 100%)..."
+profile="$(mktemp)"
+trap 'rm -f "$profile"' EXIT
+
+go test ./... -coverprofile="$profile" -count=1
+
+total=$(go tool cover -func="$profile" | grep total | awk '{print $3}' | sed 's/%//')
+echo "pre-push: total coverage: ${total}%"
+awk -v t="$total" -v m=100 'BEGIN { if (t < m) { print "pre-push: coverage " t "% is below required " m "% — push aborted (CI would fail)"; exit 1 } }'

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 
 # SpecStudio local event journal
 .specscore/events.jsonl
+.worktrees

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,3 +91,15 @@ Date:   Thu Feb 2 11:41:15 2018 -0800
 
 Notice the `Author` and `Signed-off-by` lines match.
 If they don't your PR will be rejected by the automated DCO check.
+
+## Git hooks
+
+CI requires 100% total statement coverage. To catch this before pushing,
+enable the repo-provided hooks once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The `pre-push` hook runs `go test ./... -coverprofile=...` and aborts the
+push if total coverage drops below 100% (same gate as CI).

--- a/adapters/dalgo2memory/columnar.go
+++ b/adapters/dalgo2memory/columnar.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/update"
 )
 
 // compactionThreshold is the dead-slot fraction that triggers compaction. When
@@ -344,7 +345,7 @@ func (e *columnarEngine) delete(id string) {
 	e.maybeCompact()
 }
 
-func (e *columnarEngine) update(id string, updates map[string]any) error {
+func (e *columnarEngine) update(id string, updates []update.Update) error {
 	if e.initErr != nil {
 		return e.initErr
 	}
@@ -356,13 +357,19 @@ func (e *columnarEngine) update(id string, updates map[string]any) error {
 	if err != nil {
 		return err
 	}
-	for fieldName, value := range updates {
-		// On the struct path an unknown field is rejected; on the map-backed
-		// path an undeclared field is a valid leftover field.
-		if _, ok := e.byName[fieldName]; !ok && !e.mapBacked {
-			return fmt.Errorf("record for collection %q does not conform to the schema: unknown field %q", e.collection, fieldName)
+	// Validate top-level field names against the schema before applying.
+	// FieldPath updates are nested and always mutate the intermediate map, so
+	// they are not validated against the flat column set here (the JSON
+	// round-trip in prepareWrite will reject any truly unknown top-level key).
+	for _, upd := range updates {
+		if fn := upd.FieldName(); fn != "" {
+			if _, ok := e.byName[fn]; !ok && !e.mapBacked {
+				return fmt.Errorf("record for collection %q does not conform to the schema: unknown field %q", e.collection, fn)
+			}
 		}
-		current[fieldName] = value
+	}
+	if err := applyUpdatesToMap(current, updates); err != nil {
+		return err
 	}
 	values, leftover, err := e.prepareWrite(current)
 	if err != nil {

--- a/adapters/dalgo2memory/columnar_coverage_test.go
+++ b/adapters/dalgo2memory/columnar_coverage_test.go
@@ -282,7 +282,7 @@ func TestColumnar_UpdateOnBrokenEngine(t *testing.T) {
 		WithCollection[map[string]any]("blobs", nil, WithColumnarStorage()),
 	)).(*database)
 	eng := db.engine("blobs").(*columnarEngine)
-	require.Error(t, eng.update("x", map[string]any{"a": 1}))
+	require.Error(t, eng.update("x", []update.Update{update.ByFieldName("a", 1)}))
 }
 
 // TestColumnar_DecodeFieldsNonObjectErrors covers decodeFields' unmarshal-to-map

--- a/adapters/dalgo2memory/columnar_test.go
+++ b/adapters/dalgo2memory/columnar_test.go
@@ -76,7 +76,7 @@ func TestColumnar_RequiresTypedCollection(t *testing.T) {
 	badEng := schemalessDB.engine("blobs").(*columnarEngine)
 	require.False(t, badEng.exists("b1"))
 	require.Error(t, badEng.load("b1", dal.NewRecordWithData(dal.NewKeyWithID("blobs", "b1"), &map[string]any{})))
-	require.Error(t, badEng.update("b1", map[string]any{"x": 1}))
+	require.Error(t, badEng.update("b1", []update.Update{update.ByFieldName("x", 1)}))
 	_, rowsErr := badEng.rows()
 	require.Error(t, rowsErr)
 	_, _, candErr := badEng.candidateRows(nil)

--- a/adapters/dalgo2memory/database.go
+++ b/adapters/dalgo2memory/database.go
@@ -264,13 +264,7 @@ func (s session) UpdateRecord(_ context.Context, record dal.Record, updates []up
 	if err := s.db.guardCollection(collectionName); err != nil {
 		return err
 	}
-	fieldUpdates := make(map[string]any, len(updates))
-	for _, upd := range updates {
-		if fieldName := upd.FieldName(); fieldName != "" {
-			fieldUpdates[fieldName] = upd.Value()
-		}
-	}
-	return s.db.engine(collectionName).update(keyID(record.Key()), fieldUpdates)
+	return s.db.engine(collectionName).update(keyID(record.Key()), updates)
 }
 
 func (s session) UpdateMulti(ctx context.Context, keys []*dal.Key, updates []update.Update, preconditions ...dal.Precondition) error {

--- a/adapters/dalgo2memory/engine.go
+++ b/adapters/dalgo2memory/engine.go
@@ -1,7 +1,10 @@
 package dalgo2memory
 
 import (
+	"fmt"
+
 	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/update"
 )
 
 // storageEngine is the internal, per-collection storage seam. It owns how one
@@ -28,10 +31,12 @@ type storageEngine interface {
 	// delete removes the record stored under id, if any.
 	delete(id string)
 
-	// update applies decoded field updates (name -> value) to the record
-	// stored under id, re-validating against the engine's own representation.
+	// update applies a list of field updates to the record stored under id,
+	// re-validating against the engine's own representation. Each Update carries
+	// either a FieldName (top-level key) or a FieldPath (nested key sequence).
+	// A value of update.DeleteField removes the key rather than setting it.
 	// It returns a not-found error when no record with that id is stored.
-	update(id string, updates map[string]any) error
+	update(id string, updates []update.Update) error
 
 	// rows enumerates the collection's stored rows for query execution. Each
 	// row exposes a decoded map[string]any field view (for WHERE/GROUP
@@ -46,4 +51,55 @@ type engineRow struct {
 	id          string
 	data        map[string]any
 	materialize func(target any) error
+}
+
+// applyUpdatesToMap applies a slice of Update values to a flat-or-nested
+// map[string]any. Each Update has either a FieldName (a single top-level key)
+// or a FieldPath (a sequence of nested keys). A value of update.DeleteField
+// removes the leaf key; any other value sets it. Intermediate nodes are created
+// as map[string]any when they are missing; if an intermediate node exists but is
+// not a map[string]any, applyUpdatesToMap returns a descriptive error rather
+// than panicking.
+func applyUpdatesToMap(data map[string]any, updates []update.Update) error {
+	for _, upd := range updates {
+		var path []string
+		if fp := upd.FieldPath(); len(fp) > 0 {
+			path = fp
+		} else if fn := upd.FieldName(); fn != "" {
+			path = []string{fn}
+		} else {
+			continue // neither set — skip (should not happen after Validate)
+		}
+		if err := applyPathUpdate(data, path, upd.Value()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// applyPathUpdate walks path in data, creating intermediate map[string]any
+// nodes as needed, then sets or deletes the leaf. Returns an error when an
+// intermediate value exists but is not a map[string]any.
+func applyPathUpdate(data map[string]any, path []string, value any) error {
+	// Navigate to the parent map of the leaf.
+	current := data
+	for _, key := range path[:len(path)-1] {
+		switch v := current[key].(type) {
+		case map[string]any:
+			current = v
+		case nil:
+			next := make(map[string]any)
+			current[key] = next
+			current = next
+		default:
+			return fmt.Errorf("field path segment %q is not a map (got %T)", key, current[key])
+		}
+	}
+	leaf := path[len(path)-1]
+	if value == update.DeleteField {
+		delete(current, leaf)
+	} else {
+		current[leaf] = value
+	}
+	return nil
 }

--- a/adapters/dalgo2memory/engine_test.go
+++ b/adapters/dalgo2memory/engine_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/update"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,7 +29,7 @@ func (e *countingEngine) load(id string, record dal.Record) error { return e.inn
 
 func (e *countingEngine) delete(id string) { e.inner.delete(id) }
 
-func (e *countingEngine) update(id string, updates map[string]any) error {
+func (e *countingEngine) update(id string, updates []update.Update) error {
 	return e.inner.update(id, updates)
 }
 

--- a/adapters/dalgo2memory/fieldpath_update_test.go
+++ b/adapters/dalgo2memory/fieldpath_update_test.go
@@ -1,0 +1,131 @@
+package dalgo2memory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/update"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFieldPathUpdate_SetsNestedValue verifies that an update created via
+// update.ByFieldPath sets a nested value inside a stored map[string]any record.
+func TestFieldPathUpdate_SetsNestedValue(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := NewDB().(*database)
+	key := dal.NewKeyWithID("docs", "d1")
+
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, map[string]any{
+		"meta": map[string]any{"version": 1},
+	})))
+
+	require.NoError(t, db.Update(ctx, key, []update.Update{
+		update.ByFieldPath(update.FieldPath{"meta", "version"}, 2),
+	}))
+
+	var got map[string]any
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(key, &got)))
+	meta, ok := got["meta"].(map[string]any)
+	require.True(t, ok, "meta should still be a map")
+	require.EqualValues(t, 2, meta["version"], "nested value should be updated to 2")
+}
+
+// TestFieldPathUpdate_DeleteFieldByFieldName verifies that update.DeleteField
+// used with update.ByFieldName removes the top-level key from the stored record.
+func TestFieldPathUpdate_DeleteFieldByFieldName(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := NewDB().(*database)
+	key := dal.NewKeyWithID("docs", "d1")
+
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, map[string]any{
+		"keep": "yes",
+		"drop": "goodbye",
+	})))
+
+	require.NoError(t, db.Update(ctx, key, []update.Update{
+		update.DeleteByFieldName("drop"),
+	}))
+
+	var got map[string]any
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(key, &got)))
+	require.Equal(t, "yes", got["keep"], "unaffected key must survive")
+	_, hasDropped := got["drop"]
+	require.False(t, hasDropped, "deleted key must not be present")
+}
+
+// TestFieldPathUpdate_DeleteFieldByFieldPath removes a nested map entry while
+// leaving sibling entries intact. This mirrors the contactus brief-map scenario:
+// a top-level field holds a map[string]any, one entry is deleted by FieldPath,
+// and the other entry survives.
+func TestFieldPathUpdate_DeleteFieldByFieldPath(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := NewDB().(*database)
+	key := dal.NewKeyWithID("docs", "d1")
+
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, map[string]any{
+		"members": map[string]any{
+			"alice": true,
+			"bob":   true,
+		},
+	})))
+
+	require.NoError(t, db.Update(ctx, key, []update.Update{
+		update.ByFieldPath(update.FieldPath{"members", "alice"}, update.DeleteField),
+	}))
+
+	var got map[string]any
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(key, &got)))
+	members, ok := got["members"].(map[string]any)
+	require.True(t, ok, "members should still be a map")
+	_, alicePresent := members["alice"]
+	require.False(t, alicePresent, "alice should have been deleted")
+	require.NotNil(t, members["bob"], "bob should survive the deletion")
+}
+
+// TestFieldPathUpdate_NonMapIntermediateReturnsError verifies that when a
+// FieldPath update encounters an intermediate node that is not a map[string]any,
+// the adapter returns a descriptive error and does not panic.
+func TestFieldPathUpdate_NonMapIntermediateReturnsError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := NewDB().(*database)
+	key := dal.NewKeyWithID("docs", "d1")
+
+	// "meta" is a string, not a map — navigating through it must fail gracefully.
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, map[string]any{
+		"meta": "just a string",
+	})))
+
+	err := db.Update(ctx, key, []update.Update{
+		update.ByFieldPath(update.FieldPath{"meta", "version"}, 2),
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "meta")
+}
+
+// TestFieldPathUpdate_PlainFieldNameStillWorks is a regression test: plain
+// ByFieldName updates must continue to work exactly as before.
+func TestFieldPathUpdate_PlainFieldNameStillWorks(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := NewDB().(*database)
+	key := dal.NewKeyWithID("docs", "d1")
+
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, map[string]any{
+		"title": "original",
+		"count": 1,
+	})))
+
+	require.NoError(t, db.Update(ctx, key, []update.Update{
+		update.ByFieldName("title", "updated"),
+	}))
+
+	var got map[string]any
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(key, &got)))
+	require.Equal(t, "updated", got["title"])
+	require.EqualValues(t, 1, got["count"], "untouched field must survive")
+}

--- a/adapters/dalgo2memory/fieldpath_update_test.go
+++ b/adapters/dalgo2memory/fieldpath_update_test.go
@@ -129,3 +129,60 @@ func TestFieldPathUpdate_PlainFieldNameStillWorks(t *testing.T) {
 	require.Equal(t, "updated", got["title"])
 	require.EqualValues(t, 1, got["count"], "untouched field must survive")
 }
+
+// TestFieldPathUpdate_CreatesMissingIntermediates verifies that a FieldPath
+// update creates missing intermediate maps on its way to the leaf.
+func TestFieldPathUpdate_CreatesMissingIntermediates(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := NewDB().(*database)
+	key := dal.NewKeyWithID("docs", "d5")
+
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, map[string]any{"title": "x"})))
+
+	require.NoError(t, db.Update(ctx, key, []update.Update{
+		update.ByFieldPath(update.FieldPath{"meta", "nested", "flag"}, true),
+	}))
+
+	var got map[string]any
+	require.NoError(t, db.Get(ctx, dal.NewRecordWithData(key, &got)))
+	meta, ok := got["meta"].(map[string]any)
+	require.True(t, ok, "meta should be created as a map")
+	nested, ok := meta["nested"].(map[string]any)
+	require.True(t, ok, "nested should be created as a map")
+	require.Equal(t, true, nested["flag"])
+}
+
+// emptyUpdate is an update.Update with neither FieldName nor FieldPath set —
+// applyUpdatesToMap must skip it without error.
+type emptyUpdate struct{}
+
+func (emptyUpdate) FieldName() string           { return "" }
+func (emptyUpdate) FieldPath() update.FieldPath { return nil }
+func (emptyUpdate) Value() any                  { return nil }
+
+// TestApplyUpdatesToMap_SkipsUpdateWithoutNameOrPath verifies the defensive
+// skip branch for updates carrying neither a field name nor a field path.
+func TestApplyUpdatesToMap_SkipsUpdateWithoutNameOrPath(t *testing.T) {
+	t.Parallel()
+	data := map[string]any{"a": 1}
+	require.NoError(t, applyUpdatesToMap(data, []update.Update{emptyUpdate{}}))
+	require.Equal(t, map[string]any{"a": 1}, data, "data must be unchanged")
+}
+
+// TestColumnar_FieldPathUpdateThroughNonMapFails verifies that the columnar
+// engine surfaces applyUpdatesToMap errors when a FieldPath update walks
+// through a non-map value.
+func TestColumnar_FieldPathUpdateThroughNonMapFails(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := columnarItemDB(t)
+	key := dal.NewKeyWithID("items", "i9")
+	require.NoError(t, db.Set(ctx, dal.NewRecordWithData(key, &item{Name: "a", Count: 1})))
+
+	err := db.Update(ctx, key, []update.Update{
+		update.ByFieldPath(update.FieldPath{"Name", "sub"}, 1),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "is not a map")
+}

--- a/adapters/dalgo2memory/serialized.go
+++ b/adapters/dalgo2memory/serialized.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/update"
 )
 
 // serializedEngine is the default storage engine: it stores each record as
@@ -70,7 +71,7 @@ func (e *serializedEngine) delete(id string) {
 	delete(e.records, id)
 }
 
-func (e *serializedEngine) update(id string, updates map[string]any) error {
+func (e *serializedEngine) update(id string, updates []update.Update) error {
 	b, ok := e.records[id]
 	if !ok {
 		return dal.NewErrNotFoundByKey(dal.NewKeyWithID(e.collection, id), nil)
@@ -79,8 +80,8 @@ func (e *serializedEngine) update(id string, updates map[string]any) error {
 	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
-	for fieldName, value := range updates {
-		data[fieldName] = value
+	if err := applyUpdatesToMap(data, updates); err != nil {
+		return err
 	}
 	next, err := json.Marshal(data)
 	if err != nil {


### PR DESCRIPTION
The in-memory adapter silently dropped update.ByFieldPath(...) updates and stored the update.DeleteField sentinel as a literal value. This fixes both: field-path updates walk/create nested maps, DeleteField removes the key (by name or path), non-map intermediates return a clear error. 5 new tests; full suite green.

Real-world consequence fixed: contactus brief-map removals (update.ByFieldPath(..., DeleteField)) are now observable in dalgo2memory-based facade tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhDJhFNWHBf2jhPKEqfL8T