### PR TITLE
dalgo2memory: fix cross-parent key collision (same leaf id under different parents)

### DIFF
--- a/adapters/dalgo2memory/collection_group_test.go
+++ b/adapters/dalgo2memory/collection_group_test.go
@@ -76,6 +76,97 @@ func TestParentScopedQueryFiltersByParent(t *testing.T) {
 	require.Equal(t, "spaceA", records[0].Key().Parent().ID)
 }
 
+func cgGet(t *testing.T, db dal.DB, space, id string) (*cgItem, error) {
+	t.Helper()
+	got := &cgItem{}
+	rec := dal.NewRecordWithData(cgKey(space, id), got)
+	err := db.RunReadonlyTransaction(context.Background(), func(ctx context.Context, tx dal.ReadTransaction) error {
+		return tx.Get(ctx, rec)
+	})
+	return got, err
+}
+
+func cgDelete(t *testing.T, db dal.DB, space, id string) {
+	t.Helper()
+	require.NoError(t, db.RunReadwriteTransaction(context.Background(), func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Delete(ctx, cgKey(space, id))
+	}))
+}
+
+// Two records sharing a leaf id under different parents are distinct records —
+// storing one must not overwrite the other, exactly as in Firestore where
+// spaces/A/items/i1 and spaces/B/items/i1 are unrelated documents.
+func TestSameLeafIdDifferentParentsDoNotCollide(t *testing.T) {
+	ctx := context.Background()
+	db := NewDB()
+	cgSeed(t, db, "spaceA", "i1", "fromA")
+	cgSeed(t, db, "spaceB", "i1", "fromB") // same leaf id "i1", different parent
+
+	// Each parent keeps its own record (no silent overwrite).
+	gotA, err := cgGet(t, db, "spaceA", "i1")
+	require.NoError(t, err)
+	require.Equal(t, "fromA", gotA.Name)
+	gotB, err := cgGet(t, db, "spaceB", "i1")
+	require.NoError(t, err)
+	require.Equal(t, "fromB", gotB.Name)
+
+	// A collection-group query returns both, each under its own parent.
+	records, err := dal.ExecuteQueryAndReadAllToRecords(ctx, cgQuery("items", nil), db)
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+	byName := map[string]string{}
+	for _, rec := range records {
+		byName[rec.Data().(*cgItem).Name], _ = rec.Key().Parent().ID.(string)
+	}
+	require.Equal(t, "spaceA", byName["fromA"])
+	require.Equal(t, "spaceB", byName["fromB"])
+
+	// Deleting one parent's record leaves the other untouched.
+	cgDelete(t, db, "spaceB", "i1")
+	_, err = cgGet(t, db, "spaceA", "i1")
+	require.NoError(t, err)
+	_, err = cgGet(t, db, "spaceB", "i1")
+	require.True(t, dal.IsNotFound(err))
+}
+
+// The columnar engine must also keep same-leaf-id-across-parents distinct, and
+// preserve each surviving record's full parent key across a compaction (which
+// re-indexes slots).
+func TestColumnarSameLeafIdSurvivesCompaction(t *testing.T) {
+	ctx := context.Background()
+	db := NewDB(WithSchema(false,
+		WithCollection[cgItem]("items", nil, WithColumnarStorage()),
+	))
+	seed := func(space, id, name string) {
+		require.NoError(t, db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+			return tx.Set(ctx, dal.NewRecordWithData(cgKey(space, id), &cgItem{Name: name}))
+		}))
+	}
+	seed("spaceA", "i1", "a1")
+	seed("spaceA", "i2", "a2")
+	seed("spaceB", "i1", "b1") // same leaf id "i1" as spaceA — must not collide
+	seed("spaceB", "i2", "b2")
+
+	// Delete a majority to force compaction; the sole survivor is spaceA/i1.
+	cgDelete(t, db, "spaceA", "i2")
+	cgDelete(t, db, "spaceB", "i2")
+	cgDelete(t, db, "spaceB", "i1")
+
+	records, err := dal.ExecuteQueryAndReadAllToRecords(ctx, cgQuery("items", nil), db)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	require.Equal(t, "i1", records[0].Key().ID)
+	require.Equal(t, "spaceA", records[0].Key().Parent().ID, "parent key must survive compaction")
+	require.Equal(t, "a1", records[0].Data().(*cgItem).Name)
+}
+
+func TestKeyIDRootAndNested(t *testing.T) {
+	// Root-level key keeps the bare leaf id (backward compatible).
+	require.Equal(t, "i1", keyID(dal.NewKeyWithID("items", "i1")))
+	// Nested key uses the full parent-chain path so it is globally unique.
+	require.Equal(t, "spaces/spaceA/items/i1", keyID(cgKey("spaceA", "i1")))
+}
+
 func TestIsChildOf(t *testing.T) {
 	space := dal.NewKeyWithID("spaces", "s")
 	child := dal.NewKeyWithParentAndID(space, "items", "i1")

--- a/adapters/dalgo2memory/columnar.go
+++ b/adapters/dalgo2memory/columnar.go
@@ -770,15 +770,21 @@ func (e *columnarEngine) compact() {
 		}
 	}
 	newSlotToID := make([]string, newLen)
+	newSlotToKey := make([]*dal.Key, newLen)
 	newLive := make([]bool, newLen)
 	for newSlot, oldSlot := range liveSlots {
 		id := e.slotToID[oldSlot]
 		newSlotToID[newSlot] = id
+		// Every live slot had its full key recorded at store time, so this
+		// carries the parent chain across compaction (else collection-group
+		// query results would lose their parent after a compaction).
+		newSlotToKey[newSlot] = e.slotToKey[oldSlot]
 		newLive[newSlot] = true
 		e.idToSlot[id] = newSlot
 	}
 	e.leftover = newLeftover
 	e.slotToID = newSlotToID
+	e.slotToKey = newSlotToKey
 	e.live = newLive
 	e.freeList = e.freeList[:0]
 	e.deadCount = 0

--- a/adapters/dalgo2memory/database.go
+++ b/adapters/dalgo2memory/database.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 
 	"github.com/dal-go/dalgo/dal"
@@ -396,8 +397,30 @@ func (s session) save(record dal.Record, overwrite bool) error {
 	return nil
 }
 
+// keyID is a record's storage identity within its per-leaf-collection engine.
+// Records are grouped by leaf collection name, so a nested record's leaf id is
+// not unique on its own: spaces/A/items/i1 and spaces/B/items/i1 share the leaf
+// id "i1" yet are distinct records (as in Firestore). Root-level records keep
+// the bare leaf id (backward compatible, and what the white-box engine tests
+// address records by); nested records are keyed by their full parent-chain path
+// so the same leaf id under different parents no longer collides.
 func keyID(key *dal.Key) string {
-	return fmt.Sprint(key.ID)
+	if key.Parent() == nil {
+		return fmt.Sprint(key.ID)
+	}
+	return keyPath(key)
+}
+
+// keyPath builds a record's full "collection/id/collection/id/…" path from the
+// root down. Unlike dal.Key.String it performs no validation and so never
+// panics on an incomplete key — keyID can run on the insert-generator path
+// before a generated id is finalized.
+func keyPath(key *dal.Key) string {
+	var parts []string
+	for k := key; k != nil; k = k.Parent() {
+		parts = append([]string{k.Collection() + "/" + fmt.Sprint(k.ID)}, parts...)
+	}
+	return strings.Join(parts, "/")
 }
 
 // resultKey returns the stored full key (with its parent chain) for a query


### PR DESCRIPTION
Follow-up to #89.

## Problem
The in-memory adapter groups records into a per-**leaf-collection** storage engine, keyed by `keyID` — which was the bare leaf id. So two records that share a leaf id under different parents collided:

- `spaces/A/items/i1` and `spaces/B/items/i1` both keyed to `"i1"` in the shared `items` engine
- the second `Set` **silently overwrote** the first — unlike Firestore, where they are unrelated documents

## Fix
- `keyID` now keys **nested** records by their full parent-chain path; **root-level** records keep the bare leaf id, so existing behavior and the white-box engine tests are unchanged. A panic-safe `keyPath` is used instead of `dal.Key.String` (which validates and panics on an incomplete key — `keyID` can run on the insert-generator path).
- `columnarEngine.compact` now rebuilds `slotToKey` alongside `slotToID`. Without it, a collection-group query lost each surviving record’s parent after a compaction re-indexed slots (a latent bug from #89).

## Tests
New tests fail on the pre-fix code and pass with it, covering:
- serialized engine: no overwrite; both records retrievable; collection-group returns both under their own parents; deletion of one parent leaves the other intact
- columnar engine: same-leaf-id distinctness **and** parent-key survival across a forced compaction
- `keyID` root vs nested shape

Package coverage stays at **100%**. Full repo build + test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)