### PR TITLE
Add hierarchical access policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ We build with our own tooling:
 - **[DataTug](https://datatug.io)** — query & explore data
 <!-- /dev-approach -->
 
+> **Specification scope:** The [`spec/`](./spec) tree specifies DALgo code and
+> runtime behavior only. The separate [dalgo.io](https://dalgo.io/) website,
+> its content, visual design, and marketing pages are intentionally outside the
+> SpecScore scope of this repository.
+
 ## 🎯 Why Use DALgo
 
 DALgo is useful when an application needs stable data-access code without
@@ -39,6 +44,8 @@ coupling the domain layer to Firestore, SQL, or a test-only database.
 - Keep application logic independent from a concrete database client.
 - Use the same record, query, and transaction shape across supported adapters.
 - Test business logic with the built-in in-memory adapter.
+- Put extensions, tenants, jobs, and support tools behind portable,
+  adapter-independent [access policies](./docs/access-policies.md).
 - Add logging, validation, metrics, and other behavior through hooks.
 - Model both document/key-value stores and relational tables through one key and
   schema abstraction.
@@ -47,6 +54,40 @@ DALgo does not try to hide every database difference. Adapters can return
 `dal.ErrNotSupported` for capabilities their backend cannot provide. This keeps
 the core API honest while still giving applications a shared path for the common
 operations.
+
+## 🛡️ Access Policies: Least Privilege at the DAL Boundary
+
+DALgo can wrap any adapter with a capability boundary that is enforced before
+the adapter sees a read, query, batch, mutation, or transaction operation.
+Policies distinguish `Get`, `Exists`, `Query`, `Insert`, `Set`, `Update`,
+`Delete`, and the reserved `Truncate` operation. Write access never silently
+grants read access.
+
+```go
+extension := access.MustPolicy("extension-trackus",
+	access.Root(access.Deny(access.ReadWrite, "outside-extension")),
+	access.Scope("ext", "trackus",
+		access.Allow(access.ReadWrite, "own-global-data")),
+	access.Scope("spaces", access.AnyID,
+		access.Scope("ext", "trackus",
+			access.Allow(access.ReadWrite, "own-space-data"))),
+)
+
+db := access.MustSecureDB(rawDB, access.RequireContextPolicy())
+ctx := access.WithPolicy(context.Background(), extension)
+```
+
+Rules are hierarchical: a more-specific child may carve a denial out of an
+allowed parent or reopen a subtree denied by its parent. Separate database and
+context policies intersect, so adding a policy can only narrow authority.
+Every denied call returns an inspectable `access.DeniedError` with the
+operation, resource, policy name/source, matched rule ID, and explanation.
+
+Policies can be authored as versioned YAML, represented equivalently as JSON,
+and loaded from any `io.Reader`—files are only one possible storage choice.
+The same hierarchy also supports independent audit selection without granting
+data access. See the [Access Policies guide](./docs/access-policies.md) for the
+complete model, loading APIs, error handling, and security boundary.
 
 ## ⚡ Quick Example
 

--- a/access/context.go
+++ b/access/context.go
@@ -1,0 +1,81 @@
+package access
+
+import (
+	"context"
+	"fmt"
+)
+
+type contextPoliciesKey struct{}
+
+// WithPolicy returns a child context carrying additional restrictive policies.
+// Policies inherited from the parent context are preserved.
+func WithPolicy(ctx context.Context, policies ...Policy) context.Context {
+	if ctx == nil {
+		panic("access: nil context")
+	}
+	combined := append(policiesFromContext(ctx), policies...)
+	for i, policy := range combined {
+		if policy == nil {
+			panic(fmt.Sprintf("access: nil context policy at index %d", i))
+		}
+	}
+	return context.WithValue(ctx, contextPoliciesKey{}, combined)
+}
+
+func policiesFromContext(ctx context.Context) []Policy {
+	if ctx == nil {
+		return nil
+	}
+	policies, _ := ctx.Value(contextPoliciesKey{}).([]Policy)
+	return append([]Policy(nil), policies...)
+}
+
+type guard struct {
+	databasePolicies []Policy
+	boundPolicies    []Policy
+	requireContext   bool
+}
+
+func (g guard) bind(ctx context.Context) guard {
+	bound := policiesFromContext(ctx)
+	g.boundPolicies = append(append([]Policy(nil), g.boundPolicies...), bound...)
+	return g
+}
+
+func (g guard) authorize(ctx context.Context, operation Operations, resources ...Resource) error {
+	return g.authorizeRequest(ctx, Request{Operation: operation, Resources: resources})
+}
+
+func (g guard) authorizeRequest(ctx context.Context, request Request) error {
+	dynamicPolicies := policiesFromContext(ctx)
+	contextPolicyCount := len(g.boundPolicies) + len(dynamicPolicies)
+	if err := g.requireContextPolicy(request.Operation, contextPolicyCount); err != nil {
+		return err
+	}
+	policies := make([]Policy, 0, len(g.databasePolicies)+contextPolicyCount)
+	policies = append(policies, g.databasePolicies...)
+	policies = append(policies, g.boundPolicies...)
+	policies = append(policies, dynamicPolicies...)
+	for _, policy := range policies {
+		if err := policy.Authorize(ctx, request); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g guard) checkContext(ctx context.Context) error {
+	return g.requireContextPolicy(0, len(g.boundPolicies)+len(policiesFromContext(ctx)))
+}
+
+func (g guard) requireContextPolicy(operation Operations, contextPolicyCount int) error {
+	if !g.requireContext || contextPolicyCount > 0 {
+		return nil
+	}
+	return &DeniedError{Decision: Decision{
+		Operation:   operation,
+		Policy:      "context",
+		Effect:      effectDeny.String(),
+		Explanation: "a context-bound access policy is required",
+	}}
+}

--- a/access/core_test.go
+++ b/access/core_test.go
@@ -1,0 +1,321 @@
+package access
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+)
+
+func TestOperationsComplete(t *testing.T) {
+	for _, tc := range []struct {
+		o Operations
+		s string
+	}{{0, "none"}, {Get, "get"}, {Read, "get,exists,query"}, {Operations(1 << 14), "unknown(16384)"}} {
+		if got := tc.o.String(); got != tc.s {
+			t.Errorf("String(%d)=%q", tc.o, got)
+		}
+	}
+	if !Get.validLeaf() || Read.validLeaf() || Operations(0).validSet() || Operations(1<<14).validSet() {
+		t.Fatal("validation")
+	}
+	if !Read.contains(Get) || Read.contains(Insert) || Read.contains(Read) {
+		t.Fatal("contains")
+	}
+	for _, tc := range []struct {
+		in   []string
+		want Operations
+		bad  bool
+	}{
+		{[]string{" read ", "WRITE"}, ReadWrite, false}, {[]string{"mutation"}, Write, false}, {[]string{"mutations"}, Write, false},
+		{[]string{"read-write"}, ReadWrite, false}, {[]string{"read_write"}, ReadWrite, false}, {[]string{"get", "truncate"}, Get | Truncate, false},
+		{[]string{"bogus"}, 0, true}, {nil, 0, true},
+	} {
+		got, err := parseOperations(tc.in)
+		if (err != nil) != tc.bad || got != tc.want {
+			t.Errorf("parse %#v=%v,%v", tc.in, got, err)
+		}
+	}
+	for _, tc := range []struct {
+		o    Operations
+		want string
+		bad  bool
+	}{{Read, "read", false}, {Write, "write", false}, {ReadWrite, "readwrite", false}, {Get | Delete, "get,delete", false}, {0, "", true}} {
+		got, err := operationNamesForDocument(tc.o)
+		if (err != nil) != tc.bad || strings.Join(got, ",") != tc.want {
+			t.Errorf("names %v=%v,%v", tc.o, got, err)
+		}
+	}
+}
+
+type stringID string
+type signedID int32
+type unsignedID uint16
+
+func TestResourcesAndPatternsComplete(t *testing.T) {
+	parent := dal.NewKeyWithID("spaces", stringID("a/b"))
+	key := dal.NewKeyWithParentAndID(parent, "ext", signedID(7))
+	for _, tc := range []struct {
+		r    Resource
+		kind ResourceKind
+		s    string
+	}{
+		{RecordResourceForKey(nil), PathResource, "/"}, {RecordResourceForKey(key), PathResource, "/spaces/a%2Fb/ext/7"},
+		{CollectionResourceFor(parent, "items"), PathResource, "/spaces/a%2Fb/items"}, {CollectionGroup("x"), CollectionGroupResource, "collection-group:x"},
+		{OpaqueQuery(""), OpaqueQueryResource, "opaque-query"}, {OpaqueQuery("sql"), OpaqueQueryResource, "opaque-query:sql"},
+	} {
+		if tc.r.Kind() != tc.kind || tc.r.String() != tc.s {
+			t.Errorf("resource=%v %v", tc.r, tc.r.Kind())
+		}
+	}
+	if _, err := NewPath(7); err == nil {
+		t.Error("collection type")
+	}
+	if _, err := NewPath(""); err == nil {
+		t.Error("empty collection")
+	}
+	if _, err := NewPath("x", nil); err == nil {
+		t.Error("nil id")
+	}
+	p := Path("spaces", AnyID, "ext", signedID(7))
+	if p.String() != "/spaces/*/ext/7" || !patternsMatch(p, RecordResourceForKey(key)) {
+		t.Fatal(p.String())
+	}
+	if patternsMatch(Path("x"), CollectionGroup("x")) || patternsMatch(Path("spaces", AnyID, "ext", 7, "extra"), RecordResourceForKey(key)) {
+		t.Fatal("bad match")
+	}
+	if patternsMatch(Path("spaces", AnyID, "wrong"), RecordResourceForKey(key)) {
+		t.Fatal("kind/value mismatch")
+	}
+	if !equalID(stringID("x"), "x") || !equalID(signedID(2), int64(2)) || !equalID(unsignedID(2), uint64(2)) {
+		t.Fatal("aliases")
+	}
+	if equalID(nil, 2) || equalID(int64(2), uint64(2)) || equalID(2, 3) {
+		t.Fatal("inequality")
+	}
+	if !isSignedInteger(reflectKindInt()) || !isUnsignedInteger(reflectKindUint()) {
+		t.Fatal("kind helpers")
+	}
+}
+
+func reflectKindInt() reflect.Kind  { return reflect.Int }
+func reflectKindUint() reflect.Kind { return reflect.Uint }
+
+func TestPolicyHierarchyErrorsAndAudit(t *testing.T) {
+	if _, err := NewPolicy(""); err == nil {
+		t.Fatal("name")
+	}
+	if _, err := NewAuditPolicy(""); err == nil {
+		t.Fatal("audit name")
+	}
+	if _, err := NewPolicy("duplicate", Root(Allow(Get, "same")), Collection("users", Allow(Get, "same"))); err == nil {
+		t.Fatal("duplicate rule name")
+	}
+	for _, rules := range [][]Rule{{Audit(Get)}, {Allow(0)}, {Under(Path("x"), CollectionGroupScope("g", Allow(Get)))}, {Scope("x", 1, CollectionGroupScope("g", Allow(Get)))}, {CollectionGroupScope("", Allow(Get))}, {CollectionGroupScope("g", Under(Path("x"), Allow(Get)))}, {OpaqueQueryScope(Under(Path("x"), Allow(Get)))}, {{kind: 99}}} {
+		if _, err := NewPolicy("bad", rules...); err == nil {
+			t.Errorf("expected compile error %#v", rules)
+		}
+	}
+	if _, err := NewAuditPolicy("bad", Allow(Get)); err == nil {
+		t.Fatal("access effect in audit")
+	}
+	p := MustPolicy("ext",
+		Root(Deny(ReadWrite, "root-deny")),
+		Scope("spaces", AnyID, Allow(ReadWrite, "space-allow"), Scope("ext", "mine", Allow(ReadWrite, "mine"))),
+		Scope("spaces", "one", Deny(Delete, "specific-deny")),
+		CollectionGroupScope("events", Allow(Query, "group")), OpaqueQueryScope(Allow(Query, "opaque")),
+	)
+	if p.Name() != "ext" || p.Source() != "" {
+		t.Fatal("identity")
+	}
+	ctx := context.Background()
+	mine := RecordResourceForKey(dal.NewKeyWithParentAndID(dal.NewKeyWithID("spaces", "one"), "ext", "mine"))
+	if d := p.Decide(ctx, Request{Operation: Get, Resources: []Resource{mine}}); !d.Allowed || d.Rule != "mine" {
+		t.Fatalf("allow: %+v", d)
+	}
+	if d := p.Decide(ctx, Request{Operation: Delete, Resources: []Resource{RecordResourceForKey(dal.NewKeyWithID("spaces", "one"))}}); d.Allowed || d.Rule != "specific-deny" {
+		t.Fatalf("deny %+v", d)
+	}
+	if !p.Decide(ctx, Request{Operation: Query, Resources: []Resource{CollectionGroup("events")}}).Allowed || !p.Decide(ctx, Request{Operation: Query, Resources: []Resource{OpaqueQuery("q")}}).Allowed {
+		t.Fatal("special")
+	}
+	for _, req := range []Request{{Operation: Read}, {Operation: Get}, {Operation: Get, Resources: []Resource{mine, RecordResourceForKey(dal.NewKeyWithID("root", "x"))}}} {
+		d := p.Decide(ctx, req)
+		if d.Allowed {
+			t.Fatalf("should deny %+v", d)
+		}
+		err := p.Authorize(ctx, req)
+		var de *DeniedError
+		if !errors.As(err, &de) || !errors.Is(err, ErrAccessDenied) || de.Unwrap() != ErrAccessDenied {
+			t.Fatal(err)
+		}
+	}
+	err := (&DeniedError{Decision: Decision{Policy: "p", PolicySource: "store", Rule: "r", Operation: Get, Resource: mine, Explanation: "why"}}).Error()
+	if !strings.Contains(err, "source=\"store\"") || !strings.Contains(err, "rule=\"r\"") {
+		t.Fatal(err)
+	}
+	if !effectIsRestrictive(effectDeny) || !effectIsRestrictive(effectIgnoreAudit) || effectIsRestrictive(effectAllow) {
+		t.Fatal("restrictive")
+	}
+	a := MustAuditPolicy("audit", Root(Audit(Write, "all")), Scope("audit", AnyID, IgnoreAudit(Write, "self")))
+	if a.Name() != "audit" || a.Source() != "" {
+		t.Fatal("audit identity")
+	}
+	if !a.Classify(ctx, Request{Operation: Insert, Resources: []Resource{RecordResourceForKey(dal.NewKeyWithID("users", "u"))}}).Audit {
+		t.Fatal("audit")
+	}
+	if a.Classify(ctx, Request{Operation: Insert, Resources: []Resource{RecordResourceForKey(dal.NewKeyWithID("audit", "a"))}}).Audit {
+		t.Fatal("ignore")
+	}
+	for _, r := range []Request{{Operation: Read}, {Operation: Get}, {Operation: Get, Resources: []Resource{RecordResourceForKey(dal.NewKeyWithID("x", "1"))}}} {
+		_ = a.Classify(ctx, r)
+	}
+	defer func() {
+		if recover() == nil {
+			t.Error("MustAuditPolicy panic")
+		}
+	}()
+	MustAuditPolicy("")
+}
+
+func TestMustPolicyPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("panic")
+		}
+	}()
+	MustPolicy("")
+}
+
+func TestDocumentRoundTripsAndValidation(t *testing.T) {
+	p := MustPolicy("portable", Root(Deny(Delete, "deny-delete")), Scope("spaces", AnyID, Allow(ReadWrite, "own")), CollectionGroupScope("events", Allow(Query, "group")), OpaqueQueryScope(Deny(Query, "opaque")))
+	for _, yamlMode := range []bool{true, false} {
+		var data []byte
+		var err error
+		if yamlMode {
+			data, err = MarshalAccessPolicyYAML(p)
+		} else {
+			data, err = MarshalAccessPolicyJSON(p)
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got *AccessPolicy
+		if yamlMode {
+			got, err = UnmarshalAccessPolicyYAML(data, WithSource(" store "), nil)
+		} else {
+			got, err = UnmarshalAccessPolicyJSON(data, WithSource(" store "))
+		}
+		if err != nil || got.Source() != "store" {
+			t.Fatalf("%s %v", data, err)
+		}
+	}
+	a := MustAuditPolicy("a", Root(Audit(Write, "mut")), Scope("logs", AnyID, IgnoreAudit(Write, "self")))
+	for _, codec := range []Codec{YAMLCodec{}, JSONCodec{}} {
+		var b bytes.Buffer
+		if err := EncodeAuditPolicy(&b, codec, a); err != nil {
+			t.Fatal(err)
+		}
+		got, err := DecodeAuditPolicy(&b, codec)
+		if err != nil || got.Name() != "a" {
+			t.Fatal(err)
+		}
+	}
+	if _, err := MarshalAuditPolicyYAML(a); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := MarshalAuditPolicyJSON(a); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := UnmarshalAuditPolicyYAML(mustBytes(MarshalAuditPolicyYAML(a))); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := UnmarshalAuditPolicyJSON(mustBytes(MarshalAuditPolicyJSON(a))); err != nil {
+		t.Fatal(err)
+	}
+
+	badDocs := []string{
+		`{}`, `{"apiVersion":"bad","kind":"AccessPolicy","metadata":{"name":"x"},"default":"deny","scopes":[{"path":"/","rules":[{"id":"x","effect":"allow","operations":["get"]}]}]}`,
+		`{"apiVersion":"dalgo.org/access/v1","kind":"Wrong","metadata":{"name":"x"},"default":"deny","scopes":[{"path":"/","rules":[{"id":"x","effect":"allow","operations":["get"]}]}]}`,
+		`{"apiVersion":"dalgo.org/access/v1","kind":"AccessPolicy","metadata":{"name":""},"default":"deny","scopes":[]}`,
+		`{"apiVersion":"dalgo.org/access/v1","kind":"AccessPolicy","metadata":{"name":"x"},"default":"allow","scopes":[{"path":"/","rules":[{"id":"x","effect":"allow","operations":["get"]}]}]}`,
+		`{"apiVersion":"dalgo.org/access/v1","kind":"AccessPolicy","metadata":{"name":"x"},"default":"deny","scopes":[{"path":"/","collectionGroup":"x","rules":[{"id":"x","effect":"allow","operations":["get"]}]}]}`,
+		`{"apiVersion":"dalgo.org/access/v1","kind":"AccessPolicy","metadata":{"name":"x"},"default":"deny","scopes":[{"path":"/"}]}`,
+		`{"apiVersion":"dalgo.org/access/v1","kind":"AccessPolicy","metadata":{"name":"x"},"default":"deny","scopes":[{"path":"/","rules":[{"id":"","effect":"allow","operations":["get"]}]}]}`,
+		`{"apiVersion":"dalgo.org/access/v1","kind":"AccessPolicy","metadata":{"name":"x"},"default":"deny","scopes":[{"path":"/","rules":[{"id":"x","effect":"audit","operations":["get"]}]}]}`,
+		`{"apiVersion":"dalgo.org/access/v1","kind":"AccessPolicy","metadata":{"name":"x"},"default":"deny","scopes":[{"path":"bad","rules":[{"id":"x","effect":"allow","operations":["get"]}]}]}`,
+	}
+	for i, s := range badDocs {
+		if _, err := UnmarshalAccessPolicyJSON([]byte(s)); err == nil {
+			t.Errorf("bad %d", i)
+		}
+	}
+	for _, s := range []string{"/", "/**", "/spaces/*/**", "/bad//x", "/spaces/%zz", "/*/x"} {
+		_, _ = parseDocumentPath(s)
+	}
+	if _, err := parseEffect("wat"); err == nil {
+		t.Fatal("effect")
+	}
+	for _, s := range []string{"allow", "deny", "audit", "ignore-audit"} {
+		if _, err := parseEffect(s); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, _, err := decodeDocument(nil, YAMLCodec{}, nil); err == nil {
+		t.Fatal("nil reader")
+	}
+	if _, _, err := decodeDocument(strings.NewReader("x"), nil, nil); err == nil {
+		t.Fatal("nil codec")
+	}
+	if err := EncodeAccessPolicy(nil, YAMLCodec{}, p); err == nil {
+		t.Fatal("nil writer")
+	}
+	if err := EncodeAccessPolicy(&bytes.Buffer{}, nil, p); err == nil {
+		t.Fatal("nil codec")
+	}
+	if err := EncodeAccessPolicy(&bytes.Buffer{}, YAMLCodec{}, nil); err == nil {
+		t.Fatal("nil policy")
+	}
+	if err := EncodeAuditPolicy(&bytes.Buffer{}, YAMLCodec{}, nil); err == nil {
+		t.Fatal("nil audit")
+	}
+	if _, err := MarshalAccessPolicyYAML(MustPolicy("unnamed", Allow(Get))); !errors.Is(err, ErrNotSerializable) {
+		t.Fatal(err)
+	}
+	if _, err := MarshalAccessPolicyYAML(MustPolicy("typed", Scope("x", 1, Allow(Get, "a")))); !errors.Is(err, ErrNotSerializable) {
+		t.Fatal(err)
+	}
+	if _, err := documentScopeFromRule(Rule{kind: 99}); !errors.Is(err, ErrNotSerializable) {
+		t.Fatal(err)
+	}
+	if _, err := documentRuleFromRule(Under(Path("x"))); !errors.Is(err, ErrNotSerializable) {
+		t.Fatal(err)
+	}
+	if err := ensureSingleDocument(func(any) error { return fmt.Errorf("boom") }); err == nil {
+		t.Fatal("extra err")
+	}
+	n := 0
+	if err := ensureSingleDocument(func(any) error { n++; return nil }); err == nil {
+		t.Fatal("extra")
+	}
+	var b bytes.Buffer
+	if err := (YAMLCodec{}).Encode(&b, Document{}); err != nil {
+		t.Fatal(err)
+	}
+	b.Reset()
+	if err := (JSONCodec{}).Encode(&b, Document{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustBytes(b []byte, e error) []byte {
+	if e != nil {
+		panic(e)
+	}
+	return b
+}

--- a/access/coverage_test.go
+++ b/access/coverage_test.go
@@ -1,0 +1,190 @@
+package access
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+)
+
+type failingCodec struct{ decode, encode error }
+
+func (f failingCodec) Decode(io.Reader, *Document) error { return f.decode }
+func (f failingCodec) Encode(io.Writer, Document) error  { return f.encode }
+
+type badWriter struct{}
+
+func (badWriter) Write([]byte) (int, error) { return 0, errors.New("write") }
+
+type staticCodec struct{ d Document }
+
+func (s staticCodec) Decode(_ io.Reader, out *Document) error { *out = s.d; return nil }
+func (staticCodec) Encode(io.Writer, Document) error          { return nil }
+
+func TestDocumentErrorBranches(t *testing.T) {
+	if _, err := DecodeAccessPolicy(strings.NewReader("x"), failingCodec{decode: errors.New("decode")}); err == nil {
+		t.Fatal()
+	}
+	validDoc := Document{APIVersion: DocumentAPIVersion, Kind: AccessPolicyKind, Metadata: DocumentMetadata{Name: "x"}, Default: "deny", Scopes: []DocumentScope{{Path: "/", Rules: []DocumentRule{{ID: "x", Effect: "allow", Operations: []string{"get"}}}}}}
+	for _, d := range []Document{
+		{APIVersion: DocumentAPIVersion, Kind: AccessPolicyKind, Metadata: DocumentMetadata{}, Scopes: []DocumentScope{{Path: "/", Rules: []DocumentRule{{ID: "x", Effect: "allow", Operations: []string{"get"}}}}}},
+		func() Document { x := validDoc; x.Default = "allow"; return x }(),
+		func() Document { x := validDoc; x.Scopes[0].Rules[0].Operations = []string{"bad"}; return x }(),
+		{APIVersion: DocumentAPIVersion, Kind: AccessPolicyKind, Metadata: DocumentMetadata{Name: "x"}, Default: "deny", Scopes: []DocumentScope{{CollectionGroup: "g", Scopes: []DocumentScope{{Path: "/x", Rules: []DocumentRule{{ID: "x", Effect: "allow", Operations: []string{"get"}}}}}}}},
+	} {
+		_, _ = DecodeAccessPolicy(strings.NewReader(""), staticCodec{d: d})
+	}
+	badAudit := Document{APIVersion: DocumentAPIVersion, Kind: AuditPolicyKind, Metadata: DocumentMetadata{Name: "x"}, Default: "ignore-audit", Scopes: []DocumentScope{{CollectionGroup: "g", Rules: []DocumentRule{{ID: "g", Effect: "audit", Operations: []string{"get"}}}, Scopes: []DocumentScope{{Path: "/x", Rules: []DocumentRule{{ID: "x", Effect: "audit", Operations: []string{"get"}}}}}}}}
+	_, _ = DecodeAuditPolicy(strings.NewReader(""), failingCodec{decode: errors.New("bad")})
+	_, _ = DecodeAuditPolicy(strings.NewReader(""), staticCodec{d: badAudit})
+	if err := EncodeAccessPolicy(&bytes.Buffer{}, failingCodec{encode: errors.New("encode")}, MustPolicy("p", Allow(Get, "a"))); err == nil {
+		t.Fatal()
+	}
+	if err := (YAMLCodec{}).Encode(badWriter{}, Document{}); err == nil {
+		t.Fatal()
+	}
+	if err := (JSONCodec{}).Encode(badWriter{}, Document{}); err == nil {
+		t.Fatal()
+	}
+	for _, tc := range []struct {
+		codec Codec
+		data  string
+	}{
+		{YAMLCodec{}, "bad: ["}, {JSONCodec{}, "{"}, {JSONCodec{}, `{"unknown":1}`}, {JSONCodec{}, `{} {}`}, {YAMLCodec{}, "---\n{}\n---\n{}"},
+	} {
+		var d Document
+		if err := tc.codec.Decode(strings.NewReader(tc.data), &d); err == nil {
+			t.Errorf("expected %q", tc.data)
+		}
+	}
+	base := `{"apiVersion":"` + DocumentAPIVersion + `","kind":"%s","metadata":{"name":"x"},"default":"%s","scopes":[{"path":"/","rules":[{"id":"x","effect":"%s","operations":["%s"]}]}]}`
+	for _, s := range []string{
+		fmt.Sprintf(base, AuditPolicyKind, "ignore-audit", "audit", "get"),
+		fmt.Sprintf(base, AuditPolicyKind, "deny", "audit", "get"),
+		fmt.Sprintf(base, AuditPolicyKind, "ignore-audit", "allow", "get"),
+		fmt.Sprintf(base, AuditPolicyKind, "ignore-audit", "wat", "get"),
+		fmt.Sprintf(base, AuditPolicyKind, "ignore-audit", "audit", "wat"),
+	} {
+		_, _ = UnmarshalAccessPolicyJSON([]byte(s))
+		_, _ = UnmarshalAuditPolicyJSON([]byte(s))
+	}
+	validAudit := fmt.Sprintf(base, AuditPolicyKind, "ignore-audit", "audit", "get")
+	if _, err := UnmarshalAuditPolicyJSON([]byte(validAudit)); err != nil {
+		t.Fatal(err)
+	}
+	wrong := fmt.Sprintf(base, AccessPolicyKind, "deny", "allow", "get")
+	if _, err := UnmarshalAuditPolicyJSON([]byte(wrong)); err == nil {
+		t.Fatal()
+	}
+	emptyScopes := `{"apiVersion":"` + DocumentAPIVersion + `","kind":"AccessPolicy","metadata":{"name":"x"},"default":"deny","scopes":[]}`
+	if _, err := UnmarshalAccessPolicyJSON([]byte(emptyScopes)); err == nil {
+		t.Fatal()
+	}
+	nested := `apiVersion: ` + DocumentAPIVersion + `
+kind: AccessPolicy
+metadata: {name: nested}
+default: deny
+scopes:
+  - path: /spaces/*
+    scopes:
+      - path: /ext/mine
+        rules: [{id: own, effect: allow, operations: [get]}]
+`
+	if _, err := UnmarshalAccessPolicyYAML([]byte(nested)); err != nil {
+		t.Fatal(err)
+	}
+	for _, scope := range []DocumentScope{{CollectionGroup: "g", Rules: []DocumentRule{{ID: "g", Effect: "allow", Operations: []string{"query"}}}}, {OpaqueQuery: true, Rules: []DocumentRule{{ID: "o", Effect: "allow", Operations: []string{"query"}}}}, {Path: "/", Scopes: []DocumentScope{{}}}} {
+		_, _ = ruleFromDocumentScope(scope, map[effect]bool{effectAllow: true, effectDeny: true})
+	}
+	_, _ = ruleFromDocumentScope(DocumentScope{Path: "/"}, map[effect]bool{effectAllow: true})
+	_, _ = ruleFromDocumentScope(DocumentScope{Path: "bad", Rules: []DocumentRule{{ID: "x", Effect: "allow", Operations: []string{"get"}}}}, map[effect]bool{effectAllow: true})
+	_, _ = ruleFromDocumentRule(DocumentRule{ID: " ", Effect: "allow", Operations: []string{"get"}}, map[effect]bool{effectAllow: true})
+	for _, r := range []Rule{Allow(Get, "root"), Collection("x", Allow(Get, "c")), Rule{kind: scopeRule, pattern: Path("x"), children: []Rule{{kind: 99}}}} {
+		_, _ = documentScopeFromRule(r)
+	}
+	_, _ = documentScopeFromRule(Under(Path("x"), Under(Path("y"), Allow(Get, "nested"))))
+	_, _ = documentScopeFromRule(Under(Path("x"), Allow(Get)))
+	if _, err := documentRuleFromRule(Rule{kind: directiveRule, name: "x", operations: 0, effect: effectAllow}); err == nil {
+		t.Fatal()
+	}
+	if _, err := marshalAuditPolicy(MustAuditPolicy("a", Audit(Get)), YAMLCodec{}); !errors.Is(err, ErrNotSerializable) {
+		t.Fatal(err)
+	}
+}
+
+func TestRemainingCoreBranches(t *testing.T) {
+	for _, e := range []effect{effectAllow, effectDeny, effectAudit, effectIgnoreAudit, effect(99)} {
+		_ = e.String()
+	}
+	for _, r := range []Rule{Collection("x", Allow(Get)), CollectionGroupScope("g", Allow(Query)), OpaqueQueryScope(Allow(Query))} {
+		_, _ = NewPolicy("p", r)
+	}
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Error("Path panic")
+			}
+		}()
+		Path(1)
+	}()
+	resource := Resource{kind: ResourceKind("bad")}
+	cr := compiledRule{kind: resource.kind, operations: Get}
+	if ruleMatchesResource(cr, resource) {
+		t.Fatal()
+	}
+	_ = resourceDescription(CollectionGroupResource, "g", PathPattern{})
+	_ = resourceDescription(OpaqueQueryResource, "", PathPattern{})
+	// Exercise literal and lexical tie breakers as well as the no-match path.
+	p := MustPolicy("ties", Scope("x", AnyID, Allow(Get, "z")), Scope("x", "one", Allow(Get, "b"), Allow(Get, "a")))
+	if d := p.Decide(context.Background(), Request{Operation: Get, Resources: []Resource{RecordResourceForKey(dal.NewKeyWithID("x", "one"))}}); d.Rule != "a" {
+		t.Fatal(d)
+	}
+	if err := p.Authorize(context.Background(), Request{Operation: Get, Resources: []Resource{RecordResourceForKey(dal.NewKeyWithID("x", "one"))}}); err != nil {
+		t.Fatal(err)
+	}
+	if MustPolicy("none").Decide(context.Background(), Request{Operation: Get, Resources: []Resource{RecordResourceForKey(dal.NewKeyWithID("x", "1"))}}).Allowed {
+		t.Fatal()
+	}
+	_ = MustPolicy("tie-deny", Root(Allow(Get, "a"), Deny(Get, "d"))).Decide(context.Background(), Request{Operation: Get, Resources: []Resource{RecordResourceForKey(dal.NewKeyWithID("x", "1"))}})
+	badPattern := PathPattern{segments: []pathSegment{{kind: idSegment, value: "x"}}}
+	_ = patternsMatch(badPattern, CollectionResourceFor(nil, "x"))
+	_ = patternsMatch(Path("x", "no"), RecordResourceForKey(dal.NewKeyWithID("x", "yes")))
+	_, _ = NewPolicy("bad", CollectionGroupScope("g", OpaqueQueryScope(Allow(Query))))
+	var unknown dal.RecordsetSource
+	_ = resourceForRecordsetSource(unknown)
+}
+
+func TestAllSessionFailureBranches(t *testing.T) {
+	ctx := context.Background()
+	key := dal.NewKeyWithID("x", "1")
+	r := dal.NewRecord(key)
+	rs := []dal.Record{r}
+	ks := []*dal.Key{key}
+	q := opaqueQ{}
+	for _, policy := range []*AccessPolicy{MustPolicy("deny", Root(Deny(ReadWrite, "no")), OpaqueQueryScope(Deny(Query, "noq"))), MustPolicy("allow", Root(Allow(ReadWrite, "yes")), OpaqueQueryScope(Allow(Query, "yesq")))} {
+		f := &fakeSession{}
+		if policy.Name() == "allow" {
+			f.err = errors.New("delegate")
+		}
+		rw := SecureReadwriteSession(f, policy)
+		_, _ = rw.Exists(ctx, key)
+		_ = rw.Get(ctx, r)
+		_ = rw.GetMulti(ctx, rs)
+		_, _ = rw.ExecuteQueryToRecordsReader(ctx, q)
+		_, _ = rw.ExecuteQueryToRecordsetReader(ctx, q)
+		_ = rw.Set(ctx, r)
+		_ = rw.SetMulti(ctx, rs)
+		_ = rw.Insert(ctx, r)
+		_ = rw.InsertMulti(ctx, rs)
+		_ = rw.Update(ctx, key, nil)
+		_ = rw.UpdateRecord(ctx, r, nil)
+		_ = rw.UpdateMulti(ctx, ks, nil)
+		_ = rw.Delete(ctx, key)
+		_ = rw.DeleteMulti(ctx, ks)
+	}
+}

--- a/access/database.go
+++ b/access/database.go
@@ -1,0 +1,173 @@
+package access
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/recordset"
+)
+
+type secureDBOptions struct {
+	databasePolicies []Policy
+	requireContext   bool
+}
+
+// DBOption configures SecureDB.
+type DBOption func(*secureDBOptions) error
+
+// WithDatabasePolicies adds policies that apply to every operation through the
+// secured DB and cannot be widened by a context policy.
+func WithDatabasePolicies(policies ...Policy) DBOption {
+	return func(options *secureDBOptions) error {
+		for i, policy := range policies {
+			if policy == nil {
+				return fmt.Errorf("access: nil database policy at index %d", i)
+			}
+		}
+		options.databasePolicies = append(options.databasePolicies, policies...)
+		return nil
+	}
+}
+
+// RequireContextPolicy makes missing context-bound authority fail closed.
+func RequireContextPolicy() DBOption {
+	return func(options *secureDBOptions) error {
+		options.requireContext = true
+		return nil
+	}
+}
+
+// SecureDB wraps db with adapter-independent access-policy enforcement.
+func SecureDB(db dal.DB, options ...DBOption) (dal.DB, error) {
+	if db == nil {
+		return nil, fmt.Errorf("access: db is required")
+	}
+	var settings secureDBOptions
+	for _, option := range options {
+		if option == nil {
+			return nil, fmt.Errorf("access: nil DB option")
+		}
+		if err := option(&settings); err != nil {
+			return nil, err
+		}
+	}
+	return &securedDB{
+		db: db,
+		guard: guard{
+			databasePolicies: append([]Policy(nil), settings.databasePolicies...),
+			requireContext:   settings.requireContext,
+		},
+	}, nil
+}
+
+// MustSecureDB wraps db and panics when configuration is invalid.
+func MustSecureDB(db dal.DB, options ...DBOption) dal.DB {
+	secured, err := SecureDB(db, options...)
+	if err != nil {
+		panic(err)
+	}
+	return secured
+}
+
+// BindDB captures context policies on the returned DB handle. Passing a later
+// operation context cannot remove them, while additional policies still narrow
+// the capability.
+func BindDB(db dal.DB, ctx context.Context) dal.DB {
+	if secured, ok := db.(*securedDB); ok {
+		bound := *secured
+		bound.guard = secured.guard.bind(ctx)
+		return &bound
+	}
+	return &securedDB{db: db, guard: guard{}.bind(ctx)}
+}
+
+type securedDB struct {
+	db    dal.DB
+	guard guard
+}
+
+func (db *securedDB) ID() string { return db.db.ID() }
+
+func (db *securedDB) Adapter() dal.Adapter { return db.db.Adapter() }
+
+func (db *securedDB) Schema() dal.Schema { return db.db.Schema() }
+
+func (db *securedDB) SupportsConcurrentConnections() bool {
+	return db.db.SupportsConcurrentConnections()
+}
+
+func (db *securedDB) Exists(ctx context.Context, key *dal.Key) (bool, error) {
+	return securedReadSession{session: db.db, guard: db.guard}.Exists(ctx, key)
+}
+
+func (db *securedDB) Get(ctx context.Context, record dal.Record) error {
+	return securedReadSession{session: db.db, guard: db.guard}.Get(ctx, record)
+}
+
+func (db *securedDB) GetMulti(ctx context.Context, records []dal.Record) error {
+	return securedReadSession{session: db.db, guard: db.guard}.GetMulti(ctx, records)
+}
+
+func (db *securedDB) ExecuteQueryToRecordsReader(ctx context.Context, query dal.Query) (dal.RecordsReader, error) {
+	return securedReadSession{session: db.db, guard: db.guard}.ExecuteQueryToRecordsReader(ctx, query)
+}
+
+func (db *securedDB) ExecuteQueryToRecordsetReader(ctx context.Context, query dal.Query, options ...recordset.Option) (dal.RecordsetReader, error) {
+	return securedReadSession{session: db.db, guard: db.guard}.ExecuteQueryToRecordsetReader(ctx, query, options...)
+}
+
+func (db *securedDB) RunReadonlyTransaction(ctx context.Context, worker dal.ROTxWorker, options ...dal.TransactionOption) error {
+	if err := db.guard.checkContext(ctx); err != nil {
+		return err
+	}
+	captured := db.guard.bind(ctx)
+	return db.db.RunReadonlyTransaction(ctx, func(workerCtx context.Context, tx dal.ReadTransaction) error {
+		securedTx := &securedReadTransaction{
+			securedReadSession: securedReadSession{session: tx, guard: captured},
+			tx:                 tx,
+		}
+		workerCtx = dal.NewContextWithTransaction(workerCtx, securedTx)
+		return worker(workerCtx, securedTx)
+	}, options...)
+}
+
+func (db *securedDB) RunReadwriteTransaction(ctx context.Context, worker dal.RWTxWorker, options ...dal.TransactionOption) error {
+	if err := db.guard.checkContext(ctx); err != nil {
+		return err
+	}
+	captured := db.guard.bind(ctx)
+	return db.db.RunReadwriteTransaction(ctx, func(workerCtx context.Context, tx dal.ReadwriteTransaction) error {
+		securedTx := &securedReadwriteTransaction{
+			securedReadwriteSession: securedReadwriteSession{
+				securedReadSession:  securedReadSession{session: tx, guard: captured},
+				securedWriteSession: securedWriteSession{session: tx, guard: captured},
+			},
+			tx: tx,
+		}
+		workerCtx = dal.NewContextWithTransaction(workerCtx, securedTx)
+		return worker(workerCtx, securedTx)
+	}, options...)
+}
+
+type securedReadTransaction struct {
+	securedReadSession
+	tx dal.ReadTransaction
+}
+
+func (tx *securedReadTransaction) Options() dal.TransactionOptions { return tx.tx.Options() }
+
+type securedReadwriteTransaction struct {
+	securedReadwriteSession
+	tx dal.ReadwriteTransaction
+}
+
+func (tx *securedReadwriteTransaction) ID() string { return tx.tx.ID() }
+
+func (tx *securedReadwriteTransaction) Options() dal.TransactionOptions { return tx.tx.Options() }
+
+var (
+	_ dal.DB                   = (*securedDB)(nil)
+	_ dal.ReadTransaction      = (*securedReadTransaction)(nil)
+	_ dal.ReadwriteTransaction = (*securedReadwriteTransaction)(nil)
+)

--- a/access/doc.go
+++ b/access/doc.go
@@ -1,0 +1,16 @@
+// Package access provides adapter-independent capability policies for DALgo.
+//
+// Access policies are default-deny and distinguish point reads, existence
+// checks, queries, individual mutation kinds, and the reserved truncate
+// operation. Rules inherit through structural DAL paths; the most-specific
+// rule wins within one policy, while multiple policies compose by intersection.
+//
+// Secured sessions and databases enforce policies before delegating to an
+// adapter. Policies may be attached globally, carried by context.Context, or
+// captured in a bound database handle. YAML and JSON codecs load the same
+// versioned policy model from any io.Reader.
+//
+// A denial returns a DeniedError matching ErrAccessDenied. The decision
+// includes the operation, resource, policy name and source, winning rule, and
+// explanation for trusted logs, tests, and administrative tooling.
+package access

--- a/access/document.go
+++ b/access/document.go
@@ -71,9 +71,7 @@ func (YAMLCodec) Encode(writer io.Writer, document Document) (err error) {
 	encoder := yaml.NewEncoder(writer)
 	encoder.SetIndent(2)
 	defer func() {
-		if closeErr := encoder.Close(); err == nil && closeErr != nil {
-			err = fmt.Errorf("access: close YAML encoder: %w", closeErr)
-		}
+		err = errors.Join(err, encoder.Close())
 	}()
 	if err := encoder.Encode(document); err != nil {
 		return fmt.Errorf("access: encode YAML policy: %w", err)

--- a/access/document.go
+++ b/access/document.go
@@ -1,0 +1,487 @@
+package access
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// DocumentAPIVersion is the first stable portable policy document version.
+	DocumentAPIVersion = "dalgo.io/access/v1"
+	AccessPolicyKind   = "AccessPolicy"
+	AuditPolicyKind    = "AuditPolicy"
+)
+
+// Document is the storage-neutral representation shared by YAML, JSON, and
+// third-party codecs. YAML is the canonical human-authored encoding.
+type Document struct {
+	APIVersion string           `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string           `json:"kind" yaml:"kind"`
+	Metadata   DocumentMetadata `json:"metadata" yaml:"metadata"`
+	Default    string           `json:"default" yaml:"default"`
+	Scopes     []DocumentScope  `json:"scopes" yaml:"scopes"`
+}
+
+type DocumentMetadata struct {
+	Name string `json:"name" yaml:"name"`
+}
+
+// DocumentScope selects exactly one resource kind. Path is a structural path
+// fragment; nested scopes append their path to the containing scope.
+type DocumentScope struct {
+	Path            string          `json:"path,omitempty" yaml:"path,omitempty"`
+	CollectionGroup string          `json:"collectionGroup,omitempty" yaml:"collectionGroup,omitempty"`
+	OpaqueQuery     bool            `json:"opaqueQuery,omitempty" yaml:"opaqueQuery,omitempty"`
+	Rules           []DocumentRule  `json:"rules,omitempty" yaml:"rules,omitempty"`
+	Scopes          []DocumentScope `json:"scopes,omitempty" yaml:"scopes,omitempty"`
+}
+
+type DocumentRule struct {
+	ID         string   `json:"id" yaml:"id"`
+	Effect     string   `json:"effect" yaml:"effect"`
+	Operations []string `json:"operations" yaml:"operations"`
+}
+
+// Codec decouples policy loading from both its syntax and its storage. A
+// caller may implement this interface for HCL or another representation.
+type Codec interface {
+	Decode(io.Reader, *Document) error
+	Encode(io.Writer, Document) error
+}
+
+type YAMLCodec struct{}
+
+func (YAMLCodec) Decode(reader io.Reader, document *Document) error {
+	decoder := yaml.NewDecoder(reader)
+	decoder.KnownFields(true)
+	if err := decoder.Decode(document); err != nil {
+		return fmt.Errorf("access: decode YAML policy: %w", err)
+	}
+	return ensureSingleDocument(func(value any) error { return decoder.Decode(value) })
+}
+
+func (YAMLCodec) Encode(writer io.Writer, document Document) error {
+	encoder := yaml.NewEncoder(writer)
+	encoder.SetIndent(2)
+	defer encoder.Close()
+	if err := encoder.Encode(document); err != nil {
+		return fmt.Errorf("access: encode YAML policy: %w", err)
+	}
+	return nil
+}
+
+type JSONCodec struct{}
+
+func (JSONCodec) Decode(reader io.Reader, document *Document) error {
+	decoder := json.NewDecoder(reader)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(document); err != nil {
+		return fmt.Errorf("access: decode JSON policy: %w", err)
+	}
+	return ensureSingleDocument(func(value any) error { return decoder.Decode(value) })
+}
+
+func (JSONCodec) Encode(writer io.Writer, document Document) error {
+	encoder := json.NewEncoder(writer)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(document); err != nil {
+		return fmt.Errorf("access: encode JSON policy: %w", err)
+	}
+	return nil
+}
+
+func ensureSingleDocument(next func(any) error) error {
+	var extra any
+	err := next(&extra)
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return fmt.Errorf("access: a policy stream must contain exactly one document")
+}
+
+type decodeOptions struct{ source string }
+
+type DecodeOption func(*decodeOptions)
+
+// WithSource records where a policy document came from. It may be a file
+// path, object key, URL, database key, or any application-defined reference.
+func WithSource(reference string) DecodeOption {
+	return func(options *decodeOptions) { options.source = strings.TrimSpace(reference) }
+}
+
+// DecodeAccessPolicy decodes and validates one AccessPolicy from any reader.
+func DecodeAccessPolicy(reader io.Reader, codec Codec, options ...DecodeOption) (*AccessPolicy, error) {
+	document, settings, err := decodeDocument(reader, codec, options)
+	if err != nil {
+		return nil, err
+	}
+	if document.Kind != AccessPolicyKind {
+		return nil, fmt.Errorf("access: expected kind %s, got %q", AccessPolicyKind, document.Kind)
+	}
+	if document.Default != effectDeny.String() {
+		return nil, fmt.Errorf("access: AccessPolicy default must be %q", effectDeny)
+	}
+	rules, err := rulesFromDocument(document, map[effect]bool{effectAllow: true, effectDeny: true})
+	if err != nil {
+		return nil, err
+	}
+	policy, err := NewPolicy(document.Metadata.Name, rules...)
+	if err != nil {
+		return nil, err
+	}
+	policy.source = settings.source
+	return policy, nil
+}
+
+// DecodeAuditPolicy decodes and validates one AuditPolicy from any reader.
+func DecodeAuditPolicy(reader io.Reader, codec Codec, options ...DecodeOption) (*AuditPolicy, error) {
+	document, settings, err := decodeDocument(reader, codec, options)
+	if err != nil {
+		return nil, err
+	}
+	if document.Kind != AuditPolicyKind {
+		return nil, fmt.Errorf("access: expected kind %s, got %q", AuditPolicyKind, document.Kind)
+	}
+	if document.Default != effectIgnoreAudit.String() {
+		return nil, fmt.Errorf("access: AuditPolicy default must be %q", effectIgnoreAudit)
+	}
+	rules, err := rulesFromDocument(document, map[effect]bool{effectAudit: true, effectIgnoreAudit: true})
+	if err != nil {
+		return nil, err
+	}
+	policy, err := NewAuditPolicy(document.Metadata.Name, rules...)
+	if err != nil {
+		return nil, err
+	}
+	policy.source = settings.source
+	return policy, nil
+}
+
+func decodeDocument(reader io.Reader, codec Codec, options []DecodeOption) (Document, decodeOptions, error) {
+	var settings decodeOptions
+	for _, option := range options {
+		if option != nil {
+			option(&settings)
+		}
+	}
+	if reader == nil || codec == nil {
+		return Document{}, settings, fmt.Errorf("access: policy reader and codec are required")
+	}
+	var document Document
+	if err := codec.Decode(reader, &document); err != nil {
+		return Document{}, settings, err
+	}
+	if document.APIVersion != DocumentAPIVersion {
+		return Document{}, settings, fmt.Errorf("access: unsupported apiVersion %q", document.APIVersion)
+	}
+	if strings.TrimSpace(document.Metadata.Name) == "" {
+		return Document{}, settings, fmt.Errorf("access: metadata.name is required")
+	}
+	if len(document.Scopes) == 0 {
+		return Document{}, settings, fmt.Errorf("access: at least one scope is required")
+	}
+	return document, settings, nil
+}
+
+// EncodeAccessPolicy validates and writes one AccessPolicy through codec.
+func EncodeAccessPolicy(writer io.Writer, codec Codec, policy *AccessPolicy) error {
+	if policy == nil {
+		return fmt.Errorf("access: policy is required")
+	}
+	document, err := documentFromRules(AccessPolicyKind, policy.name, effectDeny, policy.rules)
+	if err != nil {
+		return err
+	}
+	return encodeDocument(writer, codec, document)
+}
+
+// EncodeAuditPolicy validates and writes one AuditPolicy through codec.
+func EncodeAuditPolicy(writer io.Writer, codec Codec, policy *AuditPolicy) error {
+	if policy == nil {
+		return fmt.Errorf("access: audit policy is required")
+	}
+	document, err := documentFromRules(AuditPolicyKind, policy.name, effectIgnoreAudit, policy.rules)
+	if err != nil {
+		return err
+	}
+	return encodeDocument(writer, codec, document)
+}
+
+func encodeDocument(writer io.Writer, codec Codec, document Document) error {
+	if writer == nil || codec == nil {
+		return fmt.Errorf("access: policy writer and codec are required")
+	}
+	return codec.Encode(writer, document)
+}
+
+func MarshalAccessPolicyYAML(policy *AccessPolicy) ([]byte, error) {
+	return marshalAccessPolicy(policy, YAMLCodec{})
+}
+
+func MarshalAccessPolicyJSON(policy *AccessPolicy) ([]byte, error) {
+	return marshalAccessPolicy(policy, JSONCodec{})
+}
+
+func marshalAccessPolicy(policy *AccessPolicy, codec Codec) ([]byte, error) {
+	var data bytes.Buffer
+	if err := EncodeAccessPolicy(&data, codec, policy); err != nil {
+		return nil, err
+	}
+	return data.Bytes(), nil
+}
+
+func MarshalAuditPolicyYAML(policy *AuditPolicy) ([]byte, error) {
+	return marshalAuditPolicy(policy, YAMLCodec{})
+}
+
+func MarshalAuditPolicyJSON(policy *AuditPolicy) ([]byte, error) {
+	return marshalAuditPolicy(policy, JSONCodec{})
+}
+
+func marshalAuditPolicy(policy *AuditPolicy, codec Codec) ([]byte, error) {
+	var data bytes.Buffer
+	if err := EncodeAuditPolicy(&data, codec, policy); err != nil {
+		return nil, err
+	}
+	return data.Bytes(), nil
+}
+
+func UnmarshalAccessPolicyYAML(data []byte, options ...DecodeOption) (*AccessPolicy, error) {
+	return DecodeAccessPolicy(bytes.NewReader(data), YAMLCodec{}, options...)
+}
+
+func UnmarshalAccessPolicyJSON(data []byte, options ...DecodeOption) (*AccessPolicy, error) {
+	return DecodeAccessPolicy(bytes.NewReader(data), JSONCodec{}, options...)
+}
+
+func UnmarshalAuditPolicyYAML(data []byte, options ...DecodeOption) (*AuditPolicy, error) {
+	return DecodeAuditPolicy(bytes.NewReader(data), YAMLCodec{}, options...)
+}
+
+func UnmarshalAuditPolicyJSON(data []byte, options ...DecodeOption) (*AuditPolicy, error) {
+	return DecodeAuditPolicy(bytes.NewReader(data), JSONCodec{}, options...)
+}
+
+func rulesFromDocument(document Document, allowedEffects map[effect]bool) ([]Rule, error) {
+	rules := make([]Rule, 0, len(document.Scopes))
+	for i, scope := range document.Scopes {
+		rule, err := ruleFromDocumentScope(scope, allowedEffects)
+		if err != nil {
+			return nil, fmt.Errorf("access: scopes[%d]: %w", i, err)
+		}
+		rules = append(rules, rule)
+	}
+	return rules, nil
+}
+
+func ruleFromDocumentScope(scope DocumentScope, allowedEffects map[effect]bool) (Rule, error) {
+	selectors := 0
+	if scope.Path != "" {
+		selectors++
+	}
+	if scope.CollectionGroup != "" {
+		selectors++
+	}
+	if scope.OpaqueQuery {
+		selectors++
+	}
+	if selectors != 1 {
+		return Rule{}, fmt.Errorf("a scope must select exactly one of path, collectionGroup, or opaqueQuery")
+	}
+	children := make([]Rule, 0, len(scope.Rules)+len(scope.Scopes))
+	for i, documentRule := range scope.Rules {
+		rule, err := ruleFromDocumentRule(documentRule, allowedEffects)
+		if err != nil {
+			return Rule{}, fmt.Errorf("rules[%d]: %w", i, err)
+		}
+		children = append(children, rule)
+	}
+	for i, childScope := range scope.Scopes {
+		child, err := ruleFromDocumentScope(childScope, allowedEffects)
+		if err != nil {
+			return Rule{}, fmt.Errorf("scopes[%d]: %w", i, err)
+		}
+		children = append(children, child)
+	}
+	if len(children) == 0 {
+		return Rule{}, fmt.Errorf("scope contains no rules")
+	}
+	switch {
+	case scope.Path != "":
+		pattern, err := parseDocumentPath(scope.Path)
+		if err != nil {
+			return Rule{}, err
+		}
+		return Under(pattern, children...), nil
+	case scope.CollectionGroup != "":
+		return CollectionGroupScope(scope.CollectionGroup, children...), nil
+	default:
+		return OpaqueQueryScope(children...), nil
+	}
+}
+
+func ruleFromDocumentRule(documentRule DocumentRule, allowedEffects map[effect]bool) (Rule, error) {
+	id := strings.TrimSpace(documentRule.ID)
+	if id == "" {
+		return Rule{}, fmt.Errorf("rule id is required")
+	}
+	operations, err := parseOperations(documentRule.Operations)
+	if err != nil {
+		return Rule{}, err
+	}
+	ruleEffect, err := parseEffect(documentRule.Effect)
+	if err != nil {
+		return Rule{}, err
+	}
+	if !allowedEffects[ruleEffect] {
+		return Rule{}, fmt.Errorf("effect %q is not valid for policy kind %s", ruleEffect, documentRule.Effect)
+	}
+	return directive(ruleEffect, operations, []string{id}), nil
+}
+
+func parseEffect(value string) (effect, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case effectAllow.String():
+		return effectAllow, nil
+	case effectDeny.String():
+		return effectDeny, nil
+	case effectAudit.String():
+		return effectAudit, nil
+	case effectIgnoreAudit.String():
+		return effectIgnoreAudit, nil
+	default:
+		return 0, fmt.Errorf("access: unknown effect %q", value)
+	}
+}
+
+func parseDocumentPath(value string) (PathPattern, error) {
+	path := strings.TrimSpace(value)
+	if !strings.HasPrefix(path, "/") {
+		return PathPattern{}, fmt.Errorf("path %q must start with /", value)
+	}
+	if path == "/" || path == "/**" {
+		return PathPattern{}, nil
+	}
+	if strings.HasSuffix(path, "/**") {
+		path = strings.TrimSuffix(path, "/**")
+	}
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	patternParts := make([]any, len(parts))
+	for i, part := range parts {
+		if part == "" {
+			return PathPattern{}, fmt.Errorf("path %q contains an empty segment", value)
+		}
+		decoded, err := url.PathUnescape(part)
+		if err != nil {
+			return PathPattern{}, fmt.Errorf("path %q has invalid escaping: %w", value, err)
+		}
+		if i%2 == 1 && decoded == "*" {
+			patternParts[i] = AnyID
+			continue
+		}
+		if decoded == "*" {
+			return PathPattern{}, fmt.Errorf("path %q uses * where a collection name is required", value)
+		}
+		patternParts[i] = decoded
+	}
+	return NewPath(patternParts...)
+}
+
+func documentFromRules(kind, name string, defaultEffect effect, rules []Rule) (Document, error) {
+	document := Document{
+		APIVersion: DocumentAPIVersion,
+		Kind:       kind,
+		Metadata:   DocumentMetadata{Name: name},
+		Default:    defaultEffect.String(),
+	}
+	for _, rule := range rules {
+		scope, err := documentScopeFromRule(rule)
+		if err != nil {
+			return Document{}, err
+		}
+		document.Scopes = append(document.Scopes, scope)
+	}
+	return document, nil
+}
+
+func documentScopeFromRule(rule Rule) (DocumentScope, error) {
+	var scope DocumentScope
+	switch rule.kind {
+	case directiveRule:
+		documentRule, err := documentRuleFromRule(rule)
+		if err != nil {
+			return DocumentScope{}, err
+		}
+		scope.Path = "/"
+		scope.Rules = []DocumentRule{documentRule}
+		return scope, nil
+	case scopeRule:
+		path, err := documentPath(rule.pattern)
+		if err != nil {
+			return DocumentScope{}, err
+		}
+		scope.Path = path
+	case collectionGroupRule:
+		scope.CollectionGroup = rule.resource
+	case opaqueQueryRule:
+		scope.OpaqueQuery = true
+	default:
+		return DocumentScope{}, fmt.Errorf("%w: unknown rule kind", ErrNotSerializable)
+	}
+	for _, child := range rule.children {
+		if child.kind == directiveRule {
+			documentRule, err := documentRuleFromRule(child)
+			if err != nil {
+				return DocumentScope{}, err
+			}
+			scope.Rules = append(scope.Rules, documentRule)
+			continue
+		}
+		childScope, err := documentScopeFromRule(child)
+		if err != nil {
+			return DocumentScope{}, err
+		}
+		scope.Scopes = append(scope.Scopes, childScope)
+	}
+	return scope, nil
+}
+
+func documentRuleFromRule(rule Rule) (DocumentRule, error) {
+	if rule.kind != directiveRule || strings.TrimSpace(rule.name) == "" {
+		return DocumentRule{}, fmt.Errorf("%w: every encoded directive requires an explicit rule name", ErrNotSerializable)
+	}
+	operations, err := operationNamesForDocument(rule.operations)
+	if err != nil {
+		return DocumentRule{}, fmt.Errorf("%w: %v", ErrNotSerializable, err)
+	}
+	return DocumentRule{ID: rule.name, Effect: rule.effect.String(), Operations: operations}, nil
+}
+
+func documentPath(pattern PathPattern) (string, error) {
+	if len(pattern.segments) == 0 {
+		return "/", nil
+	}
+	parts := make([]string, len(pattern.segments))
+	for i, segment := range pattern.segments {
+		if segment.anyID {
+			parts[i] = "*"
+			continue
+		}
+		value, ok := segment.value.(string)
+		if !ok {
+			return "", fmt.Errorf("%w: path ID %v has type %T; portable paths support string IDs", ErrNotSerializable, segment.value, segment.value)
+		}
+		parts[i] = url.PathEscape(value)
+	}
+	return "/" + strings.Join(parts, "/"), nil
+}

--- a/access/document.go
+++ b/access/document.go
@@ -67,10 +67,14 @@ func (YAMLCodec) Decode(reader io.Reader, document *Document) error {
 	return ensureSingleDocument(func(value any) error { return decoder.Decode(value) })
 }
 
-func (YAMLCodec) Encode(writer io.Writer, document Document) error {
+func (YAMLCodec) Encode(writer io.Writer, document Document) (err error) {
 	encoder := yaml.NewEncoder(writer)
 	encoder.SetIndent(2)
-	defer encoder.Close()
+	defer func() {
+		if closeErr := encoder.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("access: close YAML encoder: %w", closeErr)
+		}
+	}()
 	if err := encoder.Encode(document); err != nil {
 		return fmt.Errorf("access: encode YAML policy: %w", err)
 	}
@@ -372,9 +376,7 @@ func parseDocumentPath(value string) (PathPattern, error) {
 	if path == "/" || path == "/**" {
 		return PathPattern{}, nil
 	}
-	if strings.HasSuffix(path, "/**") {
-		path = strings.TrimSuffix(path, "/**")
-	}
+	path = strings.TrimSuffix(path, "/**")
 	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
 	patternParts := make([]any, len(parts))
 	for i, part := range parts {

--- a/access/operation.go
+++ b/access/operation.go
@@ -1,0 +1,124 @@
+package access
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Operations is a set of DAL operations. Leaf operation constants contain one
+// bit; the group constants are immutable convenience unions of those leaves.
+type Operations uint16
+
+const (
+	Get Operations = 1 << iota
+	Exists
+	Query
+	Insert
+	Set
+	Update
+	Delete
+	// Truncate is reserved for collection-wide deletion. DALgo does not expose
+	// a truncate session method yet, but policies can grant and evaluate it now.
+	Truncate
+
+	Read      = Get | Exists | Query
+	Write     = Insert | Set | Update | Delete | Truncate
+	ReadWrite = Read | Write
+
+	knownOperations = ReadWrite
+)
+
+var operationNames = []struct {
+	operation Operations
+	name      string
+}{
+	{Get, "get"},
+	{Exists, "exists"},
+	{Query, "query"},
+	{Insert, "insert"},
+	{Set, "set"},
+	{Update, "update"},
+	{Delete, "delete"},
+	{Truncate, "truncate"},
+}
+
+func (o Operations) validLeaf() bool {
+	return o != 0 && o&knownOperations == o && o&(o-1) == 0
+}
+
+func (o Operations) contains(operation Operations) bool {
+	return operation.validLeaf() && o&operation != 0
+}
+
+func (o Operations) validSet() bool {
+	return o != 0 && o&^knownOperations == 0
+}
+
+func (o Operations) String() string {
+	if o == 0 {
+		return "none"
+	}
+	names := make([]string, 0, len(operationNames))
+	for _, item := range operationNames {
+		if o&item.operation != 0 {
+			names = append(names, item.name)
+		}
+	}
+	if unknown := o &^ knownOperations; unknown != 0 {
+		names = append(names, fmt.Sprintf("unknown(%d)", unknown))
+	}
+	return strings.Join(names, ",")
+}
+
+func parseOperations(names []string) (Operations, error) {
+	var operations Operations
+	for _, rawName := range names {
+		name := strings.ToLower(strings.TrimSpace(rawName))
+		switch name {
+		case "read":
+			operations |= Read
+		case "write", "mutation", "mutations":
+			operations |= Write
+		case "readwrite", "read-write", "read_write":
+			operations |= ReadWrite
+		default:
+			found := false
+			for _, item := range operationNames {
+				if name == item.name {
+					operations |= item.operation
+					found = true
+					break
+				}
+			}
+			if !found {
+				return 0, fmt.Errorf("access: unknown operation %q", rawName)
+			}
+		}
+	}
+	if !operations.validSet() {
+		return 0, fmt.Errorf("access: an operation list is required")
+	}
+	return operations, nil
+}
+
+func operationNamesForDocument(operations Operations) ([]string, error) {
+	if !operations.validSet() {
+		return nil, fmt.Errorf("access: invalid operation set %s", operations)
+	}
+	if operations == Read {
+		return []string{"read"}, nil
+	}
+	if operations == Write {
+		return []string{"write"}, nil
+	}
+	if operations == ReadWrite {
+		return []string{"readwrite"}, nil
+	}
+	names := make([]string, 0, len(operationNames))
+	for _, item := range operationNames {
+		if operations&item.operation != 0 {
+			names = append(names, item.name)
+		}
+	}
+	return names, nil
+}

--- a/access/policy.go
+++ b/access/policy.go
@@ -1,0 +1,287 @@
+package access
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/dal-go/dalgo/dal"
+)
+
+var (
+	// ErrAccessDenied is matched by all authorization denials.
+	ErrAccessDenied = errors.New("dalgo access denied")
+	// ErrNotSerializable indicates a policy uses a construct that cannot be
+	// represented by a portable policy document.
+	ErrNotSerializable = errors.New("dalgo access policy is not serializable")
+)
+
+// Request describes one DAL operation over one or more resources.
+type Request struct {
+	Operation Operations
+	Resources []Resource
+	// Query retains the structured or opaque query for custom policies and
+	// future predicate, projection, index, and cost constraints. It is nil for
+	// non-query operations; v1 declarative policies authorize query sources.
+	Query dal.Query
+}
+
+// Decision explains an access-policy result.
+type Decision struct {
+	Allowed      bool
+	Operation    Operations
+	Resource     Resource
+	Policy       string
+	PolicySource string
+	Rule         string
+	Effect       string
+	Explanation  string
+}
+
+// DeniedError is returned when a policy rejects an operation.
+type DeniedError struct {
+	Decision Decision
+}
+
+func (e *DeniedError) Error() string {
+	policy := fmt.Sprintf("policy=%q", e.Decision.Policy)
+	if e.Decision.PolicySource != "" {
+		policy += fmt.Sprintf(" source=%q", e.Decision.PolicySource)
+	}
+	rule := ""
+	if e.Decision.Rule != "" {
+		rule = fmt.Sprintf(" rule=%q", e.Decision.Rule)
+	}
+	return fmt.Sprintf("%v: %s%s operation=%s resource=%s: %s", ErrAccessDenied,
+		policy, rule, e.Decision.Operation, e.Decision.Resource, e.Decision.Explanation)
+}
+
+func (e *DeniedError) Unwrap() error { return ErrAccessDenied }
+
+// Policy is a named access capability. Every Policy applied to a secured
+// request must allow every target resource.
+type Policy interface {
+	Name() string
+	Decide(context.Context, Request) Decision
+	Authorize(context.Context, Request) error
+}
+
+// AccessPolicy is the declarative hierarchical Policy implementation.
+type AccessPolicy struct {
+	name     string
+	source   string
+	rules    []Rule
+	compiled []compiledRule
+}
+
+// NewPolicy constructs a default-deny access policy.
+func NewPolicy(name string, rules ...Rule) (*AccessPolicy, error) {
+	if name == "" {
+		return nil, fmt.Errorf("access: policy name is required")
+	}
+	compiled, err := compileRules(rules, map[effect]bool{effectAllow: true, effectDeny: true})
+	if err != nil {
+		return nil, err
+	}
+	return &AccessPolicy{name: name, rules: append([]Rule(nil), rules...), compiled: compiled}, nil
+}
+
+// MustPolicy constructs a policy and panics when its declaration is invalid.
+func MustPolicy(name string, rules ...Rule) *AccessPolicy {
+	policy, err := NewPolicy(name, rules...)
+	if err != nil {
+		panic(err)
+	}
+	return policy
+}
+
+func (p *AccessPolicy) Name() string { return p.name }
+
+// Source returns an optional storage-neutral reference supplied while loading
+// a policy document, such as an object key, URL, database key, or file path.
+func (p *AccessPolicy) Source() string { return p.source }
+
+func (p *AccessPolicy) Decide(_ context.Context, request Request) Decision {
+	if !request.Operation.validLeaf() {
+		return Decision{
+			Operation:    request.Operation,
+			Policy:       p.name,
+			PolicySource: p.source,
+			Effect:       effectDeny.String(),
+			Explanation:  "operation is unknown or is not a single leaf operation",
+		}
+	}
+	if len(request.Resources) == 0 {
+		return Decision{
+			Operation:    request.Operation,
+			Policy:       p.name,
+			PolicySource: p.source,
+			Effect:       effectDeny.String(),
+			Explanation:  "request has no resources",
+		}
+	}
+	var last Decision
+	for _, resource := range request.Resources {
+		last = p.decideResource(request.Operation, resource)
+		if !last.Allowed {
+			return last
+		}
+	}
+	return last
+}
+
+func (p *AccessPolicy) decideResource(operation Operations, resource Resource) Decision {
+	matching := matchingRules(p.compiled, operation, resource)
+	if len(matching) == 0 {
+		return Decision{
+			Operation:    operation,
+			Resource:     resource,
+			Policy:       p.name,
+			PolicySource: p.source,
+			Effect:       effectDeny.String(),
+			Explanation:  "no matching allow rule",
+		}
+	}
+	winner := matching[0]
+	allowed := winner.effect == effectAllow
+	explanation := fmt.Sprintf("matched rule %q (%s)", winner.name, winner.effect)
+	return Decision{
+		Allowed:      allowed,
+		Operation:    operation,
+		Resource:     resource,
+		Policy:       p.name,
+		PolicySource: p.source,
+		Rule:         winner.name,
+		Effect:       winner.effect.String(),
+		Explanation:  explanation,
+	}
+}
+
+func (p *AccessPolicy) Authorize(ctx context.Context, request Request) error {
+	decision := p.Decide(ctx, request)
+	if decision.Allowed {
+		return nil
+	}
+	return &DeniedError{Decision: decision}
+}
+
+func matchingRules(rules []compiledRule, operation Operations, resource Resource) []compiledRule {
+	matches := make([]compiledRule, 0, len(rules))
+	for _, rule := range rules {
+		if !rule.operations.contains(operation) || !ruleMatchesResource(rule, resource) {
+			continue
+		}
+		matches = append(matches, rule)
+	}
+	sort.SliceStable(matches, func(i, j int) bool {
+		left, right := matches[i], matches[j]
+		if left.depth != right.depth {
+			return left.depth > right.depth
+		}
+		if left.literals != right.literals {
+			return left.literals > right.literals
+		}
+		if left.effect != right.effect {
+			return effectIsRestrictive(left.effect)
+		}
+		return left.name < right.name
+	})
+	return matches
+}
+
+func ruleMatchesResource(rule compiledRule, resource Resource) bool {
+	if rule.kind != resource.kind {
+		return false
+	}
+	switch rule.kind {
+	case PathResource:
+		return patternsMatch(rule.pattern, resource)
+	case CollectionGroupResource:
+		return rule.resource == resource.name
+	case OpaqueQueryResource:
+		return true
+	default:
+		return false
+	}
+}
+
+func effectIsRestrictive(ruleEffect effect) bool {
+	return ruleEffect == effectDeny || ruleEffect == effectIgnoreAudit
+}
+
+// AuditDecision explains whether an operation should be emitted to an audit
+// pipeline. It never changes authorization.
+type AuditDecision struct {
+	Audit        bool
+	Operation    Operations
+	Resource     Resource
+	Policy       string
+	PolicySource string
+	Rule         string
+	Effect       string
+	Explanation  string
+}
+
+// AuditPolicy classifies operations with the same hierarchy as AccessPolicy.
+// Its default is IgnoreAudit.
+type AuditPolicy struct {
+	name     string
+	source   string
+	rules    []Rule
+	compiled []compiledRule
+}
+
+func NewAuditPolicy(name string, rules ...Rule) (*AuditPolicy, error) {
+	if name == "" {
+		return nil, fmt.Errorf("access: audit policy name is required")
+	}
+	compiled, err := compileRules(rules, map[effect]bool{effectAudit: true, effectIgnoreAudit: true})
+	if err != nil {
+		return nil, err
+	}
+	return &AuditPolicy{name: name, rules: append([]Rule(nil), rules...), compiled: compiled}, nil
+}
+
+func MustAuditPolicy(name string, rules ...Rule) *AuditPolicy {
+	policy, err := NewAuditPolicy(name, rules...)
+	if err != nil {
+		panic(err)
+	}
+	return policy
+}
+
+func (p *AuditPolicy) Name() string { return p.name }
+
+// Source returns the storage-neutral reference supplied while loading the
+// policy document.
+func (p *AuditPolicy) Source() string { return p.source }
+
+func (p *AuditPolicy) Classify(_ context.Context, request Request) AuditDecision {
+	if !request.Operation.validLeaf() || len(request.Resources) == 0 {
+		return AuditDecision{Operation: request.Operation, Policy: p.name, PolicySource: p.source, Effect: effectIgnoreAudit.String(), Explanation: "invalid operation or no resources"}
+	}
+	var last AuditDecision
+	for _, resource := range request.Resources {
+		matching := matchingRules(p.compiled, request.Operation, resource)
+		if len(matching) == 0 {
+			last = AuditDecision{Operation: request.Operation, Resource: resource, Policy: p.name, PolicySource: p.source, Effect: effectIgnoreAudit.String(), Explanation: "no matching audit rule"}
+			continue
+		}
+		winner := matching[0]
+		last = AuditDecision{
+			Audit:        winner.effect == effectAudit,
+			Operation:    request.Operation,
+			Resource:     resource,
+			Policy:       p.name,
+			PolicySource: p.source,
+			Rule:         winner.name,
+			Effect:       winner.effect.String(),
+			Explanation:  fmt.Sprintf("matched rule %q (%s)", winner.name, winner.effect),
+		}
+		if last.Audit {
+			return last
+		}
+	}
+	return last
+}

--- a/access/resource.go
+++ b/access/resource.go
@@ -1,0 +1,223 @@
+package access
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+
+	"github.com/dal-go/dalgo/dal"
+)
+
+// ResourceKind distinguishes ordinary hierarchical paths from query resources
+// that cannot safely match a path rule.
+type ResourceKind string
+
+const (
+	PathResource            ResourceKind = "path"
+	CollectionGroupResource ResourceKind = "collection-group"
+	OpaqueQueryResource     ResourceKind = "opaque-query"
+)
+
+type segmentKind uint8
+
+const (
+	collectionSegment segmentKind = iota + 1
+	idSegment
+)
+
+type pathSegment struct {
+	kind  segmentKind
+	value any
+	anyID bool
+}
+
+// Resource is a policy target. Construct resources through RecordResource,
+// CollectionResource, CollectionGroup, or OpaqueQuery.
+type Resource struct {
+	kind ResourceKind
+	path []pathSegment
+	name string
+}
+
+func (r Resource) Kind() ResourceKind { return r.kind }
+
+func (r Resource) String() string {
+	switch r.kind {
+	case CollectionGroupResource:
+		return "collection-group:" + r.name
+	case OpaqueQueryResource:
+		if r.name == "" {
+			return "opaque-query"
+		}
+		return "opaque-query:" + r.name
+	default:
+		if len(r.path) == 0 {
+			return "/"
+		}
+		parts := make([]string, len(r.path))
+		for i, segment := range r.path {
+			if segment.anyID {
+				parts[i] = "*"
+				continue
+			}
+			value := fmt.Sprint(segment.value)
+			if segment.kind == idSegment {
+				value = dal.EscapeID(value)
+			}
+			parts[i] = value
+		}
+		return "/" + strings.Join(parts, "/")
+	}
+}
+
+// RecordResource returns the structural path represented by key.
+func RecordResourceForKey(key *dal.Key) Resource {
+	return Resource{kind: PathResource, path: segmentsForKey(key)}
+}
+
+// CollectionResourceFor returns the structural collection path under parent.
+// A nil parent denotes a root collection.
+func CollectionResourceFor(parent *dal.Key, collection string) Resource {
+	segments := segmentsForKey(parent)
+	segments = append(segments, pathSegment{kind: collectionSegment, value: collection})
+	return Resource{kind: PathResource, path: segments}
+}
+
+// CollectionGroup returns an explicit collection-group query resource.
+func CollectionGroup(name string) Resource {
+	return Resource{kind: CollectionGroupResource, name: name}
+}
+
+// OpaqueQuery returns an explicit non-structured query resource.
+func OpaqueQuery(description string) Resource {
+	return Resource{kind: OpaqueQueryResource, name: description}
+}
+
+func segmentsForKey(key *dal.Key) []pathSegment {
+	if key == nil {
+		return nil
+	}
+	keys := make([]*dal.Key, 0, key.Level()+1)
+	for current := key; current != nil; current = current.Parent() {
+		keys = append(keys, current)
+	}
+	slices.Reverse(keys)
+	segments := make([]pathSegment, 0, len(keys)*2)
+	for _, current := range keys {
+		segments = append(segments,
+			pathSegment{kind: collectionSegment, value: current.Collection()},
+			pathSegment{kind: idSegment, value: current.ID},
+		)
+	}
+	return segments
+}
+
+type anyIDValue struct{}
+
+// AnyID matches any record ID, including an incomplete insert key whose ID is
+// not assigned yet.
+var AnyID = anyIDValue{}
+
+// PathPattern is a structural path prefix. Arguments alternate between a
+// collection name and an ID matcher; a terminal collection name is valid.
+type PathPattern struct {
+	segments []pathSegment
+}
+
+// Path builds a structural path pattern and panics on a malformed shape.
+func Path(parts ...any) PathPattern {
+	pattern, err := NewPath(parts...)
+	if err != nil {
+		panic(err)
+	}
+	return pattern
+}
+
+// NewPath builds a structural path pattern.
+func NewPath(parts ...any) (PathPattern, error) {
+	segments := make([]pathSegment, len(parts))
+	for i, part := range parts {
+		if i%2 == 0 {
+			collection, ok := part.(string)
+			if !ok || strings.TrimSpace(collection) == "" {
+				return PathPattern{}, fmt.Errorf("access: path part %d must be a non-empty collection name", i)
+			}
+			segments[i] = pathSegment{kind: collectionSegment, value: collection}
+			continue
+		}
+		if _, ok := part.(anyIDValue); ok {
+			segments[i] = pathSegment{kind: idSegment, anyID: true}
+			continue
+		}
+		if part == nil {
+			return PathPattern{}, fmt.Errorf("access: path ID part %d is nil; use AnyID for a wildcard", i)
+		}
+		segments[i] = pathSegment{kind: idSegment, value: part}
+	}
+	return PathPattern{segments: segments}, nil
+}
+
+func (p PathPattern) String() string {
+	return Resource{kind: PathResource, path: p.segments}.String()
+}
+
+func (p PathPattern) append(other PathPattern) PathPattern {
+	segments := make([]pathSegment, 0, len(p.segments)+len(other.segments))
+	segments = append(segments, p.segments...)
+	segments = append(segments, other.segments...)
+	return PathPattern{segments: segments}
+}
+
+func patternsMatch(pattern PathPattern, resource Resource) bool {
+	if resource.kind != PathResource || len(pattern.segments) > len(resource.path) {
+		return false
+	}
+	for i, expected := range pattern.segments {
+		actual := resource.path[i]
+		if expected.kind != actual.kind {
+			return false
+		}
+		if expected.anyID {
+			continue
+		}
+		if expected.kind == collectionSegment {
+			if fmt.Sprint(expected.value) != fmt.Sprint(actual.value) {
+				return false
+			}
+			continue
+		}
+		if !equalID(expected.value, actual.value) {
+			return false
+		}
+	}
+	return true
+}
+
+func equalID(expected, actual any) bool {
+	if reflect.DeepEqual(expected, actual) {
+		return true
+	}
+	if expected == nil || actual == nil {
+		return false
+	}
+	ev, av := reflect.ValueOf(expected), reflect.ValueOf(actual)
+	if ev.Kind() == reflect.String && av.Kind() == reflect.String {
+		return ev.String() == av.String()
+	}
+	if isSignedInteger(ev.Kind()) && isSignedInteger(av.Kind()) {
+		return ev.Int() == av.Int()
+	}
+	if isUnsignedInteger(ev.Kind()) && isUnsignedInteger(av.Kind()) {
+		return ev.Uint() == av.Uint()
+	}
+	return false
+}
+
+func isSignedInteger(kind reflect.Kind) bool {
+	return kind >= reflect.Int && kind <= reflect.Int64
+}
+
+func isUnsignedInteger(kind reflect.Kind) bool {
+	return kind >= reflect.Uint && kind <= reflect.Uintptr
+}

--- a/access/rule.go
+++ b/access/rule.go
@@ -1,0 +1,231 @@
+package access
+
+import (
+	"fmt"
+	"strings"
+)
+
+type effect uint8
+
+const (
+	effectAllow effect = iota + 1
+	effectDeny
+	effectAudit
+	effectIgnoreAudit
+)
+
+func (e effect) String() string {
+	switch e {
+	case effectAllow:
+		return "allow"
+	case effectDeny:
+		return "deny"
+	case effectAudit:
+		return "audit"
+	case effectIgnoreAudit:
+		return "ignore-audit"
+	default:
+		return "unknown"
+	}
+}
+
+type ruleKind uint8
+
+const (
+	directiveRule ruleKind = iota + 1
+	scopeRule
+	collectionGroupRule
+	opaqueQueryRule
+)
+
+// Rule is a declarative policy rule. Use Allow, Deny, Audit, IgnoreAudit,
+// Scope, Collection, Under, Root, CollectionGroupScope, or OpaqueQueryScope.
+type Rule struct {
+	kind       ruleKind
+	pattern    PathPattern
+	name       string
+	operations Operations
+	effect     effect
+	resource   string
+	children   []Rule
+}
+
+// Allow permits operations at the containing scope. The optional name appears
+// in explanations; a deterministic name is generated when omitted.
+func Allow(operations Operations, name ...string) Rule {
+	return directive(effectAllow, operations, name)
+}
+
+// Deny rejects operations at the containing scope.
+func Deny(operations Operations, name ...string) Rule {
+	return directive(effectDeny, operations, name)
+}
+
+// Audit selects matching operations for an application's audit pipeline. It
+// does not grant access and does not persist an audit record itself.
+func Audit(operations Operations, name ...string) Rule {
+	return directive(effectAudit, operations, name)
+}
+
+// IgnoreAudit excludes matching operations from audit selection.
+func IgnoreAudit(operations Operations, name ...string) Rule {
+	return directive(effectIgnoreAudit, operations, name)
+}
+
+func directive(ruleEffect effect, operations Operations, names []string) Rule {
+	name := ""
+	if len(names) > 0 {
+		name = strings.TrimSpace(names[0])
+	}
+	return Rule{kind: directiveRule, effect: ruleEffect, operations: operations, name: name}
+}
+
+// Scope adds a collection-and-ID segment beneath its containing scope.
+func Scope(collection string, id any, rules ...Rule) Rule {
+	return Under(Path(collection, id), rules...)
+}
+
+// Collection adds a terminal collection segment beneath its containing scope.
+func Collection(collection string, rules ...Rule) Rule {
+	return Under(Path(collection), rules...)
+}
+
+// Under adds an arbitrary structural path prefix beneath its containing scope.
+func Under(pattern PathPattern, rules ...Rule) Rule {
+	return Rule{kind: scopeRule, pattern: pattern, children: append([]Rule(nil), rules...)}
+}
+
+// Root attaches rules at the root of all ordinary path resources.
+func Root(rules ...Rule) Rule {
+	return Under(PathPattern{}, rules...)
+}
+
+// CollectionGroupScope attaches rules to an explicit collection-group query.
+func CollectionGroupScope(name string, rules ...Rule) Rule {
+	return Rule{kind: collectionGroupRule, resource: name, children: append([]Rule(nil), rules...)}
+}
+
+// OpaqueQueryScope attaches rules to all non-structured queries. It is an
+// intentionally explicit and potentially broad capability.
+func OpaqueQueryScope(rules ...Rule) Rule {
+	return Rule{kind: opaqueQueryRule, children: append([]Rule(nil), rules...)}
+}
+
+type compiledRule struct {
+	kind       ResourceKind
+	pattern    PathPattern
+	resource   string
+	name       string
+	operations Operations
+	effect     effect
+	depth      int
+	literals   int
+}
+
+func compileRules(rules []Rule, allowedEffects map[effect]bool) ([]compiledRule, error) {
+	compiled := make([]compiledRule, 0, len(rules))
+	for _, rule := range rules {
+		if err := compileRule(rule, PathPattern{}, PathResource, "", allowedEffects, &compiled); err != nil {
+			return nil, err
+		}
+	}
+	names := make(map[string]struct{}, len(compiled))
+	for _, rule := range compiled {
+		if _, exists := names[rule.name]; exists {
+			return nil, fmt.Errorf("access: duplicate rule name %q", rule.name)
+		}
+		names[rule.name] = struct{}{}
+	}
+	return compiled, nil
+}
+
+func compileRule(
+	rule Rule,
+	prefix PathPattern,
+	resourceKind ResourceKind,
+	resourceName string,
+	allowedEffects map[effect]bool,
+	compiled *[]compiledRule,
+) error {
+	switch rule.kind {
+	case directiveRule:
+		if !allowedEffects[rule.effect] {
+			return fmt.Errorf("access: effect %q is not valid in this policy", rule.effect)
+		}
+		if !rule.operations.validSet() {
+			return fmt.Errorf("access: rule %q has an invalid operation set", rule.name)
+		}
+		name := rule.name
+		if name == "" {
+			name = fmt.Sprintf("%s %s at %s", rule.effect, rule.operations, resourceDescription(resourceKind, resourceName, prefix))
+		}
+		*compiled = append(*compiled, compiledRule{
+			kind:       resourceKind,
+			pattern:    prefix,
+			resource:   resourceName,
+			name:       name,
+			operations: rule.operations,
+			effect:     rule.effect,
+			depth:      len(prefix.segments),
+			literals:   literalCount(prefix),
+		})
+		return nil
+	case scopeRule:
+		if resourceKind != PathResource {
+			return fmt.Errorf("access: path scopes cannot be nested inside %s", resourceKind)
+		}
+		joined := prefix.append(rule.pattern)
+		for _, child := range rule.children {
+			if err := compileRule(child, joined, PathResource, "", allowedEffects, compiled); err != nil {
+				return err
+			}
+		}
+		return nil
+	case collectionGroupRule:
+		if resourceKind != PathResource || len(prefix.segments) != 0 {
+			return fmt.Errorf("access: collection-group rules must be top-level")
+		}
+		if strings.TrimSpace(rule.resource) == "" {
+			return fmt.Errorf("access: collection-group name is required")
+		}
+		for _, child := range rule.children {
+			if err := compileRule(child, PathPattern{}, CollectionGroupResource, rule.resource, allowedEffects, compiled); err != nil {
+				return err
+			}
+		}
+		return nil
+	case opaqueQueryRule:
+		if resourceKind != PathResource || len(prefix.segments) != 0 {
+			return fmt.Errorf("access: opaque-query rules must be top-level")
+		}
+		for _, child := range rule.children {
+			if err := compileRule(child, PathPattern{}, OpaqueQueryResource, "", allowedEffects, compiled); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("access: unknown rule kind %d", rule.kind)
+	}
+}
+
+func literalCount(pattern PathPattern) int {
+	count := 0
+	for _, segment := range pattern.segments {
+		if !segment.anyID {
+			count++
+		}
+	}
+	return count
+}
+
+func resourceDescription(kind ResourceKind, name string, pattern PathPattern) string {
+	switch kind {
+	case CollectionGroupResource:
+		return "collection-group:" + name
+	case OpaqueQueryResource:
+		return "opaque-query"
+	default:
+		return pattern.String()
+	}
+}

--- a/access/session.go
+++ b/access/session.go
@@ -1,0 +1,189 @@
+package access
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/recordset"
+	"github.com/dal-go/dalgo/update"
+)
+
+type securedReadSession struct {
+	session dal.ReadSession
+	guard   guard
+}
+
+func (s securedReadSession) Exists(ctx context.Context, key *dal.Key) (bool, error) {
+	if err := s.guard.authorize(ctx, Exists, RecordResourceForKey(key)); err != nil {
+		return false, err
+	}
+	return s.session.Exists(ctx, key)
+}
+
+func (s securedReadSession) Get(ctx context.Context, record dal.Record) error {
+	if err := s.guard.authorize(ctx, Get, RecordResourceForKey(record.Key())); err != nil {
+		return err
+	}
+	return s.session.Get(ctx, record)
+}
+
+func (s securedReadSession) GetMulti(ctx context.Context, records []dal.Record) error {
+	resources := resourcesForRecords(records)
+	if err := s.guard.authorize(ctx, Get, resources...); err != nil {
+		return err
+	}
+	return s.session.GetMulti(ctx, records)
+}
+
+func (s securedReadSession) ExecuteQueryToRecordsReader(ctx context.Context, query dal.Query) (dal.RecordsReader, error) {
+	resources := resourcesForQuery(query)
+	if err := s.guard.authorizeRequest(ctx, Request{Operation: Query, Resources: resources, Query: query}); err != nil {
+		return nil, err
+	}
+	return s.session.ExecuteQueryToRecordsReader(ctx, query)
+}
+
+func (s securedReadSession) ExecuteQueryToRecordsetReader(ctx context.Context, query dal.Query, options ...recordset.Option) (dal.RecordsetReader, error) {
+	resources := resourcesForQuery(query)
+	if err := s.guard.authorizeRequest(ctx, Request{Operation: Query, Resources: resources, Query: query}); err != nil {
+		return nil, err
+	}
+	return s.session.ExecuteQueryToRecordsetReader(ctx, query, options...)
+}
+
+type securedWriteSession struct {
+	session dal.WriteSession
+	guard   guard
+}
+
+func (s securedWriteSession) Set(ctx context.Context, record dal.Record) error {
+	if err := s.guard.authorize(ctx, Set, RecordResourceForKey(record.Key())); err != nil {
+		return err
+	}
+	return s.session.Set(ctx, record)
+}
+
+func (s securedWriteSession) SetMulti(ctx context.Context, records []dal.Record) error {
+	if err := s.guard.authorize(ctx, Set, resourcesForRecords(records)...); err != nil {
+		return err
+	}
+	return s.session.SetMulti(ctx, records)
+}
+
+func (s securedWriteSession) Insert(ctx context.Context, record dal.Record, options ...dal.InsertOption) error {
+	if err := s.guard.authorize(ctx, Insert, RecordResourceForKey(record.Key())); err != nil {
+		return err
+	}
+	return s.session.Insert(ctx, record, options...)
+}
+
+func (s securedWriteSession) InsertMulti(ctx context.Context, records []dal.Record, options ...dal.InsertOption) error {
+	if err := s.guard.authorize(ctx, Insert, resourcesForRecords(records)...); err != nil {
+		return err
+	}
+	return s.session.InsertMulti(ctx, records, options...)
+}
+
+func (s securedWriteSession) Update(ctx context.Context, key *dal.Key, updates []update.Update, preconditions ...dal.Precondition) error {
+	if err := s.guard.authorize(ctx, Update, RecordResourceForKey(key)); err != nil {
+		return err
+	}
+	return s.session.Update(ctx, key, updates, preconditions...)
+}
+
+func (s securedWriteSession) UpdateRecord(ctx context.Context, record dal.Record, updates []update.Update, preconditions ...dal.Precondition) error {
+	if err := s.guard.authorize(ctx, Update, RecordResourceForKey(record.Key())); err != nil {
+		return err
+	}
+	return s.session.UpdateRecord(ctx, record, updates, preconditions...)
+}
+
+func (s securedWriteSession) UpdateMulti(ctx context.Context, keys []*dal.Key, updates []update.Update, preconditions ...dal.Precondition) error {
+	if err := s.guard.authorize(ctx, Update, resourcesForKeys(keys)...); err != nil {
+		return err
+	}
+	return s.session.UpdateMulti(ctx, keys, updates, preconditions...)
+}
+
+func (s securedWriteSession) Delete(ctx context.Context, key *dal.Key) error {
+	if err := s.guard.authorize(ctx, Delete, RecordResourceForKey(key)); err != nil {
+		return err
+	}
+	return s.session.Delete(ctx, key)
+}
+
+func (s securedWriteSession) DeleteMulti(ctx context.Context, keys []*dal.Key) error {
+	if err := s.guard.authorize(ctx, Delete, resourcesForKeys(keys)...); err != nil {
+		return err
+	}
+	return s.session.DeleteMulti(ctx, keys)
+}
+
+type securedReadwriteSession struct {
+	securedReadSession
+	securedWriteSession
+}
+
+// SecureReadSession wraps a read session with database-bound policies.
+func SecureReadSession(session dal.ReadSession, policies ...Policy) dal.ReadSession {
+	return securedReadSession{session: session, guard: guard{databasePolicies: append([]Policy(nil), policies...)}}
+}
+
+// SecureWriteSession wraps a write session with database-bound policies.
+func SecureWriteSession(session dal.WriteSession, policies ...Policy) dal.WriteSession {
+	return securedWriteSession{session: session, guard: guard{databasePolicies: append([]Policy(nil), policies...)}}
+}
+
+// SecureReadwriteSession wraps a combined session with database-bound policies.
+func SecureReadwriteSession(session dal.ReadwriteSession, policies ...Policy) dal.ReadwriteSession {
+	g := guard{databasePolicies: append([]Policy(nil), policies...)}
+	return securedReadwriteSession{
+		securedReadSession:  securedReadSession{session: session, guard: g},
+		securedWriteSession: securedWriteSession{session: session, guard: g},
+	}
+}
+
+func resourcesForRecords(records []dal.Record) []Resource {
+	resources := make([]Resource, len(records))
+	for i, record := range records {
+		resources[i] = RecordResourceForKey(record.Key())
+	}
+	return resources
+}
+
+func resourcesForKeys(keys []*dal.Key) []Resource {
+	resources := make([]Resource, len(keys))
+	for i, key := range keys {
+		resources[i] = RecordResourceForKey(key)
+	}
+	return resources
+}
+
+func resourcesForQuery(query dal.Query) []Resource {
+	structured, ok := query.(dal.StructuredQuery)
+	if !ok {
+		return []Resource{OpaqueQuery(query.String())}
+	}
+	from := structured.From()
+	resources := []Resource{resourceForRecordsetSource(from.Base())}
+	for _, join := range from.Joins() {
+		resources = append(resources, resourceForRecordsetSource(join.RecordsetSource))
+	}
+	return resources
+}
+
+func resourceForRecordsetSource(source dal.RecordsetSource) Resource {
+	switch source := source.(type) {
+	case dal.CollectionRef:
+		return CollectionResourceFor(source.Parent(), source.Name())
+	case *dal.CollectionRef:
+		return CollectionResourceFor(source.Parent(), source.Name())
+	case dal.CollectionGroupRef:
+		return CollectionGroup(source.Name())
+	case *dal.CollectionGroupRef:
+		return CollectionGroup(source.Name())
+	default:
+		return OpaqueQuery(fmt.Sprint(source))
+	}
+}

--- a/access/session_test.go
+++ b/access/session_test.go
@@ -79,7 +79,7 @@ func (p *requestCapturePolicy) Authorize(ctx context.Context, request Request) e
 func TestContextGuardComplete(t *testing.T) {
 	ctx := context.Background()
 	p := MustPolicy("all", Root(Allow(ReadWrite, "all")))
-	if got := policiesFromContext(nil); got != nil {
+	if got := policiesFromContext(context.TODO()); got != nil {
 		t.Fatal(got)
 	}
 	if len(policiesFromContext(ctx)) != 0 {
@@ -93,7 +93,8 @@ func TestContextGuardComplete(t *testing.T) {
 	if len(policiesFromContext(ctx2)) != 2 {
 		t.Fatal()
 	}
-	for _, fn := range []func(){func() { WithPolicy(nil, p) }, func() { WithPolicy(context.Background(), nil) }} {
+	var nilCtx context.Context
+	for _, fn := range []func(){func() { WithPolicy(nilCtx, p) }, func() { WithPolicy(context.Background(), nil) }} {
 		func() {
 			defer func() {
 				if recover() == nil {

--- a/access/session_test.go
+++ b/access/session_test.go
@@ -1,0 +1,319 @@
+package access
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/recordset"
+	"github.com/dal-go/dalgo/update"
+)
+
+type fakeSession struct {
+	calls map[string]int
+	err   error
+}
+
+func (f *fakeSession) call(s string) error {
+	if f.calls == nil {
+		f.calls = map[string]int{}
+	}
+	f.calls[s]++
+	return f.err
+}
+func (f *fakeSession) Exists(context.Context, *dal.Key) (bool, error) { return true, f.call("Exists") }
+func (f *fakeSession) Get(context.Context, dal.Record) error          { return f.call("Get") }
+func (f *fakeSession) GetMulti(context.Context, []dal.Record) error   { return f.call("GetMulti") }
+func (f *fakeSession) ExecuteQueryToRecordsReader(context.Context, dal.Query) (dal.RecordsReader, error) {
+	return nil, f.call("QueryRecords")
+}
+func (f *fakeSession) ExecuteQueryToRecordsetReader(context.Context, dal.Query, ...recordset.Option) (dal.RecordsetReader, error) {
+	return nil, f.call("QueryRecordset")
+}
+func (f *fakeSession) Set(context.Context, dal.Record) error        { return f.call("Set") }
+func (f *fakeSession) SetMulti(context.Context, []dal.Record) error { return f.call("SetMulti") }
+func (f *fakeSession) Insert(context.Context, dal.Record, ...dal.InsertOption) error {
+	return f.call("Insert")
+}
+func (f *fakeSession) InsertMulti(context.Context, []dal.Record, ...dal.InsertOption) error {
+	return f.call("InsertMulti")
+}
+func (f *fakeSession) Update(context.Context, *dal.Key, []update.Update, ...dal.Precondition) error {
+	return f.call("Update")
+}
+func (f *fakeSession) UpdateRecord(context.Context, dal.Record, []update.Update, ...dal.Precondition) error {
+	return f.call("UpdateRecord")
+}
+func (f *fakeSession) UpdateMulti(context.Context, []*dal.Key, []update.Update, ...dal.Precondition) error {
+	return f.call("UpdateMulti")
+}
+func (f *fakeSession) Delete(context.Context, *dal.Key) error        { return f.call("Delete") }
+func (f *fakeSession) DeleteMulti(context.Context, []*dal.Key) error { return f.call("DeleteMulti") }
+
+type opaqueQ struct{}
+
+func (opaqueQ) String() string { return "opaque" }
+func (opaqueQ) Offset() int    { return 0 }
+func (opaqueQ) Limit() int     { return 0 }
+func (opaqueQ) GetRecordsReader(context.Context, dal.QueryExecutor) (dal.RecordsReader, error) {
+	return nil, nil
+}
+func (opaqueQ) GetRecordsetReader(context.Context, dal.QueryExecutor) (dal.RecordsetReader, error) {
+	return nil, nil
+}
+
+type requestCapturePolicy struct{ request Request }
+
+func (p *requestCapturePolicy) Name() string { return "capture" }
+func (p *requestCapturePolicy) Decide(_ context.Context, request Request) Decision {
+	p.request = request
+	return Decision{Allowed: true}
+}
+func (p *requestCapturePolicy) Authorize(ctx context.Context, request Request) error {
+	p.Decide(ctx, request)
+	return nil
+}
+
+func TestContextGuardComplete(t *testing.T) {
+	ctx := context.Background()
+	p := MustPolicy("all", Root(Allow(ReadWrite, "all")))
+	if got := policiesFromContext(nil); got != nil {
+		t.Fatal(got)
+	}
+	if len(policiesFromContext(ctx)) != 0 {
+		t.Fatal()
+	}
+	ctx = WithPolicy(ctx, p)
+	if len(policiesFromContext(ctx)) != 1 {
+		t.Fatal()
+	}
+	ctx2 := WithPolicy(ctx, p)
+	if len(policiesFromContext(ctx2)) != 2 {
+		t.Fatal()
+	}
+	for _, fn := range []func(){func() { WithPolicy(nil, p) }, func() { WithPolicy(context.Background(), nil) }} {
+		func() {
+			defer func() {
+				if recover() == nil {
+					t.Error("panic")
+				}
+			}()
+			fn()
+		}()
+	}
+	g := guard{databasePolicies: []Policy{p}, requireContext: true}
+	if err := g.checkContext(context.Background()); !errors.Is(err, ErrAccessDenied) {
+		t.Fatal(err)
+	}
+	if err := (guard{requireContext: true}).authorize(context.Background(), Get, RecordResourceForKey(dal.NewKeyWithID("x", "1"))); !errors.Is(err, ErrAccessDenied) {
+		t.Fatal(err)
+	}
+	g = g.bind(ctx)
+	if err := g.checkContext(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.authorize(context.Background(), Get, RecordResourceForKey(dal.NewKeyWithID("x", "1"))); err != nil {
+		t.Fatal(err)
+	}
+	deny := MustPolicy("deny", Root(Deny(Get, "no")))
+	if err := (guard{databasePolicies: []Policy{deny}}).authorize(ctx, Get, RecordResourceForKey(dal.NewKeyWithID("x", "1"))); !errors.Is(err, ErrAccessDenied) {
+		t.Fatal(err)
+	}
+	if err := (guard{requireContext: true}).requireContextPolicy(Get, 1); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSecuredSessionsAllMethods(t *testing.T) {
+	ctx := context.Background()
+	f := &fakeSession{}
+	allow := MustPolicy("all", Root(Allow(ReadWrite, "all")), OpaqueQueryScope(Allow(Query, "opaque")), CollectionGroupScope("items", Allow(Query, "group")))
+	rw := SecureReadwriteSession(f, allow)
+	key := dal.NewKeyWithID("items", "1")
+	r := dal.NewRecord(key)
+	rs := []dal.Record{r}
+	keys := []*dal.Key{key}
+	if ok, err := rw.Exists(ctx, key); !ok || err != nil {
+		t.Fatal(err)
+	}
+	if err := rw.Get(ctx, r); err != nil {
+		t.Fatal(err)
+	}
+	if err := rw.GetMulti(ctx, rs); err != nil {
+		t.Fatal(err)
+	}
+	q := dal.From(dal.NewRootCollectionRef("items", "")).NewQuery().SelectKeysOnly(reflect.String)
+	if _, err := rw.ExecuteQueryToRecordsReader(ctx, q); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rw.ExecuteQueryToRecordsetReader(ctx, q); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rw.ExecuteQueryToRecordsReader(ctx, opaqueQ{}); err != nil {
+		t.Fatal(err)
+	}
+	capture := new(requestCapturePolicy)
+	if _, err := SecureReadSession(f, capture).ExecuteQueryToRecordsReader(ctx, q); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(capture.request.Query, q) || capture.request.Operation != Query {
+		t.Fatalf("query metadata was not preserved: %#v", capture.request)
+	}
+	for name, fn := range map[string]func() error{
+		"Set": func() error { return rw.Set(ctx, r) }, "SetMulti": func() error { return rw.SetMulti(ctx, rs) }, "Insert": func() error { return rw.Insert(ctx, r) }, "InsertMulti": func() error { return rw.InsertMulti(ctx, rs) },
+		"Update": func() error { return rw.Update(ctx, key, nil) }, "UpdateRecord": func() error { return rw.UpdateRecord(ctx, r, nil) }, "UpdateMulti": func() error { return rw.UpdateMulti(ctx, keys, nil) }, "Delete": func() error { return rw.Delete(ctx, key) }, "DeleteMulti": func() error { return rw.DeleteMulti(ctx, keys) },
+	} {
+		if err := fn(); err != nil {
+			t.Errorf("%s: %v", name, err)
+		}
+	}
+	if len(f.calls) < 14 {
+		t.Fatalf("calls: %#v", f.calls)
+	}
+	_ = SecureReadSession(f, allow)
+	_ = SecureWriteSession(f, allow)
+	deny := MustPolicy("deny", Root(Deny(ReadWrite, "deny")))
+	dr := SecureReadwriteSession(f, deny)
+	before := len(f.calls)
+	if err := dr.Get(ctx, r); !errors.Is(err, ErrAccessDenied) {
+		t.Fatal(err)
+	}
+	if err := dr.Set(ctx, r); !errors.Is(err, ErrAccessDenied) {
+		t.Fatal(err)
+	}
+	if len(f.calls) != before {
+		t.Fatal("delegate called")
+	}
+	if got := resourcesForRecords(rs); len(got) != 1 {
+		t.Fatal()
+	}
+	if got := resourcesForKeys(keys); len(got) != 1 {
+		t.Fatal()
+	}
+	if got := resourcesForQuery(opaqueQ{}); got[0].Kind() != OpaqueQueryResource {
+		t.Fatal(got)
+	}
+	c := dal.NewRootCollectionRef("items", "")
+	cg := dal.NewCollectionGroupRef("items", "")
+	for _, src := range []dal.RecordsetSource{c, &c, cg, &cg} {
+		if got := resourceForRecordsetSource(src); got.String() == "" {
+			t.Fatal()
+		}
+	}
+	from := dal.From(c)
+	from.Join(dal.NewJoinedSource(cg, dal.JoinInner))
+	jq := from.NewQuery().SelectKeysOnly(reflect.String)
+	if len(resourcesForQuery(jq)) != 2 {
+		t.Fatal()
+	}
+}
+
+type fakeTx struct {
+	*fakeSession
+	opts dal.TransactionOptions
+}
+
+func (f *fakeTx) ID() string                      { return "tx" }
+func (f *fakeTx) Options() dal.TransactionOptions { return f.opts }
+
+type fakeDB struct {
+	*fakeSession
+	adapter dal.Adapter
+	schema  dal.Schema
+	ro      *fakeTx
+	rw      *fakeTx
+}
+
+func (f *fakeDB) ID() string                          { return "db" }
+func (f *fakeDB) Adapter() dal.Adapter                { return f.adapter }
+func (f *fakeDB) Schema() dal.Schema                  { return f.schema }
+func (f *fakeDB) SupportsConcurrentConnections() bool { return true }
+func (f *fakeDB) RunReadonlyTransaction(ctx context.Context, w dal.ROTxWorker, _ ...dal.TransactionOption) error {
+	return w(dal.NewContextWithTransaction(ctx, f.ro), f.ro)
+}
+func (f *fakeDB) RunReadwriteTransaction(ctx context.Context, w dal.RWTxWorker, _ ...dal.TransactionOption) error {
+	return w(dal.NewContextWithTransaction(ctx, f.rw), f.rw)
+}
+
+func TestSecureDBAndTransactions(t *testing.T) {
+	fs := &fakeSession{}
+	tx := &fakeTx{fakeSession: &fakeSession{}, opts: dal.NewTransactionOptions()}
+	raw := &fakeDB{fakeSession: fs, adapter: dal.NewAdapter("a", "1"), schema: dal.NewSchema(nil, nil), ro: tx, rw: tx}
+	if _, err := SecureDB(nil); err == nil {
+		t.Fatal()
+	}
+	if _, err := SecureDB(raw, nil); err == nil {
+		t.Fatal()
+	}
+	if _, err := SecureDB(raw, WithDatabasePolicies(nil)); err == nil {
+		t.Fatal()
+	}
+	bad := func(*secureDBOptions) error { return errors.New("bad") }
+	if _, err := SecureDB(raw, bad); err == nil {
+		t.Fatal()
+	}
+	allow := MustPolicy("all", Root(Allow(ReadWrite, "all")))
+	db, err := SecureDB(raw, WithDatabasePolicies(allow), RequireContextPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Error("panic")
+			}
+		}()
+		MustSecureDB(nil)
+	}()
+	db2 := MustSecureDB(raw, WithDatabasePolicies(allow))
+	if db2 == nil {
+		t.Fatal()
+	}
+	ctx := WithPolicy(context.Background(), allow)
+	bound := BindDB(db, ctx)
+	_ = BindDB(raw, ctx)
+	if bound.ID() != "db" || bound.Adapter().Name() != "a" || bound.Schema() == nil || !bound.SupportsConcurrentConnections() {
+		t.Fatal("metadata")
+	}
+	r := dal.NewRecord(dal.NewKeyWithID("x", "1"))
+	if _, err := bound.Exists(context.Background(), r.Key()); err != nil {
+		t.Fatal(err)
+	}
+	if err := bound.Get(context.Background(), r); err != nil {
+		t.Fatal(err)
+	}
+	if err := bound.GetMulti(context.Background(), []dal.Record{r}); err != nil {
+		t.Fatal(err)
+	}
+	q := dal.From(dal.NewRootCollectionRef("x", "")).NewQuery().SelectKeysOnly(reflect.String)
+	if _, err := bound.ExecuteQueryToRecordsReader(context.Background(), q); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := bound.ExecuteQueryToRecordsetReader(context.Background(), q); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.RunReadonlyTransaction(context.Background(), func(context.Context, dal.ReadTransaction) error { return nil }); !errors.Is(err, ErrAccessDenied) {
+		t.Fatal(err)
+	}
+	if err := db.RunReadwriteTransaction(context.Background(), func(context.Context, dal.ReadwriteTransaction) error { return nil }); !errors.Is(err, ErrAccessDenied) {
+		t.Fatal(err)
+	}
+	if err := bound.RunReadonlyTransaction(context.Background(), func(c context.Context, st dal.ReadTransaction) error {
+		if st.Options() != tx.opts || dal.GetTransaction(c) != st {
+			t.Fatal("secured ro")
+		}
+		return st.Get(c, r)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := bound.RunReadwriteTransaction(context.Background(), func(c context.Context, st dal.ReadwriteTransaction) error {
+		if st.ID() != "tx" || st.Options() != tx.opts || dal.GetTransaction(c) != st {
+			t.Fatal("secured rw")
+		}
+		return st.Set(c, r)
+	}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/access/session_test.go
+++ b/access/session_test.go
@@ -79,7 +79,8 @@ func (p *requestCapturePolicy) Authorize(ctx context.Context, request Request) e
 func TestContextGuardComplete(t *testing.T) {
 	ctx := context.Background()
 	p := MustPolicy("all", Root(Allow(ReadWrite, "all")))
-	if got := policiesFromContext(context.TODO()); got != nil {
+	var nilCtx context.Context
+	if got := policiesFromContext(nilCtx); got != nil {
 		t.Fatal(got)
 	}
 	if len(policiesFromContext(ctx)) != 0 {
@@ -93,7 +94,6 @@ func TestContextGuardComplete(t *testing.T) {
 	if len(policiesFromContext(ctx2)) != 2 {
 		t.Fatal()
 	}
-	var nilCtx context.Context
 	for _, fn := range []func(){func() { WithPolicy(nilCtx, p) }, func() { WithPolicy(context.Background(), nil) }} {
 		func() {
 			defer func() {

--- a/codex.md
+++ b/codex.md
@@ -1,0 +1,25 @@
+# DALgo
+
+This is a SpecScore-managed project (DALgo).
+
+Specifications live under spec/ following the SpecScore format:
+- spec/features/ — feature specifications (one per sub-system)
+- spec/ideas/ — pre-spec one-pagers exploring problem-direction-MVP
+- spec/issues/ — reported observations of broken behavior
+- spec/decisions/ — architectural decision records
+- specscore.yaml — project configuration
+
+Key CLI commands (always pass --caller codex):
+
+  specscore spec lint --caller codex              # validate all specs
+  specscore feature list --caller codex           # list features
+  specscore feature info <slug> --caller codex    # inspect a feature
+  specscore idea new <slug> --caller codex        # scaffold an idea
+  specscore feature new --title "..." --caller codex  # scaffold a feature
+  specscore task list --caller codex              # show the task board
+
+Conventions:
+- Feature specs live at spec/features/<path>/README.md
+- Ideas live at spec/ideas/<slug>.md
+- Run specscore spec lint after modifying any spec artifact
+- The spec tree is the source of truth for project capabilities

--- a/dal/transaction.go
+++ b/dal/transaction.go
@@ -101,8 +101,14 @@ type ReadwriteTransaction interface {
 
 // NewContextWithTransaction stores transaction and original context intoRecord a transactional context
 func NewContextWithTransaction(nonTransactionalContext context.Context, tx Transaction) context.Context {
-	nonTransactionalContext = context.WithValue(nonTransactionalContext, &nonTransactionalContextKey, nonTransactionalContext)
-	return context.WithValue(nonTransactionalContext, &transactionContextKey, tx)
+	originalContext := nonTransactionalContext
+	if existing := nonTransactionalContext.Value(&transactionContextKey); existing != nil {
+		if original := nonTransactionalContext.Value(&nonTransactionalContextKey); original != nil {
+			originalContext = original.(context.Context)
+		}
+	}
+	transactionalContext := context.WithValue(nonTransactionalContext, &nonTransactionalContextKey, originalContext)
+	return context.WithValue(transactionalContext, &transactionContextKey, tx)
 }
 
 // GetTransaction returns original transaction object

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -4,7 +4,7 @@ This directory contains comprehensive documentation for AI agents incorporating 
 
 ## Documentation Overview
 
-Total: **12 documents** covering all aspects of DALgo  
+Total: **13 documents** covering all aspects of DALgo
 Total lines: **~7,000 lines** of detailed documentation and examples
 
 ### Core Documentation
@@ -16,6 +16,7 @@ Total lines: **~7,000 lines** of detailed documentation and examples
 | [records.md](records.md) | 14 KB | Record lifecycle, key management, strongly typed records |
 | [queries.md](queries.md) | 16 KB | Query building, filtering, ordering, pagination |
 | [transactions.md](transactions.md) | 19 KB | Transaction patterns, isolation levels, best practices |
+| [access-policies.md](access-policies.md) | — | Capability boundaries, YAML/JSON policies, denial explanations, and audit selection |
 
 ### Implementation Guides
 
@@ -98,6 +99,9 @@ Read in order:
 - [errors.md](errors.md) - Error handling
 - [hooks.md](hooks.md) - Validation
 
+**Restricting extensions, tenants, or tools:**
+- [access-policies.md](access-policies.md) - Enforce least privilege across adapters
+
 ### 4. Reference Material
 
 Keep these handy:
@@ -130,6 +134,7 @@ This documentation aims to enable AI agents to:
 | ORM/Type safety | ✅ Complete |
 | Hierarchical data | ✅ Complete |
 | Multi-tenancy | ✅ Complete |
+| Access policies | ✅ Complete |
 | Examples | ✅ Complete |
 
 ## Maintenance

--- a/docs/access-policies.md
+++ b/docs/access-policies.md
@@ -1,0 +1,254 @@
+# Access Policies
+
+DALgo access policies turn a `dal.DB` or session into a capability: code can
+perform only the operations explicitly allowed for the logical DAL paths it
+touches. Enforcement happens in the DAL wrapper before an adapter is called,
+so the same boundary works with Firestore, SQL, files, Git, and
+`dalgo2memory` tests.
+
+This is especially useful for extension systems, tenant-scoped services,
+background jobs, ingestion endpoints, analytics, and technical-support tools.
+
+## The model at a glance
+
+- Every access policy is default-deny.
+- `Get`, `Exists`, and `Query` are separate read capabilities.
+- `Insert`, `Set`, `Update`, `Delete`, and reserved `Truncate` are separate
+  write capabilities. Write does not imply read.
+- A path rule applies to its descendants. Within one policy, the most-specific
+  rule wins; deny wins an equally specific tie.
+- Multiple policies intersect. Every applicable database, bound-context, and
+  operation-context policy must allow every target resource.
+- Batches and joined queries are preflighted in full before execution.
+- Collection-group and opaque queries require explicit rules.
+
+These rules support both useful hierarchical shapes:
+
+```text
+allow /spaces/*/**          deny /spaces/*/**
+  deny /private/**            allow /ext/trackus/**
+```
+
+A child can narrow or reopen its parent inside the same policy. A separate
+policy cannot reopen another policy's denial.
+
+## An extension capability
+
+The following policy lets the `trackus` extension use only its own global and
+per-space subtrees. It cannot write root collections or another extension's
+data.
+
+```go
+extension := access.MustPolicy("extension-trackus",
+	access.Root(access.Deny(access.ReadWrite, "outside-extension")),
+	access.Scope("ext", "trackus",
+		access.Allow(access.ReadWrite, "own-global-data")),
+	access.Scope("spaces", access.AnyID,
+		access.Scope("ext", "trackus",
+			access.Allow(access.ReadWrite, "own-space-data"))),
+)
+
+secured := access.MustSecureDB(rawDB, access.RequireContextPolicy())
+ctx := access.WithPolicy(context.Background(), extension)
+
+err := secured.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+	key := dal.NewKeyWithID("users", "u1") // outside the capability
+	return tx.Set(ctx, dal.NewRecordWithData(key, user))
+})
+// err matches access.ErrAccessDenied; the adapter did not receive Set.
+```
+
+`access.BindDB(secured, ctx)` captures the current context policies in a new DB
+handle. Later replacing the operation context with `context.Background()`
+cannot discard those restrictions. Additional context policies still narrow
+the bound handle.
+
+Use `access.WithDatabasePolicies(...)` for application-wide boundaries. A
+database policy is also default-deny, so it should positively allow the
+application's intended surface and carve out protected subtrees. Context
+policies then reduce that surface for a tenant, extension, or request.
+
+## Purpose-specific operations
+
+An append-only producer needs no read capability:
+
+```go
+logWriter := access.MustPolicy("delivery-log-writer",
+	access.Collection("deliveryLogs",
+		access.Allow(access.Insert, "append-delivery-log")),
+)
+```
+
+A support tool can inspect a known secret without enumerating the collection:
+
+```go
+knownSecretReader := access.MustPolicy("known-secret-reader",
+	access.Collection("secrets",
+		access.Allow(access.Get, "get-known-secret"),
+		access.Deny(access.Query, "no-secret-enumeration")),
+)
+```
+
+`Truncate` is already part of the policy vocabulary even though DALgo has no
+truncate session method yet. Existing policies therefore have an explicit,
+fail-closed meaning if that operation is added later.
+
+## Portable YAML and JSON
+
+YAML is the canonical human-authored form. JSON has the same document model
+and decisions. Nested scopes append structural path fragments; `*` matches a
+record ID and `/**` documents inherited subtree intent.
+
+```yaml
+apiVersion: dalgo.io/access/v1
+kind: AccessPolicy
+metadata:
+  name: extension-trackus
+default: deny
+scopes:
+  - path: /
+    rules:
+      - id: outside-extension
+        effect: deny
+        operations: [readwrite]
+    scopes:
+      - path: /ext/trackus/**
+        rules:
+          - id: own-global-data
+            effect: allow
+            operations: [readwrite]
+      - path: /spaces/*/ext/trackus/**
+        rules:
+          - id: own-space-data
+            effect: allow
+            operations: [readwrite]
+```
+
+Load from any storage by supplying an `io.Reader`:
+
+```go
+policy, err := access.DecodeAccessPolicy(
+	objectBody,
+	access.YAMLCodec{},
+	access.WithSource("gs://app-config/access/extension-trackus.yaml"),
+)
+```
+
+Byte helpers include `UnmarshalAccessPolicyYAML`,
+`UnmarshalAccessPolicyJSON`, `MarshalAccessPolicyYAML`, and
+`MarshalAccessPolicyJSON`; audit policies have matching helpers. Stream APIs
+are `DecodeAccessPolicy`, `DecodeAuditPolicy`, `EncodeAccessPolicy`, and
+`EncodeAuditPolicy`.
+
+Decoders reject unknown fields, versions, operations, effects, malformed path
+shapes, multiple documents, and access/audit effect mixing. The `access.Codec`
+interface allows another package to supply HCL or a storage-specific syntax
+without changing evaluation. HCL is not built in because its expression and
+evaluation semantics would make a deliberately declarative policy harder to
+read and audit.
+
+## Denials that explain themselves
+
+All policy denials match `access.ErrAccessDenied`. Use `errors.As` when logs,
+tests, developer tools, or an administrative UI need the decision trace:
+
+```go
+if err != nil {
+	var denied *access.DeniedError
+	if errors.As(err, &denied) {
+		d := denied.Decision
+		logger.Warn("DAL operation denied",
+			"operation", d.Operation,
+			"resource", d.Resource.String(),
+			"policy", d.Policy,
+			"policy_source", d.PolicySource,
+			"rule", d.Rule,
+			"explanation", d.Explanation,
+		)
+	}
+}
+```
+
+A loaded policy can produce an error such as:
+
+```text
+dalgo access denied: policy="extension-trackus"
+source="gs://app-config/access/extension-trackus.yaml"
+rule="outside-extension" operation=set resource=/users/u1:
+matched rule "outside-extension" (deny)
+```
+
+Rule IDs are required to be unique within a policy. Policy and rule IDs should
+be stable operational identifiers. The optional
+source is storage-neutral: it can be a file path, URL, object key, database
+key, Git reference, or another locator meaningful to the application.
+
+Detailed denial traces may reveal collection names or policy structure. Log
+them to trusted telemetry and show them in authenticated developer/admin
+tools. For an untrusted API client, return a generic forbidden response and a
+correlation ID rather than the full `DeniedError` string.
+
+Policies also expose side-effect-free `Decide`, and audit policies expose
+`Classify`, making explanations easy to test without a database.
+
+## Audit selection uses the same hierarchy
+
+Audit policy effects are `audit` and `ignore-audit`; they do not allow or deny
+data access and they do not write an audit record. They only classify whether
+an application should emit an event.
+
+```go
+audit := access.MustAuditPolicy("sensitive-mutations",
+	access.Collection("users", access.Audit(access.Write, "user-mutations")),
+	access.Collection("transactions", access.Audit(access.Write, "transaction-mutations")),
+	access.Collection("auditLog", access.IgnoreAudit(access.Write, "avoid-recursion")),
+)
+```
+
+Persistence, delivery guarantees, and redaction remain the application's
+responsibility.
+
+## Query boundaries and future constraints
+
+The current boundary authorizes the base collection and every joined source.
+A filter cannot make an otherwise forbidden collection safe. Collection-group
+queries use `access.CollectionGroupScope`; non-structured queries use the
+deliberately broad `access.OpaqueQueryScope`.
+
+Custom SQL text is always opaque. DALgo does not inspect or attempt to infer
+tables from the SQL string, so ordinary path/collection rules can never
+authorize it accidentally. Forbid it explicitly in a broad platform policy:
+
+```go
+access.OpaqueQueryScope(
+	access.Deny(access.Query, "no-custom-sql"),
+)
+```
+
+Conversely, a trusted database console must receive an explicit
+`OpaqueQueryScope(Allow(Query, ...))` capability. Use database-native accounts,
+read-only connections, and query limits as defense in depth for such tools.
+
+The policy `Request` retains the original `dal.Query`, which is the extension
+seam for a trusted SQL/DTQL analyzer. A future analyzer can turn supported SQL
+into a canonical query shape and authorize every table, join, subquery, CTE,
+predicate, and projection. This must be proof-based rather than best-effort:
+unsupported syntax, a dialect mismatch, dynamic identifiers, stored
+procedures, or incomplete analysis must fall back to the opaque-query decision.
+An analyzed query should also retain its text-query provenance so a platform
+policy can still forbid all custom SQL regardless of the sources it appears to
+touch.
+
+Keeping `Query` distinct from `Get` leaves a clean path for future query
+conditions such as allowed filter fields, mandatory tenant predicates,
+projections, indexes, row limits, and cost budgets. Those constraints are not
+part of the first policy version.
+
+## Security boundary
+
+Access policies protect operations routed through the secured DALgo handle.
+They are not a sandbox for hostile Go code: code that retains the raw adapter,
+opens another database connection, or accesses the network or filesystem can
+bypass the wrapper. Pass only secured handles to restricted components and use
+database IAM, process isolation, or database-native row/security rules as
+defense in depth where the threat model requires them.

--- a/spec/README.md
+++ b/spec/README.md
@@ -4,6 +4,17 @@ This directory contains the specification for [DALgo](https://github.com/dal-go/
 
 The specification format follows [SpecScore](https://specscore.md).
 
+## Scope Boundary
+
+This specification tree covers DALgo source code, public Go APIs, runtime
+behavior, compatibility, and code-level verification only.
+
+It MUST NOT be used to specify the separate [dalgo.io](https://dalgo.io/)
+website, including its content, information architecture, visual design,
+marketing, deployment, or other website implementation. Website work may link
+to DALgo code specifications for technical facts, but remains a separate
+product deliverable outside this `spec/` tree.
+
 ## Open Questions
 
 None at this time.

--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -33,6 +33,7 @@ The Feature format follows [SpecScore](https://specscore.md/feature-specificatio
 | [collection-generated-insert](collection-generated-insert/README.md) | Approved | — |
 | [typed-collection-extras](typed-collection-extras/README.md) | Approved | — |
 | [dalgo2namecheap-namecheap-api-adapter](dalgo2namecheap-namecheap-api-adapter/README.md) | Approved | — |
+| [access-policies](access-policies/README.md) | Stable | — |
 
 ## Open Questions
 

--- a/spec/features/access-policies/README.md
+++ b/spec/features/access-policies/README.md
@@ -1,0 +1,542 @@
+---
+format: https://specscore.md/feature-specification
+status: Stable
+---
+
+# Feature: Hierarchical access and audit policies
+
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies?op=request-change) |
+**Status:** Stable
+**Date:** 2026-07-17
+**Owner:** alex
+**Source Ideas:** access-policies
+
+## Summary
+
+Add portable, adapter-independent access policies to DALgo. A secured `dal.DB` enforces named, hierarchical rules over logical DAL paths for point reads, queries, mutations, and the reserved `TRUNCATE` operation. Database-bound policies and context-bound capabilities compose by intersection. The same hierarchy also supports an independent audit-selection decision so applications can record mutations to sensitive collections while excluding the audit-log collection itself.
+
+The product promise is: **define least privilege once and enforce it across every DALgo adapter.**
+
+## Problem
+
+DALgo currently provides a common API for records, queries, and transactions, but a component receiving a `dal.DB` or transaction receives all authority exposed by that handle. Applications with extensions, plug-ins, tenants, background jobs, analytics users, or support tooling must rely on convention to keep code inside an allowed subtree. A mistake can write a root collection, enumerate sensitive records, or query data outside the current tenant.
+
+Database-native security systems do not solve this portably: Firestore rules, PostgreSQL row-level security, filesystem permissions, and in-memory test databases expose different models. Applications either duplicate authorization per backend or lose the boundary when switching adapters and in tests.
+
+Auditing has a related path-selection problem. Applications need to record selected mutations (for example changes to `users` and `transactions`) without recursively recording writes to the audit-log collection. Reusing one deterministic path and operation matcher avoids a second policy language while keeping access authorization and audit selection independent.
+
+## Design Principles
+
+- **Capability boundary, not validation hook.** Enforcement wraps DAL interfaces before an adapter sees an operation.
+- **Least privilege is explicit.** Write never implies read; `Get`, `Exists`, and `Query` are distinct.
+- **Hierarchical and order-independent.** A more specific rule overrides an inherited rule within the same policy; declaration order has no effect.
+- **Monotonic composition.** Adding another policy can only remove authority.
+- **Fail closed.** Missing matches, unknown operations, opaque queries, and ambiguous rules are denied.
+- **Explainable.** Named policies and matched rules are available in denial errors and decision explanations.
+- **Adapter-independent.** Policies reason over DAL keys and structured queries, not backend-native path strings or SQL text.
+
+## Behavior
+
+### REQ: operation-vocabulary
+
+The access-policy package MUST define separate leaf operations for `Get`, `Exists`, `Query`, `Insert`, `Set`, `Update`, `Delete`, and `Truncate`. It MUST expose convenience groups equivalent to `Read = Get + Exists + Query`, `Write = Insert + Set + Update + Delete + Truncate`, and `ReadWrite = Read + Write`. Granting any leaf or group MUST grant exactly its member operations: in particular, write MUST NOT imply read and query MUST NOT imply get.
+
+`Truncate` MUST be available for policy construction and direct policy evaluation even though `dal.WriteSession` does not yet expose a truncate method. Adding a future DAL truncate capability MUST reuse this operation rather than changing existing policy meaning.
+
+#### AC-1: write-only-insert
+
+**Given** a policy that allows only `Insert` under `/logs/*`
+**When** `Insert`, `Get`, `Query`, `Update`, `Delete`, and `Truncate` requests for `/logs/entry-1` are evaluated
+**Then** only the `Insert` request is allowed.
+
+#### AC-2: get-without-query
+
+**Given** a policy that allows `Get` but not `Query` under `/secrets/*`
+**When** a point-get request and a collection-query request are evaluated for `secrets`
+**Then** the point get is allowed and the query is denied.
+
+#### AC-3: truncate-is-reserved
+
+**Given** a policy that explicitly allows `Truncate` on the `stagingEvents` collection
+**When** a truncate request for that collection is evaluated directly through the policy API
+**Then** the request is allowed without requiring `dal.WriteSession` to expose a truncate method.
+
+### REQ: structural-path-patterns
+
+Policies MUST match structural DAL paths rather than escaped path strings. A path pattern MUST support literal collection names, literal record IDs, an any-ID matcher, record paths, terminal collection paths, and inherited subtree matching. The package MUST provide explicit constructors for collection-group and opaque-query resources; neither resource kind may match an ordinary path rule accidentally.
+
+#### AC-1: typed-id-and-slash-safe
+
+**Given** a policy path containing a literal ID whose value contains `/`
+**When** a DAL key with the same unescaped ID is evaluated
+**Then** it matches structurally without parsing or splitting the ID value.
+
+#### AC-2: terminal-collection-rule
+
+**Given** a rule attached to the collection path `/spaces/*/ext/trackus/events`
+**When** a query of that collection and an insert of a record directly in that collection are evaluated
+**Then** both resources match the collection rule and an unrelated sibling collection does not.
+
+### REQ: hierarchical-policy-precedence
+
+Within one policy, decisions MUST inherit into descendant paths. The matching rule with the greatest path depth MUST win; at equal depth a rule with more literal segments MUST outrank one with more wildcard segments; if equally specific rules conflict, deny MUST win. Rule declaration order MUST NOT affect the result. A child allow MAY reopen a subtree denied by its parent within that same policy, and a child deny MAY carve a subtree out of a parent allow.
+
+Policy construction MUST reject malformed path shapes. It MUST reject any remaining ambiguity that cannot be resolved by depth, literal specificity, and deny-on-tie.
+
+#### AC-1: allowed-parent-denied-child
+
+**Given** one policy that allows `ReadWrite` under `/ext/trackus/**` and denies `Delete` under `/ext/trackus/audit/**`
+**When** delete requests target `/ext/trackus/items/i1` and `/ext/trackus/audit/a1`
+**Then** the items deletion is allowed and the audit deletion is denied.
+
+#### AC-2: denied-parent-reopened-children
+
+**Given** one policy that denies `Read` under `/spaces/*/**` and allows `Read` under `/spaces/*/ext/trackus/**`
+**When** reads target a space root, the trackus subtree, and a sibling extension subtree
+**Then** only the read in the trackus subtree is allowed.
+
+#### AC-3: order-independent
+
+**Given** two policies containing identical hierarchical rules in opposite declaration orders
+**When** the same set of requests is evaluated against each policy
+**Then** every request receives the same decision from both policies.
+
+### REQ: database-and-context-composition
+
+A secured database MUST accept zero or more database-bound policies and MUST also read zero or more policies from `context.Context`. Every applicable policy MUST independently allow every resource in a request; a denial from any policy MUST deny the request. A context policy MUST therefore be unable to reopen a resource denied by a database policy. The wrapper MUST offer an option that requires at least one context-bound policy and denies operations when none is present.
+
+The package MUST support binding the policies currently carried by a context to a secured database handle so that later use of a different operation context cannot discard those captured restrictions. Additional policies supplied by a later operation context MUST narrow the captured authority further.
+
+#### AC-1: context-cannot-widen-global
+
+**Given** a database policy denying writes under `/system/**` and a context policy allowing writes under `/system/public/**`
+**When** a write to `/system/public/item-1` is attempted through the secured database
+**Then** the write is denied before the underlying adapter is called.
+
+#### AC-2: bound-policy-survives-context-replacement
+
+**Given** a secured database bound to an extension policy allowing only `/ext/trackus/**`
+**When** code uses that bound handle with `context.Background()` to write `/users/u1`
+**Then** the write remains denied.
+
+#### AC-3: required-context-policy
+
+**Given** a secured database configured to require a context policy
+**When** a read or transaction is started with a context carrying no access policy
+**Then** it fails with an access-denied error before the adapter operation or transaction begins.
+
+### REQ: portable-policy-documents
+
+Access and audit policies MUST have a versioned, storage-neutral document representation. YAML MUST be the canonical human-authored format and JSON MUST encode the same document model without semantic differences. The document MUST carry an API version, policy kind (`AccessPolicy` or `AuditPolicy`), name, default effect, hierarchical scopes, operation groups or leaf operations, and named rules.
+
+The package MUST provide YAML and JSON marshal/unmarshal helpers for byte slices and encode/decode helpers over `io.Writer` and `io.Reader`; these APIs MUST NOT require filesystem paths. Decoding MUST validate the complete document before returning a policy and MUST reject unknown API versions, unknown operations/effects, malformed paths, mixed access/audit effects, and ambiguous rules. Encoding a policy that contains a custom callback or another non-declarative rule MUST return a descriptive not-serializable error.
+
+The codec boundary MUST be extensible so another package can add HCL or a storage-specific encoding without changing policy evaluation. Native HCL parsing and expression evaluation are not required by this Feature.
+
+#### AC-1: yaml-roundtrip
+
+**Given** a hierarchical access policy document in YAML containing parent deny and child allow scopes
+**When** it is decoded, evaluated, encoded to YAML, and decoded again
+**Then** both decoded policies return identical decisions and explanations for the same request table.
+
+#### AC-2: json-has-identical-semantics
+
+**Given** one versioned policy document represented once as YAML and once as JSON
+**When** both representations are decoded
+**Then** they produce equivalent policy names, rules, defaults, and decisions.
+
+#### AC-3: storage-neutral-streams
+
+**Given** a policy document stored in an in-memory buffer, object-store response body, database blob, or file
+**When** its bytes are exposed through `io.Reader` and decoded, or a policy is encoded through `io.Writer`
+**Then** the codec succeeds without inspecting or requiring the underlying storage type or path.
+
+#### AC-4: invalid-or-future-document-rejected
+
+**Given** a document with an unknown API version, operation, effect, or malformed path
+**When** it is decoded
+**Then** decoding returns a descriptive validation error and no executable policy.
+
+### REQ: complete-session-enforcement
+
+The secured DAL wrapper MUST authorize all current read and write session methods: `Exists`, `Get`, `GetMulti`, both query-executor methods, `Set`, `SetMulti`, `Insert`, `InsertMulti`, `Update`, `UpdateRecord`, `UpdateMulti`, `Delete`, and `DeleteMulti`. `GetMulti` and every multi-mutation MUST preflight every resource and MUST call the adapter zero times when any resource is denied.
+
+The wrapper MUST expose secured read-session, write-session, read-transaction, and read-write-transaction handles without exposing the wrapped raw session through a public accessor.
+
+#### AC-1: every-leaf-method-enforced
+
+**Given** a recording session and a policy that denies all resources
+**When** each read-session and write-session leaf method is invoked through its secured wrapper
+**Then** every method returns an access-denied error and the recording session observes no delegated operation.
+
+#### AC-2: batch-preflight-is-all-or-nothing
+
+**Given** a three-record batch where the first and third resources are allowed and the second is denied
+**When** any secured multi-operation is invoked
+**Then** the call is denied and the adapter receives none of the three resources.
+
+### REQ: transaction-capability-capture
+
+`RunReadonlyTransaction` and `RunReadwriteTransaction` MUST capture the effective policies at transaction start, pass a secured transaction to the worker, and replace any transaction stored in the worker context with that secured transaction. Every operation on the transaction MUST enforce the captured policies even when supplied another context. Transaction retry behavior and options MUST continue to be delegated to the adapter.
+
+#### AC-1: readwrite-transaction-is-secured
+
+**Given** a context policy allowing writes only under `/ext/trackus/**`
+**When** a read-write transaction worker tries an allowed insert and then a forbidden root write using `context.Background()`
+**Then** the worker receives a secured transaction, the allowed insert reaches the adapter, and the root write is denied.
+
+#### AC-2: context-transaction-is-secured
+
+**Given** an adapter that stores its raw transaction in the worker context
+**When** the secured transaction worker calls `dal.GetTransaction(workerContext)`
+**Then** it receives the secured transaction rather than the adapter's raw transaction.
+
+### REQ: generated-insert-authorization
+
+An insert whose record key has no ID yet MUST be authorized against its parent and target collection before adapter-native or DALgo ID generation. An any-ID collection rule MAY authorize it. A rule that requires a specific record ID MUST NOT authorize an incomplete-key insert. Adapter-internal collision checks MUST NOT require the caller to hold `Exists` or `Get` permission.
+
+#### AC-1: generated-id-under-allowed-collection
+
+**Given** an insert-only policy for `/logs/*` and an incomplete key for the `logs` collection
+**When** an insert with an ID generator is performed through a secured write session
+**Then** the insert reaches the adapter without read permission and the adapter may assign the ID.
+
+#### AC-2: exact-id-does-not-match-incomplete-key
+
+**Given** a policy allowing insert only at `/jobs/fixed-id`
+**When** an incomplete-key insert into `jobs` is attempted
+**Then** it is denied before ID generation.
+
+### REQ: structured-query-enforcement
+
+`Get`, `Exists`, and `Query` MUST remain independently authorizable. For a `dal.StructuredQuery`, the secured query executor MUST authorize the base source and every joined source before execution. Parent-scoped collections MUST be represented by their full logical collection path. A collection-group query MUST require an explicit matching collection-group rule. A non-structured or otherwise opaque query MUST require an explicit opaque-query rule and MUST NOT be authorized by inspecting query text. A query filter alone MUST NOT make an otherwise forbidden source authorized.
+
+#### AC-1: query-only-does-not-grant-get
+
+**Given** a policy that allows only `Query` on `/events`
+**When** the caller queries `events` and separately gets `/events/e1`
+**Then** the query is allowed and the point get is denied.
+
+#### AC-2: every-join-source-authorized
+
+**Given** a policy allowing query of `users` but not `transactions`
+**When** a structured query joins `users` to `transactions`
+**Then** the query is denied before the adapter executes it.
+
+#### AC-3: collection-group-is-explicit
+
+**Given** a path rule allowing queries under one tenant subtree but no collection-group rule
+**When** a collection-group query targets a collection with the same name
+**Then** the query is denied.
+
+#### AC-4: opaque-query-is-explicit
+
+**Given** a policy containing only structural path rules
+**When** a `dal.TextQuery` or another non-structured query is executed
+**Then** it is denied without attempting to infer resources from its text.
+
+### REQ: denial-errors-and-explanations
+
+Denied operations MUST return an error matching an exported sentinel through `errors.Is`. The concrete error MUST expose the operation, safe resource description, denying policy name, and an explanation of the winning or missing rule. Policies MUST support side-effect-free direct evaluation suitable for unit tests and tooling.
+
+Unknown or invalid operation values MUST be denied. A future DALgo release MUST NOT silently grant a newly introduced operation through an existing compiled policy group.
+
+#### AC-1: denial-is-inspectable
+
+**Given** a named policy denying update of `/users/u1`
+**When** that update is attempted
+**Then** the returned error matches `ErrAccessDenied` and exposes `Update`, `/users/u1`, the policy name, and the matched deny rule.
+
+#### AC-2: unknown-operation-denied
+
+**Given** an operation value unknown to the policy implementation
+**When** it is evaluated against a policy allowing `ReadWrite`
+**Then** it is denied rather than inheriting a broad permission group.
+
+### REQ: hierarchical-audit-selection
+
+The package MUST provide an audit-selection policy using the same operations, resources, wildcard matching, hierarchy, specificity, and order-independence as access authorization. Its effects MUST be independent `Audit` and `IgnoreAudit` decisions, with default `IgnoreAudit`. Access `Allow`/`Deny` rules MUST NOT change audit selection, and audit rules MUST NOT grant or deny access.
+
+The audit selector MUST be usable without a database and MUST return a structured explanation. Persisting, transporting, redacting, or retrying audit events is outside this Feature.
+
+#### AC-1: audit-selected-mutations
+
+**Given** an audit policy that audits `Write` under `/users/**` and `/transactions/**`
+**When** get, insert, update, delete, and truncate requests are classified for those resources
+**Then** the mutation requests are selected for audit and the get request is ignored.
+
+#### AC-2: audit-log-recursion-carveout
+
+**Given** an audit policy that audits all mutations and more specifically ignores mutations under `/auditLog/**`
+**When** writes to `/users/u1` and `/auditLog/a1` are classified
+**Then** the users write is selected and the audit-log write is ignored.
+
+#### AC-3: audit-does-not-authorize
+
+**Given** an access policy denying writes and an audit policy selecting the same writes
+**When** a write is authorized and separately classified for audit
+**Then** authorization remains denied while audit classification reports that the denied attempt is selected.
+
+### REQ: compatibility-and-threat-boundary
+
+Existing unwrapped `dal.DB` and session implementations MUST retain their current behavior. The access package MUST introduce no adapter dependency and MUST work with the built-in memory adapter. Documentation MUST state that code holding the raw adapter, a native database client, or another unrestricted handle can bypass a DALgo wrapper; the capability boundary covers operations routed through secured DALgo handles and is not an in-process sandbox.
+
+#### AC-1: unwrapped-suite-remains-green
+
+**Given** the existing DALgo test suite
+**When** the access-policy package is added without wrapping existing database constructors
+**Then** existing tests and unwrapped database behavior remain unchanged.
+
+#### AC-2: memory-adapter-roundtrip
+
+**Given** the built-in memory adapter wrapped with an extension policy
+**When** allowed and forbidden reads, writes, batches, and transactions are exercised
+**Then** allowed operations preserve the adapter's results and forbidden operations never mutate or disclose the forbidden resources.
+
+## Acceptance Criteria
+
+### AC: write-only-insert (verifies REQ:operation-vocabulary)
+
+**Given** a policy that allows only `Insert` under `/logs/*`
+**When** insert, get, query, update, delete, and truncate requests for `/logs/entry-1` are evaluated
+**Then** only the insert request is allowed.
+
+### AC: get-without-query (verifies REQ:operation-vocabulary)
+
+**Given** a policy that allows `Get` but not `Query` under `/secrets/*`
+**When** a point-get request and a collection-query request are evaluated for `secrets`
+**Then** the point get is allowed and the query is denied.
+
+### AC: truncate-is-reserved (verifies REQ:operation-vocabulary)
+
+**Given** a policy that explicitly allows `Truncate` on the `stagingEvents` collection
+**When** a truncate request for that collection is evaluated directly through the policy API
+**Then** the request is allowed without requiring `dal.WriteSession` to expose a truncate method.
+
+### AC: typed-id-and-slash-safe (verifies REQ:structural-path-patterns)
+
+**Given** a policy path containing a literal ID whose value contains `/`
+**When** a DAL key with the same unescaped ID is evaluated
+**Then** it matches structurally without parsing or splitting the ID value.
+
+### AC: terminal-collection-rule (verifies REQ:structural-path-patterns)
+
+**Given** a rule attached to the collection path `/spaces/*/ext/trackus/events`
+**When** a query of that collection and an insert of a record directly in that collection are evaluated
+**Then** both resources match the collection rule and an unrelated sibling collection does not.
+
+### AC: allowed-parent-denied-child (verifies REQ:hierarchical-policy-precedence)
+
+**Given** one policy that allows `ReadWrite` under `/ext/trackus/**` and denies `Delete` under `/ext/trackus/audit/**`
+**When** delete requests target `/ext/trackus/items/i1` and `/ext/trackus/audit/a1`
+**Then** the items deletion is allowed and the audit deletion is denied.
+
+### AC: denied-parent-reopened-children (verifies REQ:hierarchical-policy-precedence)
+
+**Given** one policy that denies `Read` under `/spaces/*/**` and allows `Read` under `/spaces/*/ext/trackus/**`
+**When** reads target a space root, the trackus subtree, and a sibling extension subtree
+**Then** only the read in the trackus subtree is allowed.
+
+### AC: order-independent (verifies REQ:hierarchical-policy-precedence)
+
+**Given** two policies containing identical hierarchical rules in opposite declaration orders
+**When** the same set of requests is evaluated against each policy
+**Then** every request receives the same decision from both policies.
+
+### AC: context-cannot-widen-global (verifies REQ:database-and-context-composition)
+
+**Given** a database policy denying writes under `/system/**` and a context policy allowing writes under `/system/public/**`
+**When** a write to `/system/public/item-1` is attempted through the secured database
+**Then** the write is denied before the underlying adapter is called.
+
+### AC: bound-policy-survives-context-replacement (verifies REQ:database-and-context-composition)
+
+**Given** a secured database bound to an extension policy allowing only `/ext/trackus/**`
+**When** code uses that bound handle with `context.Background()` to write `/users/u1`
+**Then** the write remains denied.
+
+### AC: required-context-policy (verifies REQ:database-and-context-composition)
+
+**Given** a secured database configured to require a context policy
+**When** a read or transaction is started with a context carrying no access policy
+**Then** it fails with an access-denied error before the adapter operation or transaction begins.
+
+### AC: yaml-roundtrip (verifies REQ:portable-policy-documents)
+
+**Given** a hierarchical access policy document in YAML containing parent deny and child allow scopes
+**When** it is decoded, evaluated, encoded to YAML, and decoded again
+**Then** both decoded policies return identical decisions and explanations for the same request table.
+
+### AC: json-has-identical-semantics (verifies REQ:portable-policy-documents)
+
+**Given** one versioned policy document represented once as YAML and once as JSON
+**When** both representations are decoded
+**Then** they produce equivalent policy names, rules, defaults, and decisions.
+
+### AC: storage-neutral-streams (verifies REQ:portable-policy-documents)
+
+**Given** a policy document exposed through an `io.Reader` rather than a filesystem path
+**When** it is decoded or a policy is encoded through an `io.Writer`
+**Then** the codec succeeds without inspecting or requiring the underlying storage type.
+
+### AC: invalid-or-future-document-rejected (verifies REQ:portable-policy-documents)
+
+**Given** a document with an unknown API version, operation, effect, or malformed path
+**When** it is decoded
+**Then** decoding returns a descriptive validation error and no executable policy.
+
+### AC: every-leaf-method-enforced (verifies REQ:complete-session-enforcement)
+
+**Given** a recording session and a policy that denies all resources
+**When** each read-session and write-session leaf method is invoked through its secured wrapper
+**Then** every method returns an access-denied error and the recording session observes no delegated operation.
+
+### AC: batch-preflight-is-all-or-nothing (verifies REQ:complete-session-enforcement)
+
+**Given** a three-record batch where the first and third resources are allowed and the second is denied
+**When** any secured multi-operation is invoked
+**Then** the call is denied and the adapter receives none of the three resources.
+
+### AC: readwrite-transaction-is-secured (verifies REQ:transaction-capability-capture)
+
+**Given** a context policy allowing writes only under `/ext/trackus/**`
+**When** a read-write transaction worker tries an allowed insert and then a forbidden root write using `context.Background()`
+**Then** the worker receives a secured transaction, the allowed insert reaches the adapter, and the root write is denied.
+
+### AC: context-transaction-is-secured (verifies REQ:transaction-capability-capture)
+
+**Given** an adapter that stores its raw transaction in the worker context
+**When** the secured transaction worker calls `dal.GetTransaction(workerContext)`
+**Then** it receives the secured transaction rather than the adapter's raw transaction.
+
+### AC: generated-id-under-allowed-collection (verifies REQ:generated-insert-authorization)
+
+**Given** an insert-only policy for `/logs/*` and an incomplete key for the `logs` collection
+**When** an insert with an ID generator is performed through a secured write session
+**Then** the insert reaches the adapter without read permission and the adapter may assign the ID.
+
+### AC: exact-id-does-not-match-incomplete-key (verifies REQ:generated-insert-authorization)
+
+**Given** a policy allowing insert only at `/jobs/fixed-id`
+**When** an incomplete-key insert into `jobs` is attempted
+**Then** it is denied before ID generation.
+
+### AC: query-only-does-not-grant-get (verifies REQ:structured-query-enforcement)
+
+**Given** a policy that allows only `Query` on `/events`
+**When** the caller queries `events` and separately gets `/events/e1`
+**Then** the query is allowed and the point get is denied.
+
+### AC: every-join-source-authorized (verifies REQ:structured-query-enforcement)
+
+**Given** a policy allowing query of `users` but not `transactions`
+**When** a structured query joins `users` to `transactions`
+**Then** the query is denied before the adapter executes it.
+
+### AC: collection-group-is-explicit (verifies REQ:structured-query-enforcement)
+
+**Given** a path rule allowing queries under one tenant subtree but no collection-group rule
+**When** a collection-group query targets a collection with the same name
+**Then** the query is denied.
+
+### AC: opaque-query-is-explicit (verifies REQ:structured-query-enforcement)
+
+**Given** a policy containing only structural path rules
+**When** a `dal.TextQuery` or another non-structured query is executed
+**Then** it is denied without attempting to infer resources from its text.
+
+### AC: denial-is-inspectable (verifies REQ:denial-errors-and-explanations)
+
+**Given** a named policy denying update of `/users/u1`
+**When** that update is attempted
+**Then** the returned error matches `ErrAccessDenied` and exposes `Update`, `/users/u1`, the policy name, and the matched deny rule.
+
+### AC: unknown-operation-denied (verifies REQ:denial-errors-and-explanations)
+
+**Given** an operation value unknown to the policy implementation
+**When** it is evaluated against a policy allowing `ReadWrite`
+**Then** it is denied rather than inheriting a broad permission group.
+
+### AC: audit-selected-mutations (verifies REQ:hierarchical-audit-selection)
+
+**Given** an audit policy that audits `Write` under `/users/**` and `/transactions/**`
+**When** get, insert, update, delete, and truncate requests are classified for those resources
+**Then** the mutation requests are selected for audit and the get request is ignored.
+
+### AC: audit-log-recursion-carveout (verifies REQ:hierarchical-audit-selection)
+
+**Given** an audit policy that audits all mutations and more specifically ignores mutations under `/auditLog/**`
+**When** writes to `/users/u1` and `/auditLog/a1` are classified
+**Then** the users write is selected and the audit-log write is ignored.
+
+### AC: audit-does-not-authorize (verifies REQ:hierarchical-audit-selection)
+
+**Given** an access policy denying writes and an audit policy selecting the same writes
+**When** a write is authorized and separately classified for audit
+**Then** authorization remains denied while audit classification reports that the denied attempt is selected.
+
+### AC: unwrapped-suite-remains-green (verifies REQ:compatibility-and-threat-boundary)
+
+**Given** the existing DALgo test suite
+**When** the access-policy package is added without wrapping existing database constructors
+**Then** existing tests and unwrapped database behavior remain unchanged.
+
+### AC: memory-adapter-roundtrip (verifies REQ:compatibility-and-threat-boundary)
+
+**Given** the built-in memory adapter wrapped with an extension policy
+**When** allowed and forbidden reads, writes, batches, and transactions are exercised
+**Then** allowed operations preserve the adapter's results and forbidden operations never mutate or disclose forbidden resources.
+
+## Architecture
+
+The implementation adds a top-level `access` package that imports `dal` and implements secured wrappers around DAL interfaces. Keeping it outside `dal` avoids import cycles and keeps the core interfaces unchanged. The package contains:
+
+- Operation and operation-group definitions.
+- Structural `Resource` and hierarchical path-pattern types.
+- Declarative access and audit policies compiled from shared scope rules.
+- Context policy attachment and binding.
+- Secured DB/session/transaction/query wrappers.
+- Typed denial and explanation values.
+
+No adapter is modified. Adapter conformance follows from wrappers delegating only after policy evaluation.
+
+## Error Handling and Failure Modes
+
+- No matching access rule: deny with `ErrAccessDenied`.
+- Explicit winning deny: deny with named policy/rule explanation.
+- Missing required context capability: deny before transaction or operation delegation.
+- One denied batch resource: deny the entire batch before delegation.
+- Unsupported/opaque query without an explicit special-resource rule: deny.
+- Invalid path or conflicting unresolvable rule construction: constructor error; `Must...` convenience may panic.
+- Audit selection with no match: ignore.
+- Audit selection errors never change access authorization because the decisions are evaluated independently.
+
+## Testing Strategy
+
+- Pure table tests for operations, structural paths, specificity, wildcard ties, access effects, and audit effects.
+- Recording fake sessions to prove every DAL method is preflighted and batches are all-or-nothing.
+- Fake transaction coordinators to prove policy capture, retry delegation, options, and context transaction replacement.
+- Built-in `dalgo2memory` integration tests for allowed/denied round trips and generated inserts.
+- Structured-query tests covering parent collections, joins, collection groups, and opaque queries.
+- `errors.Is` and explanation-field tests.
+- Existing full suite for compatibility.
+- Static-site link/content checks plus responsive browser verification for DALgo.io.
+
+## Out of Scope
+
+- Adding `Truncate` to `dal.WriteSession` or implementing truncate in adapters.
+- Field-level response redaction or record-content predicates.
+- Query constraints over `WHERE`, projection, ordering, grouping, aggregates, indexes, limits, or cost. The separate `Query` operation and structured request preserve room for these follow-ups.
+- Automatically injecting tenant predicates into a query.
+- Persisting audit records, choosing an audit schema, delivery guarantees, redaction, retention, or sink-failure semantics.
+- A built-in filesystem repository or database table for policy documents; codecs operate on bytes and streams supplied by the caller.
+- Native HCL support, variables, functions, interpolation, or expression evaluation. HCL can be implemented later through the codec boundary if a concrete consumer needs it.
+- Protecting access that bypasses DALgo through a raw adapter or native client.
+- Treating policies as a substitute for database IAM, network controls, encryption, or hostile plug-in sandboxing.
+
+## Open Questions
+
+None at this time.
+
+---
+*This document follows the https://specscore.md/feature-specification*

--- a/spec/ideas/README.md
+++ b/spec/ideas/README.md
@@ -12,6 +12,7 @@ The Idea format follows [SpecScore](https://specscore.md/idea-specification).
 
 | Idea | Status | Date | Owner | Promotes To |
 |------|--------|------|-------|-------------|
+| [access-policies](access-policies.md) | Implemented | 2026-07-17 | alex | access-policies |
 | [concurrency-capability](concurrency-capability.md) | Approved | 2026-05-12 | alex | — |
 | [dal-records-reader-iter-seq](dal-records-reader-iter-seq.md) | Draft | 2026-05-15 | alex | — |
 | [dalgo-dialect-aware-sql-emission](dalgo-dialect-aware-sql-emission.md) | Draft | 2026-05-15 | alex | — |

--- a/spec/ideas/access-policies.md
+++ b/spec/ideas/access-policies.md
@@ -1,0 +1,109 @@
+---
+format: https://specscore.md/idea-specification
+status: Implemented
+---
+
+# Idea: Portable hierarchical access policies
+
+**Status:** Implemented
+**Date:** 2026-07-17
+**Owner:** alex
+**Promotes To:** access-policies
+**Supersedes:** —
+**Related Ideas:** —
+
+## Problem Statement
+
+How might DALgo let applications grant least-privilege data capabilities once and enforce them consistently across every adapter, transaction, batch, and query?
+
+## Context
+
+DALgo gives the same `dal.DB` and transaction API to code using Firestore,
+SQL, memory, files, or Git-backed storage, but today that handle carries the
+full authority of its adapter. In an extension host such as Sneat, a module
+that should write only beneath `/ext/<id>/...` or
+`/spaces/<space-id>/ext/<id>/...` can accidentally mutate a root collection.
+The convention is neither enforced in production nor reproduced reliably by
+the in-memory test adapter.
+
+The same gap affects tenant-scoped services, ingestion endpoints, analytics,
+and support tools. A logger may need insert-only access; a support tool may be
+allowed to get a known record but forbidden to enumerate the collection; an
+analytics tool such as DataTug may need query-only access today and constrained
+fields, predicates, projections, or indexes later.
+
+## Recommended Direction
+
+Add hierarchical, adapter-independent policies over structural DAL paths and explicit operations. Compose database and context policies by intersection, keep read/write/query permissions independent, reuse the matcher for audit selection, and serialize declarative policies as versioned YAML or JSON through storage-neutral codecs.
+
+Within one policy, the most-specific path wins, enabling both common shapes:
+
+```text
+Allow /spaces/*/**
+  Deny /spaces/*/private/**
+
+Deny /spaces/*/**
+  Allow /spaces/*/ext/trackus/**
+```
+
+Separate policies intersect, so a context capability can narrow but never
+reopen a database-level denial. Operations remain explicit: `Get`, `Exists`,
+`Query`, `Insert`, `Set`, `Update`, `Delete`, and reserved `Truncate`. Thus an
+append-only log can allow only `Insert`, while a known-key secret store can
+allow `Get` and deny `Query`.
+
+The same hierarchy can classify audit events with independent verbs:
+
+```text
+Audit mutations under /users/** and /transactions/**
+Ignore mutations under /auditLog/**
+```
+
+YAML is the canonical authored format, JSON represents the same versioned data
+model, and codecs operate on streams or bytes rather than filesystem paths so
+policies can live in object storage, a database, Git, embedded assets, or files.
+
+## Alternatives Considered
+
+- **Application checks and save hooks.** Too easy to omit, do not cover reads or
+  every batch/query path, and vary between adapters.
+- **Database-native security only.** Strong as defense in depth but not portable
+  across DALgo adapters and absent from in-memory tests.
+- **Deny always wins at every ancestor.** Simple but prevents useful
+  `Deny(path).Allow(subpaths...)` policies. Most-specific-wins inside one policy
+  plus intersection between policies preserves both hierarchy and hard bounds.
+- **HCL as the primary document format.** Attractive for a configuration
+  language, but expressions, variables, functions, and evaluation contexts add
+  semantics the policy model does not need. A codec extension can add HCL when
+  a concrete consumer requires it.
+
+## MVP Scope
+
+A secured DALgo wrapper; Get, Exists, Query, Insert, Set, Update, Delete, and reserved Truncate operations; hierarchical allow/deny; context capture; batch and transaction enforcement; explicit collection-group and opaque-query handling; audit/ignore classification; YAML and JSON codecs.
+
+## Not Doing (and Why)
+
+- Database-native IAM or hostile plug-in sandboxing — the boundary covers operations routed through secured DALgo handles.
+- Audit persistence and delivery guarantees — the MVP classifies events but leaves sinks to applications.
+- Field-level and WHERE/index-aware query constraints — the operation model preserves room for follow-up features.
+
+## Key Assumptions to Validate
+
+| Tier | Assumption | How to validate |
+|------|------------|-----------------|
+| Must-be-true | Every DAL session and transaction operation can be intercepted without adapter changes. | Wrap the public DAL interfaces and prove delegation/denial with recording fakes and `dalgo2memory`. |
+| Must-be-true | Hierarchical precedence is deterministic and declaration-order independent. | Evaluate reversed rule tables, wildcard ties, and parent/child overrides. |
+| Must-be-true | Context restrictions cannot be discarded inside a transaction. | Capture policies at transaction start and verify operations using `context.Background()` remain restricted. |
+| Should-be-true | One declarative document model round-trips through YAML and JSON. | Decode equivalent fixtures and compare decisions and explanations. |
+| Might-be-true | Query policies will grow field, predicate, projection, index, and cost constraints. | Preserve `Query` as a distinct operation and the structured query on the authorization request. |
+
+
+## SpecScore Integration
+
+- **New Features this would create:** [access-policies](../features/access-policies/README.md)
+- **Existing Features affected:** none
+- **Dependencies:** none
+
+## Open Questions
+
+None at this time.

--- a/spec/plans/2026-06-05-qualified-orderby-resolution.md
+++ b/spec/plans/2026-06-05-qualified-orderby-resolution.md
@@ -19,7 +19,7 @@ The Feature is one comparator used at two call sites, so the order is build-then
 ### Task 1: Shared source-aware multi-key comparator, adopted by the join executor
 
 **Verifies:** qualified-orderby-resolution#ac:join-orders-by-qualified-key, qualified-orderby-resolution#ac:orders-by-multiple-keys, qualified-orderby-resolution#ac:tiebreak-no-order-by, qualified-orderby-resolution#ac:tiebreak-all-keys-equal
-**Status:** done
+**Status:** complete
 
 Build one ordering routine that resolves each `ORDER BY` `FieldRef` to its recordset (empty `Source()` -> base; non-empty -> the source whose `Alias()`/`Name()` matches, reusing the join WHERE resolver), stably sorts rows key-by-key in declared order honoring each `Descending()` via the existing `compare()`, and falls back to ascending base record id. Replace the join executor's base-id-only `sort.SliceStable` with it.
 
@@ -27,7 +27,7 @@ Build one ordering routine that resolves each `ORDER BY` `FieldRef` to its recor
 
 **Verifies:** qualified-orderby-resolution#ac:unresolvable-order-source-errors, qualified-orderby-resolution#ac:non-field-order-key-ignored
 **Depends-On:** 1
-**Status:** done
+**Status:** complete
 
 Validate the resolved `ORDER BY` keys before sorting (since the sort callback cannot return an error): an `ORDER BY` `FieldRef` whose non-empty source names no recordset returns a descriptive error and no rows, while a non-`FieldRef` expression is skipped as an ordering key with the remaining keys and base-id tiebreak still applied.
 
@@ -35,7 +35,7 @@ Validate the resolved `ORDER BY` keys before sorting (since the sort callback ca
 
 **Verifies:** qualified-orderby-resolution#ac:single-source-order-unchanged, qualified-orderby-resolution#ac:single-source-unresolvable-order-source
 **Depends-On:** 1
-**Status:** done
+**Status:** complete
 
 Route `ExecuteQueryToRecordsReader` through the shared comparator and remove `sortRows`, resolving an empty/base-matching `Source()` against the single base recordset so existing unqualified ordering (ascending and descending) is unchanged, and a non-empty source that matches neither the base alias nor name errors — the same rule as joins.
 

--- a/spec/plans/2026-06-05-query-column-projection.md
+++ b/spec/plans/2026-06-05-query-column-projection.md
@@ -19,7 +19,7 @@ The Feature is a builder capability plus an executor that honors it, so the orde
 ### Task 1: SelectColumns terminal on dal.QueryBuilder
 
 **Verifies:** query-column-projection#ac:select-columns-recorded
-**Status:** done
+**Status:** complete
 
 Add `SelectColumns(columns ...dal.Column) dal.StructuredQuery` to `QueryBuilder` and the `IQueryBuilder` interface, recording the ordered column list on the `StructuredQuery` via `newQuery()` (mirroring the existing `Select*` terminals), so `Columns()` returns them while queries built by any other terminal report an empty `Columns()`.
 
@@ -27,7 +27,7 @@ Add `SelectColumns(columns ...dal.Column) dal.StructuredQuery` to `QueryBuilder`
 
 **Verifies:** query-column-projection#ac:single-source-projection, query-column-projection#ac:join-projection-qualified, query-column-projection#ac:empty-columns-unchanged
 **Depends-On:** 1
-**Status:** done
+**Status:** complete
 
 When `q.Columns()` is non-empty, project each result row of both `ExecuteQueryToRecordsReader` (single-source) and `executeJoinQuery` (join) to a `map[string]any` with one entry per selected column, keyed by its `Alias` (falling back to the field name) and resolved via the shared per-source resolver (empty `Source()` -> base; alias/name -> source, collision-correct), bypassing the keys-only `IntoRecord()==nil` branch. An empty `Columns()` leaves the existing full-record output unchanged.
 
@@ -35,7 +35,7 @@ When `q.Columns()` is non-empty, project each result row of both `ExecuteQueryTo
 
 **Verifies:** query-column-projection#ac:unknown-column-source-errors, query-column-projection#ac:non-field-column-errors
 **Depends-On:** 2
-**Status:** done
+**Status:** complete
 
 Validate the selected columns before producing rows: a column whose `FieldRef` names a non-empty source matching no recordset, or whose expression is not a `FieldRef`, returns a descriptive error and no rows — consistent with the `WHERE`/`ORDER BY` unresolvable-source behavior.
 

--- a/spec/plans/2026-06-05-query-group-by-aggregation.md
+++ b/spec/plans/2026-06-05-query-group-by-aggregation.md
@@ -19,21 +19,21 @@ The Feature is a builder capability plus an executor that consumes it, so the or
 ### Task 1: GroupBy builder method on dal.QueryBuilder
 
 **Verifies:** query-group-by-aggregation#ac:group-by-recorded
-**Status:** done
+**Status:** complete
 
 Add a chainable `GroupBy(expressions ...dal.Expression) dal.IQueryBuilder` to `QueryBuilder` and the `IQueryBuilder` interface, appending to `structuredQuery.groupBy` exactly as `OrderBy` appends to `orderBy`, so `GroupBy()` returns the expressions while a query on which `GroupBy` was never called reports an empty `GroupBy()`.
 
 ### Task 2: Having clause — getter, field, builder, and String() rendering
 
 **Verifies:** query-group-by-aggregation#ac:having-recorded-and-rendered
-**Status:** done
+**Status:** complete
 
 Add `Having() dal.Condition` to `StructuredQuery`, a `having Condition` field on `structuredQuery`, and a `Having(conditions ...dal.Condition) dal.IQueryBuilder` builder method that AND-combines multiple conditions like `Where`; render the `HAVING` clause in `structuredQuery.String()` immediately after the `GROUP BY` block.
 
 ### Task 3: COUNT(*) star expression and Count() builder
 
 **Verifies:** query-group-by-aggregation#ac:count-star-expressible
-**Status:** done
+**Status:** complete
 
 Add a star/row `Expression` to the `dal` query model and a `Count()` builder defined as an alias for `Count(*)`, rendering as `COUNT(*)` in `String()`, while the existing `CountAs(field, alias)` keeps its field-count semantics.
 
@@ -41,7 +41,7 @@ Add a star/row `Expression` to the `dal` query model and a `Count()` builder def
 
 **Verifies:** query-group-by-aggregation#ac:single-source-grouping-with-aggregates, query-group-by-aggregation#ac:all-null-group-aggregates-null, query-group-by-aggregation#ac:empty-groupby-unchanged
 **Depends-On:** 1, 3
-**Status:** done
+**Status:** complete
 
 When `q.GroupBy()` is non-empty, partition the WHERE-matched rows into groups keyed by the ordered group-key tuple (resolved via the shared per-source resolver) and emit one row per group, evaluating `SUM`/`COUNT`/`MIN`/`MAX`/`AVG`/`COUNT(*)` with standard SQL null handling (skip nulls; `AVG` divides by non-null count; all-null `SUM`/`AVG`/`MIN`/`MAX` yield `null`; `COUNT(*)` counts all rows) reusing the existing `number()` coercion; an empty `GroupBy()` bypasses the path entirely, leaving today's behavior unchanged.
 
@@ -49,7 +49,7 @@ When `q.GroupBy()` is non-empty, partition the WHERE-matched rows into groups ke
 
 **Verifies:** query-group-by-aggregation#ac:non-grouped-select-column-errors
 **Depends-On:** 4
-**Status:** done
+**Status:** complete
 
 Before emitting any group row, reject a grouped query whose SELECT contains a column that is neither an aggregate function expression nor one of the group-by expressions, returning a descriptive error and no rows — consistent with the eager hard-reject `validateColumns` already applies.
 
@@ -57,7 +57,7 @@ Before emitting any group row, reject a grouped query whose SELECT contains a co
 
 **Verifies:** query-group-by-aggregation#ac:having-filters-by-alias, query-group-by-aggregation#ac:having-filters-by-aggregate-expression, query-group-by-aggregation#ac:having-on-unselected-aggregate
 **Depends-On:** 2, 4
-**Status:** done
+**Status:** complete
 
 When `q.Having()` is non-nil, evaluate it as a post-aggregation filter over each group's aggregated row and drop failing groups; resolve a `HAVING` operand by either the SELECT alias bound to an aggregate or the aggregate expression itself (both yielding the same per-group value), computing an aggregate referenced only in `HAVING` over the group without adding it to the output row.
 
@@ -65,7 +65,7 @@ When `q.Having()` is non-nil, evaluate it as a post-aggregation filter over each
 
 **Verifies:** query-group-by-aggregation#ac:grouped-order-and-limit
 **Depends-On:** 4
-**Status:** done
+**Status:** complete
 
 For a grouped query, apply `ORDER BY`, `LIMIT`, and `OFFSET` to the post-`HAVING` group rows rather than to the pre-grouping input rows, so ordering and limiting operate on the aggregated result set.
 
@@ -73,7 +73,7 @@ For a grouped query, apply `ORDER BY`, `LIMIT`, and `OFFSET` to the post-`HAVING
 
 **Verifies:** query-group-by-aggregation#ac:join-grouping-qualified
 **Depends-On:** 4
-**Status:** done
+**Status:** complete
 
 Route `executeJoinQuery` through the same grouping/aggregation pass so group keys and aggregate inputs can reference qualified sources (e.g. `u.country`), reusing the join's existing source-aware resolver, emitting one aggregated row per distinct group across the joined rows.
 

--- a/spec/plans/2026-06-05-query-joins.md
+++ b/spec/plans/2026-06-05-query-joins.md
@@ -19,42 +19,42 @@ Tasks follow the build-dependency chain: the AST must express a qualified, typed
 ### Task 1: Source-qualified `NewFieldRef(src, name)` and call-site migration
 
 **Verifies:** query-joins#ac:qualified-field-carries-source, query-joins#ac:existing-single-source-unaffected
-**Status:** done
+**Status:** complete
 
 Add a source qualifier to `dal.FieldRef` and change the constructor to `NewFieldRef(src, name string)` with a `Source()` accessor; an empty `src` denotes the `From` base. Migrate the in-module constructor call sites — the `Field`/`AscendingField`/`DescendingField` wrappers in `dal` and `dtql/deserialize.go` — and update `dal` tests, leaving the full `dal` + `dtql` + `dalgo2memory` suites green so existing single-source queries are unaffected.
 
 ### Task 2: Join-type enum on `JoinedSource`
 
 **Verifies:** query-joins#ac:join-type-readable
-**Status:** done
+**Status:** complete
 
 Introduce an exported join-type value (e.g. `dal.JoinType` with `JoinInner` and `JoinLeft`, leaving room for `RIGHT`/`FULL`/`CROSS`) carried on each `JoinedSource` and readable through its public API, so an INNER join is distinguishable from a LEFT join in the AST.
 
 ### Task 3: Public `NewJoinedSource` constructor with value-readable `On()`
 
 **Verifies:** query-joins#ac:build-join-from-outside-dal
-**Status:** done
+**Status:** complete
 
 Add an exported `NewJoinedSource(src RecordsetSource, joinType JoinType, on ...Condition)` constructor, and make a join readable by value (a value receiver on `On()` or have `Joins()` return addressable joins) so a caller outside `dal` can build a typed equi-join with a populated `ON` clause and read back its type and conditions without touching unexported fields.
 
 ### Task 4: `dalgo2memory` INNER nested-loop join with qualified resolution
 
 **Verifies:** query-joins#ac:inner-join-matches-only, query-joins#ac:qualified-resolution-in-where
-**Status:** done
+**Status:** complete
 
 Extend `dalgo2memory` to walk `From().Joins()` and execute an INNER equi-join over the two in-memory collections via nested loop, returning only matched pairs. Add the qualified-field resolver — empty `src` → `From` base, non-empty `src` → the joined source whose `Alias()`/`Name()` matches — and apply it when evaluating `ON`, `Where`, `Columns`, and `OrderBy`.
 
 ### Task 5: `dalgo2memory` LEFT join with null-filled right side
 
 **Verifies:** query-joins#ac:left-join-keeps-unmatched-left
-**Status:** done
+**Status:** complete
 
 Add LEFT semantics on top of Task 4's resolver and loop: emit every `From`-base row, with the joined source's fields present where the `ON` equality holds and absent/`nil` where no right row matches.
 
 ### Task 6: `dalgo2memory` error paths for unsupported and unresolvable shapes
 
 **Verifies:** query-joins#ac:unsupported-join-errors, query-joins#ac:unresolvable-source-errors
-**Status:** done
+**Status:** complete
 
 Return descriptive, row-suppressing errors when `dalgo2memory` meets a join type it does not support (anything other than INNER/LEFT, including a chained second join) or a non-empty field `src` that matches no recordset in the query, rather than silently producing wrong or empty results.
 

--- a/spec/plans/2026-06-06-columnar-mixed-mode-maps.md
+++ b/spec/plans/2026-06-06-columnar-mixed-mode-maps.md
@@ -19,7 +19,7 @@ The columnar engine already has the typed-column slices, slot/free-list model, t
 ### Task 1: Map-backed selection, declared-column option, and type enforcement
 
 **Verifies:** columnar-mixed-mode-maps#ac:mixed-mode-requires-declared-column, columnar-mixed-mode-maps#ac:declared-value-wrong-type-errors
-**Status:** done
+**Status:** complete
 
 Lift the struct-only restriction so `WithColumnarStorage` builds a columnar engine for a `map[string]any` collection from explicitly declared columns; selecting it with no declared column fails with a descriptive error. Add the declared-column `ColumnOption` (name + element type) and make a written declared value that cannot be stored as the declared type a descriptive write error that stores nothing for that record.
 
@@ -27,7 +27,7 @@ Lift the struct-only restriction so `WithColumnarStorage` builds a columnar engi
 
 **Verifies:** columnar-mixed-mode-maps#ac:declared-field-removed-from-leftover, columnar-mixed-mode-maps#ac:leftover-holds-undeclared-fields, columnar-mixed-mode-maps#ac:slot-stays-synced-through-delete-and-compaction
 **Depends-On:** 1
-**Status:** done
+**Status:** complete
 
 Store each declared column in its typed slice (removing the declared key from the record) and retain every undeclared field in a parallel `leftover []map[string]any` indexed by the same per-row slot. Wire the leftover store into slot allocation, tombstone delete, slot reuse, and compaction so a row's declared cells and its leftover map are always moved or freed together.
 
@@ -35,7 +35,7 @@ Store each declared column in its typed slice (removing the declared key from th
 
 **Verifies:** columnar-mixed-mode-maps#ac:read-reconstructs-full-record, columnar-mixed-mode-maps#ac:where-on-declared-column-accelerated, columnar-mixed-mode-maps#ac:where-on-leftover-field-scans
 **Depends-On:** 2
-**Status:** done
+**Status:** complete
 
 Reassemble `Get`/query rows by overlaying each declared column's slot value onto a copy of the slot's leftover map, yielding the full `map[string]any` with each key exactly once. Route an equality `WHERE` on a declared column through that column's `ColumnStrategy` and an equality `WHERE` on a leftover field through the scan fall-back; both results identical to the Serialized engine.
 
@@ -43,7 +43,7 @@ Reassemble `Get`/query rows by overlaying each declared column's slot value onto
 
 **Verifies:** columnar-mixed-mode-maps#ac:mixed-mode-parity-and-fidelity
 **Depends-On:** 2
-**Status:** done
+**Status:** complete
 
 Confirm declared columns inherit the hybrid write + fidelity opt-out, the leftover map's values are deep-copied under the faithful default (post-write caller mutation does not affect stored data), and `Set`/`Insert`/`Delete`/`Update` outcomes match the Serialized engine for the same `map[string]any` data.
 

--- a/spec/plans/2026-06-06-columnar-storage.md
+++ b/spec/plans/2026-06-06-columnar-storage.md
@@ -19,7 +19,7 @@ The columnar engine is the largest piece, so it is built bottom-up: representati
 ### Task 1: WithColumnarStorage selection (typed-only)
 
 **Verifies:** columnar-storage#ac:columnar-requires-typed-collection
-**Status:** done
+**Status:** complete
 
 Add the `WithColumnarStorage(...ColumnOption)` `CollectionOption` that selects the columnar engine for a schema-registered `WithCollection[T]` collection, and make selection on a schemaless/undefined collection fail with a descriptive error.
 
@@ -27,7 +27,7 @@ Add the `WithColumnarStorage(...ColumnOption)` `CollectionOption` that selects t
 
 **Verifies:** columnar-storage#ac:columns-are-typed-slices, columnar-storage#ac:slot-stable-across-columns
 **Depends-On:** 1
-**Status:** done
+**Status:** complete
 
 Derive one column per JSON-serializable field of `T` via reflection, storing each in a slice typed to the field's Go type (`[]any` fallback for interface/heterogeneous fields), all indexed by a single shared per-row slot; map each record id to a slot that stays stable for the record's lifetime.
 
@@ -35,7 +35,7 @@ Derive one column per JSON-serializable field of `T` via reflection, storing eac
 
 **Verifies:** columnar-storage#ac:write-breaks-refs-by-default, columnar-storage#ac:fidelity-opt-out-toggles-ref-breaking
 **Depends-On:** 2
-**Status:** done
+**Status:** complete
 
 On write, store scalar/value columns by direct assignment and deep-copy reference-bearing columns via a serialization round-trip so stored data shares no references with caller values by default; add a schema-wide option and a per-collection option to disable ref-breaking (per-collection overriding schema-wide), defaulting to faithful.
 
@@ -43,7 +43,7 @@ On write, store scalar/value columns by direct assignment and deep-copy referenc
 
 **Verifies:** columnar-storage#ac:parity-with-serialized-ops
 **Depends-On:** 2
-**Status:** done
+**Status:** complete
 
 Ensure `Set` overwrites, `Insert` on an existing id errors without overwriting, `Get`/`Update` on an absent id return not-found, and an `Update` naming a field undefined on `T` is rejected — matching the Serialized engine's outcomes exactly (representational differences only).
 
@@ -51,7 +51,7 @@ Ensure `Set` overwrites, `Insert` on an existing id errors without overwriting, 
 
 **Verifies:** columnar-storage#ac:delete-tombstones-and-hides, columnar-storage#ac:compaction-preserves-live-records
 **Depends-On:** 2
-**Status:** done
+**Status:** complete
 
 `Delete` marks a slot dead and frees it for reuse while keeping other slots stable, and a tombstoned slot never appears in `Get`/`Exists`/queries; when the dead-slot fraction crosses a threshold, compaction reclaims dead slots under the global write lock, preserving every live record and its values without exposing partial state to readers.
 
@@ -59,7 +59,7 @@ Ensure `Set` overwrites, `Insert` on an existing id errors without overwriting, 
 
 **Verifies:** columnar-storage#ac:get-and-query-reassemble, columnar-storage#ac:columnar-query-matches-serialized
 **Depends-On:** 3, 5
-**Status:** done
+**Status:** complete
 
 Reassemble each live row from its per-column slot values into a `map[string]any` field view and a typed materialization for `Get`/`IntoRecord`/factory targets, with no shared references between rows; verify that the supported single equality `WHERE` predicate plus projection and `ORDER BY`/`LIMIT` (and join) return results identical in content and order to an equivalent Serialized collection.
 
@@ -67,7 +67,7 @@ Reassemble each live row from its per-column slot values into a `map[string]any`
 
 **Verifies:** columnar-storage#ac:strategy-interface-exported, columnar-storage#ac:default-strategy-scans-column
 **Depends-On:** 2
-**Status:** done
+**Status:** complete
 
 Define and export a `ColumnStrategy` interface (write side to set/clear a value at a slot; equality read side returning matching live slots or "no opinion") and a per-column option to supply one; implement the default typed-slice strategy that answers equality by scanning comparable columns (Go `==`, as in `matchesWhere`) and may return "no opinion" for non-comparable `[]any` columns — proving an external package can plug in without a core dependency.
 
@@ -75,7 +75,7 @@ Define and export a `ColumnStrategy` interface (write side to set/clear a value 
 
 **Verifies:** columnar-storage#ac:where-uses-strategy, columnar-storage#ac:where-falls-back-on-no-opinion
 **Depends-On:** 6, 7
-**Status:** done
+**Status:** complete
 
 For the single `field == value` predicate the adapter supports, consult the target column's `ColumnStrategy` and use its returned slot set to select candidate rows (the read side returns a set so future multi-predicate `AND` can intersect), falling back to scanning on "no opinion"; the result is identical to the Serialized engine's for the same query.
 
@@ -83,7 +83,7 @@ For the single `field == value` predicate the adapter supports, consult the targ
 
 **Verifies:** columnar-storage#ac:columnar-passes-race
 **Depends-On:** 5, 8
-**Status:** done
+**Status:** complete
 
 Run the columnar engine under the existing single global write lock with `go test -race`, interleaving reads with writes, deletes, and a compaction, confirming no data race is reported and results remain correct.
 

--- a/spec/plans/2026-06-06-serialized-storage.md
+++ b/spec/plans/2026-06-06-serialized-storage.md
@@ -19,7 +19,7 @@ The Serialized engine's behavior already exists in the codebase and is extracted
 ### Task 1: serializedEngine type, byte representation, and default/schemaless role
 
 **Verifies:** serialized-storage#ac:stored-as-decodable-bytes, serialized-storage#ac:serialized-is-default-and-schemaless-capable
-**Status:** done
+**Status:** complete
 **Notes:** Builds on the seam plan's Task 3, which extracts the engine.
 
 Formalize the `serializedEngine` implementing `storageEngine`, with a compile-time `var _ storageEngine = (*serializedEngine)(nil)` assertion, storing each record as a serialized (JSON) byte buffer keyed by id and reconstructing by decoding. Confirm it is the engine resolved for the default/`WithSerializedStorage()` selection and that it supports both schema-typed and schemaless collections.
@@ -28,7 +28,7 @@ Formalize the `serializedEngine` implementing `storageEngine`, with a compile-ti
 
 **Verifies:** serialized-storage#ac:mutation-after-write-isolated, serialized-storage#ac:two-reads-independent, serialized-storage#ac:non-serializable-write-errors
 **Depends-On:** 1
-**Status:** done
+**Status:** complete
 
 Pin the fidelity contract: because records are stored as bytes and decoded afresh, mutating a caller value after a write does not affect stored data, two reads of one record are mutually independent, and a write of a non-serializable value fails with a descriptive error set on the record while storing nothing for that id.
 
@@ -36,7 +36,7 @@ Pin the fidelity contract: because records are stored as bytes and decoded afres
 
 **Verifies:** serialized-storage#ac:unknown-field-rejected-when-typed, serialized-storage#ac:insert-duplicate-errors
 **Depends-On:** 1
-**Status:** done
+**Status:** complete
 
 Lock the write rules: for a schema-typed collection a write/update carrying a field undefined on the type is rejected with a descriptive error naming the collection (no check for schemaless collections), `Insert` on an existing id returns an "already exists" error without overwriting, and `Set` overwrites; both validate before storing so a rejected write leaves storage unchanged.
 
@@ -44,7 +44,7 @@ Lock the write rules: for a schema-typed collection a write/update carrying a fi
 
 **Verifies:** serialized-storage#ac:get-absent-not-found, serialized-storage#ac:query-decodes-rows, serialized-storage#ac:update-applies-and-revalidates
 **Depends-On:** 1
-**Status:** done
+**Status:** complete
 
 Cover reads and updates: `Get` on an absent id returns a not-found error set on the record while `Exists` reports false; query execution exposes decoded `map[string]any` views and typed materializations with no shared references between result records; and `Update` reads-modifies-writes the decoded data, re-runs the unknown-field check for typed collections, and returns not-found (storing nothing) on an absent id.
 

--- a/spec/plans/2026-06-06-storage-engine-seam.md
+++ b/spec/plans/2026-06-06-storage-engine-seam.md
@@ -19,7 +19,7 @@ The seam is an interface plus a refactor, so the order is define-the-contract, a
 ### Task 1: Define the storageEngine interface
 
 **Verifies:** storage-engine-seam#ac:engine-interface-defined
-**Status:** done
+**Status:** complete
 
 Declare an internal `storageEngine` interface owning per-collection store-by-id (insert/overwrite), exists-by-id, load-by-id-into-record, delete-by-id, update-by-id (decoded field updates, not bytes), and row enumeration. Enumeration yields each row as a `map[string]any` field view plus a typed-materialization path, with no parameter or return type that is a serialized byte representation.
 
@@ -27,7 +27,7 @@ Declare an internal `storageEngine` interface owning per-collection store-by-id 
 
 **Verifies:** storage-engine-seam#ac:withcollection-options-backward-compatible
 **Depends-On:** 1
-**Status:** done
+**Status:** complete
 
 Introduce an exported `CollectionOption` type and `WithSerializedStorage()` option, and extend `WithCollection[T]` to `WithCollection[T](name, newRecord, opts ...CollectionOption)` so existing 2-arg calls compile unchanged with `newRecord` keeping its `func() *T` type. Record the selected engine on the collection definition so `WithSchema` carries it into the database.
 
@@ -35,7 +35,7 @@ Introduce an exported `CollectionOption` type and `WithSerializedStorage()` opti
 
 **Verifies:** storage-engine-seam#ac:operations-succeed-through-engine, storage-engine-seam#ac:no-byte-map-on-database, storage-engine-seam#ac:default-is-serialized, storage-engine-seam#ac:unregistered-collection-is-serialized
 **Depends-On:** 2
-**Status:** done
+**Status:** complete
 
 Replace `database.collections map[string]map[string][]byte` with a per-collection engine registry, extracting today's JSON marshal/unmarshal/`checkUnknownFields`/insert-guard/not-found logic into a default `serializedEngine` that implements the interface. Make every `database`/`session` operation (`Exists`, `Get`/`GetMulti`, `Set`/`SetMulti`, `Insert`/`InsertMulti`, `Delete`/`DeleteMulti`, `Update`/`UpdateRecord`/`UpdateMulti`, both query paths) delegate to the target collection's engine, resolving the Serialized default for any unregistered or option-less collection so observable behavior is unchanged.
 
@@ -43,7 +43,7 @@ Replace `database.collections map[string]map[string][]byte` with a per-collectio
 
 **Verifies:** storage-engine-seam#ac:mixed-engines-in-one-db, storage-engine-seam#ac:existing-suite-green
 **Depends-On:** 3
-**Status:** done
+**Status:** complete
 
 Support distinct engines per collection within one `database`, each routing through its own engine instance with no cross-collection interference, and confirm the default and `WithSerializedStorage()` paths are observably identical to pre-Feature behavior. The full existing `dalgo2memory` test suite passes unchanged and statement coverage remains 100%.
 

--- a/spec/plans/access-policies.md
+++ b/spec/plans/access-policies.md
@@ -1,0 +1,78 @@
+---
+format: https://specscore.md/plan-specification
+status: Approved
+---
+
+# Plan: Implement hierarchical access policies
+
+**Status:** Implemented
+**Source Feature:** access-policies
+**Date:** 2026-07-17
+**Owner:** alex
+**Supersedes:** —
+
+## Summary
+
+Implement the `access-policies` Feature in seven bottom-up tasks: vocabulary and matching, access/audit decisions, portable documents, context composition, secured sessions, secured transactions and queries, and integration hardening. Each task is independently testable and every Feature acceptance criterion is assigned.
+
+## Approach
+
+Build the pure policy engine before wrappers so precedence and explanations are stable and easy to test. Then wrap leaf sessions, followed by DB transaction coordination and query-source analysis, so no adapter changes are required. Finish with memory-adapter integration. Audit scope is deliberately classification-only: it reuses the matcher but does not introduce an audit persistence subsystem.
+
+## Tasks
+
+### Task 1: Operation vocabulary and structural resources
+
+**Verifies:** access-policies#ac:write-only-insert, access-policies#ac:get-without-query, access-policies#ac:truncate-is-reserved, access-policies#ac:typed-id-and-slash-safe, access-policies#ac:terminal-collection-rule
+**Status:** complete
+
+Add leaf operations and immutable convenience groups, including reserved `Truncate`. Add record, collection, collection-group, and opaque-query resources plus typed path patterns supporting literal IDs, `AnyID`, and terminal collections.
+
+### Task 2: Hierarchical access and audit policy engine
+
+**Verifies:** access-policies#ac:allowed-parent-denied-child, access-policies#ac:denied-parent-reopened-children, access-policies#ac:order-independent, access-policies#ac:denial-is-inspectable, access-policies#ac:unknown-operation-denied, access-policies#ac:audit-selected-mutations, access-policies#ac:audit-log-recursion-carveout, access-policies#ac:audit-does-not-authorize
+**Status:** complete
+
+Compile nested scopes into deterministic rules; implement deepest/literal specificity and deny/ignore tie-breaking; expose direct decisions, typed denial errors, and independent audit classification with explanations.
+
+### Task 3: Versioned YAML and JSON policy documents
+
+**Verifies:** access-policies#ac:yaml-roundtrip, access-policies#ac:json-has-identical-semantics, access-policies#ac:storage-neutral-streams, access-policies#ac:invalid-or-future-document-rejected
+**Status:** complete
+
+Define one declarative document model for access and audit policies, implement strict versioned validation, YAML/JSON bytes and stream codecs, and a codec extension boundary that does not couple loading to files or another storage system.
+
+### Task 4: Database and context policy composition
+
+**Verifies:** access-policies#ac:context-cannot-widen-global, access-policies#ac:bound-policy-survives-context-replacement, access-policies#ac:required-context-policy
+**Status:** complete
+
+Add context attachment, database-bound policies, bound-context capture, monotonic intersection, and the require-context option.
+
+### Task 5: Complete secured read/write sessions
+
+**Verifies:** access-policies#ac:every-leaf-method-enforced, access-policies#ac:batch-preflight-is-all-or-nothing, access-policies#ac:generated-id-under-allowed-collection, access-policies#ac:exact-id-does-not-match-incomplete-key
+**Status:** complete
+
+Wrap every current read and write leaf method, preflight whole batches, preserve return values, and authorize incomplete-key inserts at their target collection without requiring read permission.
+
+### Task 6: Secured transactions and structured queries
+
+**Verifies:** access-policies#ac:readwrite-transaction-is-secured, access-policies#ac:context-transaction-is-secured, access-policies#ac:query-only-does-not-grant-get, access-policies#ac:every-join-source-authorized, access-policies#ac:collection-group-is-explicit, access-policies#ac:opaque-query-is-explicit
+**Status:** complete
+
+Capture effective policies at transaction start, pass secured transactions and contexts, preserve options/retries, and authorize every structured query source while keeping collection-group and opaque-query grants explicit.
+
+### Task 7: Memory-adapter integration and compatibility hardening
+
+**Verifies:** access-policies#ac:unwrapped-suite-remains-green, access-policies#ac:memory-adapter-roundtrip
+**Status:** complete
+
+Exercise allowed and forbidden point, batch, generated-insert, query, and transaction flows through `dalgo2memory`; run the full DALgo suite and fix wrapper compatibility without changing unwrapped behavior.
+
+## Open Questions
+
+None at this time.
+
+---
+*This document follows the https://specscore.md/plan-specification*

--- a/spec/plans/collection-generated-insert.md
+++ b/spec/plans/collection-generated-insert.md
@@ -24,7 +24,7 @@ Adapter first, terminal second: wire `dalgo2memory` to honor `InsertOption` so g
 
 **Verifies:** collection-generated-insert#ac:memory-generates-via-insert-option, collection-generated-insert#ac:generation-precedes-storage
 **Depends-On:** —
-**Status:** done
+**Status:** complete
 
 Extend `dalgo2memory`'s write path so that when `NewInsertOptions(opts...).IDGenerator()` is non-nil it runs `dal.InsertWithIdGenerator` (supplying an `exists` predicate over the engine and an `insert` callback), generating the id and retrying on collision BEFORE computing the storage key. On generator exhaustion return the generator's error with nothing persisted. This also makes raw `session.Insert(ctx, record, gen)` work, fixing the latent no-op.
 
@@ -32,7 +32,7 @@ Extend `dalgo2memory`'s write path so that when `NewInsertOptions(opts...).IDGen
 
 **Verifies:** collection-generated-insert#ac:generated-insert-returns-key, collection-generated-insert#ac:generated-insert-explicit-option, collection-generated-insert#ac:generator-not-accepted-elsewhere
 **Depends-On:** 1
-**Status:** done
+**Status:** complete
 
 Add `Insert(ctx, WriteSession, value T, opts ...dal.InsertOption) (*dal.Key, error)` to `dal.Collection[T]`: build a record with an incomplete key from the handle's `CollectionRef`, inject the default `WithRandomStringKey(dal.DefaultRandomStringIDLength, 5)` when `opts` is empty, forward to `WriteSession.Insert`, and return the assigned key. Confirm (signature + negative-compile example) that only the bare `Insert` accepts `InsertOption`, so generators cannot reach `InsertWithID`/`Get`/`Set`/`Update`/`Delete`.
 
@@ -40,7 +40,7 @@ Add `Insert(ctx, WriteSession, value T, opts ...dal.InsertOption) (*dal.Key, err
 
 **Verifies:** collection-generated-insert#ac:loud-failure-on-nonhonoring-adapter
 **Depends-On:** 2
-**Status:** done
+**Status:** complete
 
 After the underlying insert returns nil error, have `Insert` assert the record's key id is non-nil/non-empty and otherwise return a descriptive error (e.g. an exported sentinel), so generated `Insert` fails loudly on an adapter that ignores `InsertOption` instead of reporting a `<nil>`-id success. Test with a stub `WriteSession` that drops the option.
 
@@ -48,7 +48,7 @@ After the underlying insert returns nil error, have `Insert` assert the record's
 
 **Verifies:** collection-generated-insert#ac:e2e-generated-insert-roundtrip
 **Depends-On:** 3
-**Status:** done
+**Status:** complete
 
 Add a `dalgo2memory`-specific test (NOT the shared gomock-driven `TestDalgoDB`) exercising generated `Insert` with both the zero-option default and an explicit `WithRandomStringKey`, asserting a complete assigned key is returned and the record round-trips via `Get`; confirm the existing shared `TestDalgoDB` suite stays green.
 

--- a/spec/plans/typed-collection-extras.md
+++ b/spec/plans/typed-collection-extras.md
@@ -24,7 +24,7 @@ Each terminal is independent (it adds one method/interface on the existing `Coll
 
 **Verifies:** typed-collection-extras#ac:item-type-no-record-import, typed-collection-extras#ac:insert-many-roundtrips
 **Depends-On:** —
-**Status:** done
+**Status:** complete
 
 Define `dal.Item[K comparable, T any]{ ID K; Value T }` (no `record` import) and the `dal.ManyInserter[K, T]` interface; implement `InsertMany(ctx, WriteSession, items ...Item[K, T]) ([]*dal.Key, error)` on the concrete `Collection[K, T]` by building `[]dal.Record` from each item's complete key (`Item.ID` + the handle's `CollectionRef`) and delegating to the session's `MultiInserter` (falling back to per-item `Inserter.Insert`), returning keys in input order.
 
@@ -32,7 +32,7 @@ Define `dal.Item[K comparable, T any]{ ID K; Value T }` (no `record` import) and
 
 **Verifies:** typed-collection-extras#ac:count-returns-total, typed-collection-extras#ac:count-unsupported
 **Depends-On:** —
-**Status:** done
+**Status:** complete
 
 Implement `Count(ctx, ReadSession) (int, error)` building a count aggregation `StructuredQuery` over the handle's `CollectionRef` and running it via the `ReadSession` query executor; surface `dal.ErrNotSupported` from incapable backends rather than a silent `0`.
 
@@ -40,7 +40,7 @@ Implement `Count(ctx, ReadSession) (int, error)` building a count aggregation `S
 
 **Verifies:** typed-collection-extras#ac:exists-true-false, typed-collection-extras#ac:exists-error-passthrough
 **Depends-On:** —
-**Status:** done
+**Status:** complete
 
 Implement `Exists(ctx, ReadSession, id K) (bool, error)` as a key-only probe: build the key from the typed `id K` + the handle's `CollectionRef`, call the session getter, and map a not-found error to `(false, nil)`, any other error to `(false, err)`, and success to `(true, nil)`.
 
@@ -48,7 +48,7 @@ Implement `Exists(ctx, ReadSession, id K) (bool, error)` as a key-only probe: bu
 
 **Verifies:** typed-collection-extras#ac:first-returns-or-empty, typed-collection-extras#ac:first-unsupported
 **Depends-On:** —
-**Status:** done
+**Status:** complete
 
 Implement `First(ctx, ReadSession) (T, bool, error)` building a limit-1 `StructuredQuery` over the `CollectionRef` with a `new(T)` factory; return `(value, true, nil)` for a non-empty collection, `(zero T, false, nil)` for an empty one, and surface `dal.ErrNotSupported` from incapable backends.
 

--- a/spec/plans/typed-collection.md
+++ b/spec/plans/typed-collection.md
@@ -24,7 +24,7 @@ Build bottom-up in package `dal`: first the interface, constructors, and session
 
 **Verifies:** typed-collection#ac:construct-by-convention, typed-collection#ac:construct-by-explicit-name, typed-collection#ac:write-needs-write-session
 **Depends-On:** —
-**Status:** done
+**Status:** complete
 
 Define `dal.Collection[T]` (read methods take `ReadSession`, write methods take `WriteSession`), the `CollectionNamer` interface, the unexported impl composing a `dal.CollectionRef`, and the `CollectionOf[T CollectionNamer]()` / `CollectionAt[T any](name)` constructors. Add a negative-compile example proving a write terminal rejects a plain `DB`.
 
@@ -32,7 +32,7 @@ Define `dal.Collection[T]` (read methods take `ReadSession`, write methods take 
 
 **Verifies:** typed-collection#ac:key-options-on-constructor
 **Depends-On:** 1
-**Status:** done
+**Status:** complete
 
 Internal `idToKey(id K)` helper turning the typed `id K` argument into a `*dal.Key` from the handle's `CollectionRef`: it sets `Key.ID = id`, then applies the collection's configured key options (`dal.WithKeyOptions(...)`, e.g. `WithFields`/parent) via `setKeyOptions`, and guards the parent chain. Shared by every `*ByID` terminal.
 
@@ -40,7 +40,7 @@ Internal `idToKey(id K)` helper turning the typed `id K` argument into a `*dal.K
 
 **Verifies:** typed-collection#ac:typed-get-roundtrip, typed-collection#ac:get-not-found
 **Depends-On:** 2
-**Status:** done
+**Status:** complete
 
 Implement `Get(ctx, ReadSession, id) (T, error)` by wrapping `new(T)` in a record and calling the session getter, returning the decoded value. Map the session call's not-found error to `(zero T, err)` without consulting `record.Error()`/`record.Exists()`.
 
@@ -48,7 +48,7 @@ Implement `Get(ctx, ReadSession, id) (T, error)` by wrapping `new(T)` in a recor
 
 **Verifies:** typed-collection#ac:typed-all-distinct, typed-collection#ac:all-unsupported-surfaces-error
 **Depends-On:** 2
-**Status:** done
+**Status:** complete
 
 Implement `All(ctx, ReadSession) ([]T, error)` building a `StructuredQuery` over the handle's `CollectionRef` with a per-row `new(T)` factory so results never alias; surface `dal.ErrNotSupported` from backends that cannot run the query.
 
@@ -56,7 +56,7 @@ Implement `All(ctx, ReadSession) ([]T, error)` building a `StructuredQuery` over
 
 **Verifies:** typed-collection#ac:insert-with-id-returns-key, typed-collection#ac:set-upserts
 **Depends-On:** 2
-**Status:** done
+**Status:** complete
 
 Implement `InsertWithID(ctx, WriteSession, id, value) (*dal.Key, error)` and `Set(ctx, WriteSession, id, value) error`, delegating to the session `Inserter`/`Setter` with a record built from the resolved key; `InsertWithID` returns that key. Also add the free function `dal.InsertRecordWithDataAndID[K, D](ctx, s, key, id, data) (dal.RecordWithDataAndID[K, D], error)` — the write twin of `GetRecordWithIDIntoData` — which inserts a caller-supplied (possibly interface) data value and returns the typed wrapper.
 
@@ -64,7 +64,7 @@ Implement `InsertWithID(ctx, WriteSession, id, value) (*dal.Key, error)` and `Se
 
 **Verifies:** typed-collection#ac:update-applies-fields, typed-collection#ac:delete-removes
 **Depends-On:** 2
-**Status:** done
+**Status:** complete
 
 Implement `Update(ctx, WriteSession, id, updates []update.Update, preconditions ...dal.Precondition) error` and `Delete(ctx, WriteSession, id) error`, delegating to the session `Updater`/`Deleter` with the resolved key.
 
@@ -72,7 +72,7 @@ Implement `Update(ctx, WriteSession, id, updates []update.Update, preconditions 
 
 **Verifies:** typed-collection#ac:nested-get, typed-collection#ac:nested-incomplete-parent-errors
 **Depends-On:** 3
-**Status:** done
+**Status:** complete
 
 Implement `In(parent *dal.Key) dal.Collection[T]` composing the `CollectionRef` parent chain (one level). A terminal on a handle scoped under an incomplete parent key returns a descriptive error rather than panicking.
 
@@ -80,7 +80,7 @@ Implement `In(parent *dal.Key) dal.Collection[T]` composing the `CollectionRef` 
 
 **Verifies:** typed-collection#ac:additive-suite-stays-green
 **Depends-On:** 7
-**Status:** done
+**Status:** complete
 
 Confirm the layer is additive: run the full pre-existing `dal` + `dalgo2memory` + `end2end` suites and keep them green with no existing call-site changes, and add a test/assertion that `dal` still does not import the `record` package.
 
@@ -88,7 +88,7 @@ Confirm the layer is additive: run the full pre-existing `dal` + `dalgo2memory` 
 
 **Verifies:** typed-collection#ac:get-record-and-with-id
 **Depends-On:** 3
-**Status:** done
+**Status:** complete
 
 Add `GetRecord(ctx, ReadSession, id K) (dal.Record, error)` as the read primitive the other read accessors delegate to. Add the typed id accessors `GetRecordWithID(...) (dal.RecordWithID[K], error)` and `GetRecordWithDataAndID(...) (dal.RecordWithDataAndID[K, *T], error)` as `Collection` methods, plus the free function `dal.GetRecordWithIDIntoData[K, D](ctx, s, key, id, data) (dal.RecordWithDataAndID[K, D], error)` for interface/factory data (decoding into a caller-supplied value). Keep `record.GetWithID` as a deprecated thin forwarder to `Collection.GetRecordWithID`. All surface the session not-found error.
 


### PR DESCRIPTION
## What changed

- adds hierarchical, adapter-independent access and audit policies
- enforces global and context-bound capabilities across sessions, batches, queries, and transactions
- adds YAML/JSON policy codecs and explainable denial errors
- adds SpecScore Idea, Feature, and implementation Plan artifacts
- documents access policies in the root README and dedicated repository guide

## Why

Extensions, tenants, jobs, analytics, and support tools need a portable least-privilege boundary that works consistently across every DALgo adapter and in-memory tests.

## Validation

- `access` package: 100.0% statement coverage
- `go test -race ./access`
- `go test ./...`
- `go vet ./...`
- `specscore spec lint --caller codex`
