### PR TITLE
fix: synchronize memory engine initialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,4 @@ jobs:
     with:
       code_coverage: true
       min_test_coverage_percent: 100
+      additional_go_test_path: -race ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,6 @@ jobs:
       COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
     with:
       code_coverage: true
+      cgo_enabled: true
       min_test_coverage_percent: 100
       additional_go_test_path: -race ./...

--- a/adapters/dalgo2memory/database.go
+++ b/adapters/dalgo2memory/database.go
@@ -36,7 +36,11 @@ type database struct {
 	// live solely inside these engine instances; the engine is created lazily
 	// on first access (see database.engine).
 	collections map[string]storageEngine
-	schema      *memorySchema
+	// enginesMu serializes lazy engine initialization. Read-only transactions
+	// hold mu.RLock and therefore cannot safely initialize collections through
+	// mu without attempting an RWMutex lock upgrade.
+	enginesMu sync.Mutex
+	schema    *memorySchema
 	// schemaRefBreaking is the schema-wide columnar fidelity default (faithful
 	// unless WithoutSchemaRefBreaking was used). NewDB initializes it to true.
 	schemaRefBreaking bool

--- a/adapters/dalgo2memory/database_test.go
+++ b/adapters/dalgo2memory/database_test.go
@@ -3,7 +3,9 @@ package dalgo2memory
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/dal-go/dalgo/dal"
@@ -194,6 +196,50 @@ func TestQueryEmptyCollection(t *testing.T) {
 	record, err := reader.Next()
 	require.Nil(t, record)
 	require.ErrorIs(t, err, dal.ErrNoMoreRecords)
+}
+
+// TestConcurrentReadonlyQueriesInitializeEnginesSafely verifies that queries
+// against previously unseen collections can initialize their storage engines
+// concurrently. It is intended to run under the race detector.
+func TestConcurrentReadonlyQueriesInitializeEnginesSafely(t *testing.T) {
+	const workers = 32
+
+	db := NewDB().(*database)
+	ready := make(chan struct{}, workers)
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+
+	for i := range workers {
+		collection := fmt.Sprintf("collection-%d", i)
+		query := dal.From(dal.NewRootCollectionRef(collection, "")).NewQuery().SelectKeysOnly(reflect.String)
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- db.RunReadonlyTransaction(context.Background(), func(ctx context.Context, tx dal.ReadTransaction) error {
+				ready <- struct{}{}
+				<-start
+				reader, err := tx.ExecuteQueryToRecordsReader(ctx, query)
+				if err != nil {
+					return err
+				}
+				return reader.Close()
+			})
+		}()
+	}
+
+	for range workers {
+		<-ready
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Len(t, db.collections, workers)
 }
 
 func TestQueryHelperBranches(t *testing.T) {

--- a/adapters/dalgo2memory/schema.go
+++ b/adapters/dalgo2memory/schema.go
@@ -207,6 +207,9 @@ func (db *database) guardCollection(collection string) error {
 // unknown-field validation) is resolved alongside; callers that need the guard
 // error should call recordFactory/guardCollection first.
 func (db *database) engine(collection string) storageEngine {
+	db.enginesMu.Lock()
+	defer db.enginesMu.Unlock()
+
 	if eng, ok := db.collections[collection]; ok {
 		return eng
 	}


### PR DESCRIPTION
Fixes #96.

Lazy in-memory storage engine initialization now uses a dedicated mutex, so concurrent readonly transactions cannot write the collections map concurrently.

Adds a barrier-based regression test and runs `go test -race ./...` in CI.

Validated with `go test ./...` and `go test -race ./...`.