### PR TITLE
ci: point workflows at strongo/cicd (renamed from go-ci-action)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   strongo_workflow:
     permissions:
       contents: write
-    uses: strongo/go-ci-action/.github/workflows/workflow.yml@main
+    uses: strongo/cicd/.github/workflows/workflow.yml@main
 
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
strongo/go-ci-action was renamed to strongo/cicd. Old refs redirect, this updates them explicitly. Trivial workflow-ref change.