### PR TITLE
feat: add database branching contracts and memory provider

### DIFF
--- a/adapters/dalgo2memory/branching.go
+++ b/adapters/dalgo2memory/branching.go
@@ -105,12 +105,10 @@ func validateSerializedConfiguration(db *database) error {
 		if factoryPC == serializedEngineFactoryPC {
 			continue
 		}
-		mode := "custom"
-		configured := factory(collection, db.schema.collections[collection], db.schemaRefBreaking)
-		if _, ok := configured.(*columnarEngine); ok {
-			mode = "columnar"
-		}
-		return unsupportedEngineMode(collection, mode)
+		// A non-serialized factory is user-supplied configuration. Do not call it
+		// merely to classify the unsupported mode: constructors may have side
+		// effects or panic. An initialized engine was classified above.
+		return unsupportedEngineMode(collection, "non-serialized")
 	}
 	return nil
 }

--- a/adapters/dalgo2memory/branching.go
+++ b/adapters/dalgo2memory/branching.go
@@ -1,0 +1,321 @@
+package dalgo2memory
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"sync"
+	"sync/atomic"
+
+	"github.com/dal-go/dalgo/branching"
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/record"
+)
+
+const (
+	branchingProviderName    = "dalgo2memory"
+	branchingProviderVersion = "1"
+	branchingProviderMode    = "serialized"
+)
+
+var checkpointSequence atomic.Uint64
+
+var (
+	serializedEngineFactoryPC = reflect.ValueOf(serializedEngineFactory).Pointer()
+)
+
+// NewBranchingProvider returns the optional database branching capability for
+// dalgo2memory's default serialized storage engine.
+//
+// Columnar and custom storage engines are intentionally outside this
+// capability. Capture reports them as branching.UnsupportedError instead of
+// publishing an incomplete checkpoint.
+func NewBranchingProvider() branching.Provider {
+	return serializedBranchingProvider{}
+}
+
+type serializedBranchingProvider struct{}
+
+var _ branching.Provider = serializedBranchingProvider{}
+
+func (serializedBranchingProvider) Capability() branching.Capability {
+	return branching.Capability{
+		Provider: branchingProviderName,
+		Version:  branchingProviderVersion,
+		Mode:     branchingProviderMode,
+	}
+}
+
+func (serializedBranchingProvider) Capture(ctx context.Context, source dal.DB) (branching.Checkpoint, error) {
+	if source == nil {
+		return nil, branching.ErrNilSourceDB
+	}
+	db, ok := source.(*database)
+	if !ok {
+		return nil, &branching.UnsupportedError{
+			Provider: branchingProviderName,
+			Mode:     fmt.Sprintf("source:%T", source),
+			Reason:   "source is not a dalgo2memory database",
+		}
+	}
+	if db == nil {
+		return nil, branching.ErrNilSourceDB
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	// Every data operation acquires db.mu before reaching an engine. Taking the
+	// write lock makes record bytes stable, while enginesMu also excludes lazy
+	// collection creation by concurrent readers.
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.enginesMu.Lock()
+	defer db.enginesMu.Unlock()
+
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := validateSerializedConfiguration(db); err != nil {
+		return nil, err
+	}
+
+	snapshot := snapshotDatabase(db)
+	generation := fmt.Sprintf("%s-%d", branchingProviderName, checkpointSequence.Add(1))
+	return &serializedCheckpoint{generation: generation, snapshot: &snapshot}, nil
+}
+
+// validateSerializedConfiguration checks both engines already initialized in
+// the database and engines configured in the schema but not initialized yet.
+// Sorted collection names make an unsupported error deterministic when several
+// collections use deferred engines.
+func validateSerializedConfiguration(db *database) error {
+	for _, collection := range sortedEngineNames(db.collections) {
+		if _, ok := db.collections[collection].(*serializedEngine); !ok {
+			return unsupportedEngine(collection, db.collections[collection])
+		}
+	}
+	if db.schema == nil {
+		return nil
+	}
+	for _, collection := range sortedFactoryNames(db.schema.engines) {
+		factory := db.schema.engines[collection]
+		factoryPC := reflect.ValueOf(factory).Pointer()
+		if factoryPC == serializedEngineFactoryPC {
+			continue
+		}
+		mode := "custom"
+		configured := factory(collection, db.schema.collections[collection], db.schemaRefBreaking)
+		if _, ok := configured.(*columnarEngine); ok {
+			mode = "columnar"
+		}
+		return unsupportedEngineMode(collection, mode)
+	}
+	return nil
+}
+
+func sortedEngineNames(engines map[string]storageEngine) []string {
+	names := make([]string, 0, len(engines))
+	for name := range engines {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func sortedFactoryNames(factories map[string]engineFactory) []string {
+	names := make([]string, 0, len(factories))
+	for name := range factories {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func unsupportedEngine(collection string, engine storageEngine) error {
+	mode := "custom"
+	if _, ok := engine.(*columnarEngine); ok {
+		mode = "columnar"
+	}
+	return unsupportedEngineMode(collection, mode)
+}
+
+func unsupportedEngineMode(collection, mode string) error {
+	return &branching.UnsupportedError{
+		Provider: branchingProviderName,
+		Mode:     mode,
+		Reason:   fmt.Sprintf("collection %q does not use serialized storage", collection),
+	}
+}
+
+type databaseSnapshot struct {
+	collections                     map[string]serializedEngineSnapshot
+	schema                          *memorySchema
+	noReadsAfterWritesInTransaction bool
+	schemaRefBreaking               bool
+}
+
+type serializedEngineSnapshot struct {
+	collection string
+	factory    func() any
+	records    map[string][]byte
+	keys       map[string]*record.Key
+}
+
+func snapshotDatabase(db *database) databaseSnapshot {
+	collections := make(map[string]serializedEngineSnapshot, len(db.collections))
+	for name, storage := range db.collections {
+		engine := storage.(*serializedEngine) // validated while the database is locked
+		collections[name] = snapshotSerializedEngine(engine)
+	}
+	return databaseSnapshot{
+		collections:                     collections,
+		schema:                          cloneMemorySchema(db.schema),
+		noReadsAfterWritesInTransaction: db.noReadsAfterWritesInTransaction,
+		schemaRefBreaking:               db.schemaRefBreaking,
+	}
+}
+
+func snapshotSerializedEngine(engine *serializedEngine) serializedEngineSnapshot {
+	records := make(map[string][]byte, len(engine.records))
+	for id, data := range engine.records {
+		records[id] = append([]byte(nil), data...)
+	}
+	keys := make(map[string]*record.Key, len(engine.keys))
+	for id, key := range engine.keys {
+		keys[id] = cloneRecordKey(key)
+	}
+	return serializedEngineSnapshot{
+		collection: engine.collection,
+		factory:    engine.factory,
+		records:    records,
+		keys:       keys,
+	}
+}
+
+func cloneMemorySchema(schema *memorySchema) *memorySchema {
+	if schema == nil {
+		return nil
+	}
+	collections := make(map[string]func() any, len(schema.collections))
+	for name, factory := range schema.collections {
+		collections[name] = factory
+	}
+	engines := make(map[string]engineFactory, len(schema.engines))
+	for name, factory := range schema.engines {
+		engines[name] = factory
+	}
+	return &memorySchema{
+		collections:    collections,
+		engines:        engines,
+		allowUndefined: schema.allowUndefined,
+	}
+}
+
+func cloneRecordKey(key *record.Key) *record.Key {
+	if key == nil {
+		return nil
+	}
+	parent := cloneRecordKey(key.Parent())
+	if key.ID == nil && key.IDKind != 0 {
+		return record.NewIncompleteKey(key.Collection(), key.IDKind, parent)
+	}
+	id := cloneRecordKeyID(key.ID)
+	if parent == nil {
+		return record.NewKeyWithID[any](key.Collection(), id)
+	}
+	return record.NewKeyWithParentAndID[any](parent, key.Collection(), id)
+}
+
+// Composite key slices are the only mutable key-ID shape defined by record.
+// Their field values are identifiers and therefore treated as immutable, while
+// the containing slice is copied so callers cannot replace components after a
+// checkpoint.
+func cloneRecordKeyID(id any) any {
+	fields, ok := id.([]record.FieldVal)
+	if !ok {
+		return id
+	}
+	return append([]record.FieldVal(nil), fields...)
+}
+
+type serializedCheckpoint struct {
+	mu         sync.Mutex
+	generation string
+	snapshot   *databaseSnapshot
+}
+
+var _ branching.Checkpoint = (*serializedCheckpoint)(nil)
+
+func (c *serializedCheckpoint) Generation() string {
+	return c.generation
+}
+
+func (c *serializedCheckpoint) Branch(ctx context.Context) (branching.Branch, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.snapshot == nil {
+		return nil, branching.ErrReleased
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return &serializedBranch{db: c.snapshot.newDatabase()}, nil
+}
+
+func (c *serializedCheckpoint) Release(context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.snapshot = nil
+	return nil
+}
+
+func (s databaseSnapshot) newDatabase() dal.DB {
+	db := &database{
+		collections:                     make(map[string]storageEngine, len(s.collections)),
+		schema:                          cloneMemorySchema(s.schema),
+		noReadsAfterWritesInTransaction: s.noReadsAfterWritesInTransaction,
+		schemaRefBreaking:               s.schemaRefBreaking,
+	}
+	for name, snapshot := range s.collections {
+		db.collections[name] = snapshot.newEngine()
+	}
+	return db
+}
+
+func (s serializedEngineSnapshot) newEngine() *serializedEngine {
+	records := make(map[string][]byte, len(s.records))
+	for id, data := range s.records {
+		records[id] = append([]byte(nil), data...)
+	}
+	keys := make(map[string]*record.Key, len(s.keys))
+	for id, key := range s.keys {
+		keys[id] = cloneRecordKey(key)
+	}
+	return &serializedEngine{
+		collection: s.collection,
+		factory:    s.factory,
+		records:    records,
+		keys:       keys,
+	}
+}
+
+type serializedBranch struct {
+	db     dal.DB
+	closed atomic.Bool
+}
+
+var _ branching.Branch = (*serializedBranch)(nil)
+
+func (b *serializedBranch) DB() dal.DB {
+	return b.db
+}
+
+func (b *serializedBranch) Close(context.Context) error {
+	b.closed.Store(true)
+	return nil
+}

--- a/adapters/dalgo2memory/branching_coverage_test.go
+++ b/adapters/dalgo2memory/branching_coverage_test.go
@@ -1,0 +1,201 @@
+package dalgo2memory
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/dal-go/dalgo/branching"
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/record"
+)
+
+func TestBranchingCaptureRejectsInvalidSources(t *testing.T) {
+	provider := NewBranchingProvider()
+
+	t.Run("nil interface", func(t *testing.T) {
+		checkpoint, err := provider.Capture(context.Background(), nil)
+		if checkpoint != nil || !errors.Is(err, branching.ErrNilSourceDB) {
+			t.Fatalf("Capture() = (%v, %v), want (nil, ErrNilSourceDB)", checkpoint, err)
+		}
+	})
+
+	t.Run("typed nil", func(t *testing.T) {
+		var memoryDB *database
+		var source dal.DB = memoryDB
+		checkpoint, err := provider.Capture(context.Background(), source)
+		if checkpoint != nil || !errors.Is(err, branching.ErrNilSourceDB) {
+			t.Fatalf("Capture() = (%v, %v), want (nil, ErrNilSourceDB)", checkpoint, err)
+		}
+	})
+
+	t.Run("other adapter", func(t *testing.T) {
+		source := struct{ dal.DB }{DB: NewDB()}
+		checkpoint, err := provider.Capture(context.Background(), source)
+		if checkpoint != nil {
+			t.Fatal("Capture() published a checkpoint for a non-dalgo2memory adapter")
+		}
+		var unsupported *branching.UnsupportedError
+		if !errors.As(err, &unsupported) {
+			t.Fatalf("Capture() error = %v, want *branching.UnsupportedError", err)
+		}
+		if unsupported.Provider != branchingProviderName || unsupported.Mode != "source:struct { dal.DB }" {
+			t.Fatalf("unsupported capability = %#v", unsupported)
+		}
+	})
+}
+
+func TestBranchingCaptureHonorsContextAtBothBoundaries(t *testing.T) {
+	provider := NewBranchingProvider()
+
+	t.Run("before capture", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		checkpoint, err := provider.Capture(ctx, NewDB())
+		if checkpoint != nil || !errors.Is(err, context.Canceled) {
+			t.Fatalf("Capture() = (%v, %v), want (nil, context.Canceled)", checkpoint, err)
+		}
+	})
+
+	t.Run("after database lock", func(t *testing.T) {
+		ctx := &errSequenceContext{errs: []error{nil, context.Canceled}}
+		checkpoint, err := provider.Capture(ctx, NewDB())
+		if checkpoint != nil || !errors.Is(err, context.Canceled) {
+			t.Fatalf("Capture() = (%v, %v), want (nil, context.Canceled)", checkpoint, err)
+		}
+		if ctx.calls != 2 {
+			t.Fatalf("context Err() calls = %d, want 2", ctx.calls)
+		}
+	})
+}
+
+func TestBranchingPreservesSerializedSchemaConfiguration(t *testing.T) {
+	ctx := context.Background()
+	source := NewDB(
+		WithNoReadsAfterWritesInTransaction(),
+		WithoutSchemaRefBreaking(),
+		WithSchema(true,
+			WithCollection[branchingRecord]("items", nil, WithSerializedStorage()),
+		),
+	).(*database)
+	if err := source.Set(ctx, record.NewRecordWithData(branchingRootKey("milk"), &branchingRecord{Title: "milk"})); err != nil {
+		t.Fatal(err)
+	}
+
+	checkpoint, err := NewBranchingProvider().Capture(ctx, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = checkpoint.Release(ctx) }()
+
+	// Mutating source configuration after Capture must not mutate the checkpoint.
+	delete(source.schema.collections, "items")
+	delete(source.schema.engines, "items")
+	source.schema.allowUndefined = false
+
+	first := mustBranch(t, checkpoint)
+	defer closeTestBranch(t, first)
+	firstDB := first.DB().(*database)
+	assertSerializedSchemaClone(t, firstDB)
+
+	// A branch also owns its schema maps; sibling creation must clone them again.
+	delete(firstDB.schema.collections, "items")
+	delete(firstDB.schema.engines, "items")
+	second := mustBranch(t, checkpoint)
+	defer closeTestBranch(t, second)
+	assertSerializedSchemaClone(t, second.DB().(*database))
+}
+
+func assertSerializedSchemaClone(t testing.TB, db *database) {
+	t.Helper()
+	if db.schema == nil || !db.schema.allowUndefined {
+		t.Fatalf("branched schema = %#v, want allowUndefined schema", db.schema)
+	}
+	if db.schema.collections["items"] == nil || db.schema.engines["items"] == nil {
+		t.Fatalf("branched schema lost items factories: %#v", db.schema)
+	}
+	if !db.noReadsAfterWritesInTransaction {
+		t.Fatal("branch lost no-reads-after-writes setting")
+	}
+	if db.schemaRefBreaking {
+		t.Fatal("branch lost schema reference-breaking setting")
+	}
+}
+
+func TestCloneRecordKeyHandlesIncompleteAndCompositeIDs(t *testing.T) {
+	t.Run("incomplete parent chain", func(t *testing.T) {
+		parent := record.NewIncompleteKey("spaces", reflect.String, nil)
+		key := record.NewIncompleteKey("items", reflect.Int64, parent)
+		cloned := cloneRecordKey(key)
+		if cloned == key || cloned.Parent() == parent {
+			t.Fatal("clone reused a key node")
+		}
+		if cloned.Collection() != "items" || cloned.ID != nil || cloned.IDKind != reflect.Int64 {
+			t.Fatalf("cloned key = %#v", cloned)
+		}
+		if got := cloned.Parent(); got.Collection() != "spaces" || got.ID != nil || got.IDKind != reflect.String {
+			t.Fatalf("cloned parent = %#v", got)
+		}
+	})
+
+	t.Run("composite ID slice", func(t *testing.T) {
+		key := record.NewKeyWithFields("items",
+			record.FieldVal{Name: "list", Value: "groceries"},
+			record.FieldVal{Name: "title", Value: "milk"},
+		)
+		cloned := cloneRecordKey(key)
+		originalFields := key.ID.([]record.FieldVal)
+		clonedFields := cloned.ID.([]record.FieldVal)
+		originalFields[0] = record.FieldVal{Name: "changed", Value: "changed"}
+		if clonedFields[0].Name != "list" || clonedFields[0].Value != "groceries" {
+			t.Fatalf("cloned composite fields changed with source: %#v", clonedFields)
+		}
+	})
+}
+
+func TestBranchingBranchHonorsContextAtBothBoundaries(t *testing.T) {
+	checkpoint, err := NewBranchingProvider().Capture(context.Background(), NewDB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = checkpoint.Release(context.Background()) }()
+
+	t.Run("before branch", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		branch, err := checkpoint.Branch(ctx)
+		if branch != nil || !errors.Is(err, context.Canceled) {
+			t.Fatalf("Branch() = (%v, %v), want (nil, context.Canceled)", branch, err)
+		}
+	})
+
+	t.Run("after checkpoint lock", func(t *testing.T) {
+		ctx := &errSequenceContext{errs: []error{nil, context.Canceled}}
+		branch, err := checkpoint.Branch(ctx)
+		if branch != nil || !errors.Is(err, context.Canceled) {
+			t.Fatalf("Branch() = (%v, %v), want (nil, context.Canceled)", branch, err)
+		}
+		if ctx.calls != 2 {
+			t.Fatalf("context Err() calls = %d, want 2", ctx.calls)
+		}
+	})
+}
+
+type errSequenceContext struct {
+	errs  []error
+	calls int
+}
+
+func (c *errSequenceContext) Deadline() (time.Time, bool) { return time.Time{}, false }
+func (c *errSequenceContext) Done() <-chan struct{}       { return nil }
+func (c *errSequenceContext) Value(any) any               { return nil }
+func (c *errSequenceContext) Err() error {
+	index := c.calls
+	c.calls++
+	if index >= len(c.errs) {
+		return c.errs[len(c.errs)-1]
+	}
+	return c.errs[index]
+}

--- a/adapters/dalgo2memory/branching_test.go
+++ b/adapters/dalgo2memory/branching_test.go
@@ -1,0 +1,623 @@
+package dalgo2memory
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/dal-go/dalgo/branching"
+	"github.com/dal-go/dalgo/branchingtest"
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/record"
+	"github.com/dal-go/record/update"
+)
+
+type branchingRecord struct {
+	Title string         `json:"title"`
+	Done  bool           `json:"done"`
+	Meta  map[string]any `json:"meta,omitempty"`
+}
+
+func TestBranchingConformanceSerialized(t *testing.T) {
+	branchingtest.RunConformance(t, branchingtest.Callbacks{
+		New: func(testing.TB) (dal.DB, branching.Provider) {
+			return NewDB(), NewBranchingProvider()
+		},
+		Seed:   seedBranchingRecords,
+		Mutate: mutateBranchingRecords,
+		Digest: digestBranchingRecords,
+	})
+}
+
+func seedBranchingRecords(ctx context.Context, db dal.DB) error {
+	writer := db.(branchingWriter)
+	for _, fixture := range []struct {
+		key  *record.Key
+		data *branchingRecord
+	}{
+		{branchingRootKey("milk"), &branchingRecord{Title: "milk", Meta: map[string]any{"version": 1}}},
+		{branchingRootKey("bread"), &branchingRecord{Title: "bread"}},
+		{branchingNestedKey("family", "groceries", "apples"), &branchingRecord{Title: "apples"}},
+	} {
+		if err := writer.Set(ctx, record.NewRecordWithData(fixture.key, fixture.data)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func mutateBranchingRecords(ctx context.Context, db dal.DB) error {
+	writer := db.(branchingWriter)
+	if err := writer.Insert(ctx, record.NewRecordWithData(branchingRootKey("bananas"), &branchingRecord{Title: "bananas"})); err != nil {
+		return err
+	}
+	if err := writer.Update(ctx, branchingRootKey("milk"), []update.Update{
+		update.ByFieldName("done", true),
+		update.ByFieldPath(update.FieldPath{"meta", "version"}, 2),
+	}); err != nil {
+		return err
+	}
+	return writer.Delete(ctx, branchingRootKey("bread"))
+}
+
+type branchingWriter interface {
+	Set(context.Context, record.Record) error
+	Insert(context.Context, record.Record, ...dal.InsertOption) error
+	Update(context.Context, *record.Key, []update.Update, ...dal.Precondition) error
+	Delete(context.Context, *record.Key) error
+}
+
+func digestBranchingRecords(ctx context.Context, db dal.DB) (string, error) {
+	keys := []*record.Key{
+		branchingRootKey("bananas"),
+		branchingRootKey("bread"),
+		branchingRootKey("milk"),
+		branchingNestedKey("family", "groceries", "apples"),
+	}
+	entries := make([]string, 0, len(keys))
+	for _, key := range keys {
+		var data map[string]any
+		err := db.Get(ctx, record.NewRecordWithData(key, &data))
+		if record.IsNotFound(err) {
+			entries = append(entries, keyPath(key)+"=<missing>")
+			continue
+		}
+		if err != nil {
+			return "", err
+		}
+		encoded, err := json.Marshal(data)
+		if err != nil {
+			return "", err
+		}
+		entries = append(entries, keyPath(key)+"="+string(encoded))
+	}
+	return fmt.Sprint(entries), nil
+}
+
+func branchingRootKey(id string) *record.Key {
+	return record.NewKeyWithID("items", id)
+}
+
+func branchingNestedKey(spaceID, listID, itemID string) *record.Key {
+	space := record.NewKeyWithID("spaces", spaceID)
+	list := record.NewKeyWithParentAndID(space, "lists", listID)
+	return record.NewKeyWithParentAndID(list, "items", itemID)
+}
+
+func TestBranchingPreservesNestedKeyChains(t *testing.T) {
+	ctx := context.Background()
+	source := NewDB().(*database)
+	sourceKey := branchingNestedKey("family", "groceries", "apples")
+	wantPath := sourceKey.String()
+	if err := source.Set(ctx, record.NewRecordWithData(sourceKey, &branchingRecord{Title: "apples"})); err != nil {
+		t.Fatal(err)
+	}
+
+	checkpoint, err := NewBranchingProvider().Capture(ctx, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := checkpoint.Release(ctx); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// serializedEngine stores the caller's key pointer. Mutating it after
+	// Capture must not alter the immutable checkpoint's copied parent chain.
+	sourceKey.ID = "changed-item"
+	sourceKey.Parent().ID = "changed-list"
+	sourceKey.Parent().Parent().ID = "changed-space"
+
+	first := mustBranch(t, checkpoint)
+	defer closeTestBranch(t, first)
+	second := mustBranch(t, checkpoint)
+	defer closeTestBranch(t, second)
+
+	firstKey := onlyQueriedItemKey(t, first.DB())
+	secondKey := onlyQueriedItemKey(t, second.DB())
+	if got := firstKey.String(); got != wantPath {
+		t.Fatalf("first branch key = %q, want %q", got, wantPath)
+	}
+	if got := secondKey.String(); got != wantPath {
+		t.Fatalf("second branch key = %q, want %q", got, wantPath)
+	}
+	for left, right := firstKey, secondKey; left != nil || right != nil; left, right = left.Parent(), right.Parent() {
+		if left == right {
+			t.Fatal("sibling branches share a record-key node")
+		}
+	}
+}
+
+func onlyQueriedItemKey(t testing.TB, db dal.DB) *record.Key {
+	t.Helper()
+	query := dal.From(dal.NewRootCollectionRef("items", "")).NewQuery().SelectKeysOnly(reflect.String)
+	records, err := dal.ExecuteQueryAndReadAllToRecords(context.Background(), query, db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("query returned %d records, want 1", len(records))
+	}
+	return records[0].Key()
+}
+
+func TestBranchingDeepCopiesSerializedBytes(t *testing.T) {
+	ctx := context.Background()
+	source := NewDB().(*database)
+	key := branchingRootKey("milk")
+	if err := source.Set(ctx, record.NewRecordWithData(key, &branchingRecord{Title: "milk"})); err != nil {
+		t.Fatal(err)
+	}
+	checkpoint, err := NewBranchingProvider().Capture(ctx, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = checkpoint.Release(ctx) }()
+
+	storedID := keyID(key)
+	sourceBytes := source.collections["items"].(*serializedEngine).records[storedID]
+	sourceBytes[0] = '['
+	assertBranchingTitle(t, mustBranch(t, checkpoint), key, "milk")
+
+	first := mustBranch(t, checkpoint)
+	firstDB := first.DB().(*database)
+	firstDB.collections["items"].(*serializedEngine).records[storedID][0] = '['
+	closeTestBranch(t, first)
+	assertBranchingTitle(t, mustBranch(t, checkpoint), key, "milk")
+}
+
+func assertBranchingTitle(t testing.TB, branch branching.Branch, key *record.Key, want string) {
+	t.Helper()
+	defer closeTestBranch(t, branch)
+	var got branchingRecord
+	if err := branch.DB().Get(context.Background(), record.NewRecordWithData(key, &got)); err != nil {
+		t.Fatal(err)
+	}
+	if got.Title != want {
+		t.Fatalf("title = %q, want %q", got.Title, want)
+	}
+}
+
+func TestBranchingRejectsColumnarEngine(t *testing.T) {
+	tests := []struct {
+		name       string
+		collection CollectionOption
+		initialize bool
+		wantMode   string
+	}{
+		{name: "configured columnar", collection: WithColumnarStorage(), wantMode: "columnar"},
+		{name: "initialized columnar", collection: WithColumnarStorage(), initialize: true, wantMode: "columnar"},
+		{name: "configured custom", collection: withBranchingCustomStorage(), wantMode: "custom"},
+		{name: "configured custom returning serialized", collection: withBranchingCustomSerializedStorage(), wantMode: "custom"},
+		{name: "initialized custom", collection: withBranchingCustomStorage(), initialize: true, wantMode: "custom"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			db := NewDB(WithSchema(false,
+				WithCollection[branchingRecord]("items", nil, tc.collection),
+			)).(*database)
+			if tc.initialize {
+				if err := db.Set(context.Background(), record.NewRecordWithData(branchingRootKey("milk"), &branchingRecord{Title: "milk"})); err != nil {
+					t.Fatal(err)
+				}
+			}
+			checkpoint, err := NewBranchingProvider().Capture(context.Background(), db)
+			if checkpoint != nil {
+				t.Fatal("unsupported engine published a checkpoint")
+			}
+			var unsupported *branching.UnsupportedError
+			if !errors.As(err, &unsupported) {
+				t.Fatalf("Capture() error = %v, want *branching.UnsupportedError", err)
+			}
+			if !errors.Is(err, branching.ErrUnsupportedCapability) {
+				t.Fatalf("Capture() error = %v, want ErrUnsupportedCapability", err)
+			}
+			if unsupported.Mode != tc.wantMode {
+				t.Fatalf("unsupported mode = %q, want %q", unsupported.Mode, tc.wantMode)
+			}
+		})
+	}
+}
+
+type branchingCustomEngine struct {
+	inner *serializedEngine
+}
+
+func withBranchingCustomStorage() CollectionOption {
+	return func(def *collectionDef) {
+		def.newEngine = func(collection string, factory func() any, _ bool) storageEngine {
+			return &branchingCustomEngine{inner: newSerializedEngine(collection, factory)}
+		}
+	}
+}
+
+func withBranchingCustomSerializedStorage() CollectionOption {
+	return func(def *collectionDef) {
+		def.newEngine = func(collection string, factory func() any, _ bool) storageEngine {
+			return newSerializedEngine(collection, factory)
+		}
+	}
+}
+
+func (e *branchingCustomEngine) exists(id string) bool { return e.inner.exists(id) }
+func (e *branchingCustomEngine) store(id string, rec record.Record, overwrite bool) error {
+	return e.inner.store(id, rec, overwrite)
+}
+func (e *branchingCustomEngine) load(id string, rec record.Record) error {
+	return e.inner.load(id, rec)
+}
+func (e *branchingCustomEngine) delete(id string) { e.inner.delete(id) }
+func (e *branchingCustomEngine) update(id string, updates []update.Update) error {
+	return e.inner.update(id, updates)
+}
+func (e *branchingCustomEngine) rows() ([]engineRow, error) { return e.inner.rows() }
+
+func TestTwoMemoryDatabasesConformAsOneGroup(t *testing.T) {
+	t.Run("fresh handles and sibling isolation", func(t *testing.T) {
+		ctx := context.Background()
+		primary := NewDB()
+		audit := NewDB()
+		mustSetBranchingTitle(t, primary, "primary", "baseline-primary")
+		mustSetBranchingTitle(t, audit, "audit", "baseline-audit")
+
+		group := testMemoryGroup{
+			{name: "primary", source: primary, provider: NewBranchingProvider()},
+			{name: "audit", source: audit, provider: NewBranchingProvider()},
+		}
+		checkpoint, err := group.Capture(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err := checkpoint.Release(ctx); err != nil {
+				t.Error(err)
+			}
+		}()
+
+		mustSetBranchingTitle(t, primary, "primary", "changed-source-primary")
+		mustSetBranchingTitle(t, audit, "audit", "changed-source-audit")
+
+		first, err := checkpoint.Branch(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertGroupFresh(t, first, map[string]dal.DB{"primary": primary, "audit": audit})
+		assertBranchingDBTitle(t, first.DB("primary"), "primary", "baseline-primary")
+		assertBranchingDBTitle(t, first.DB("audit"), "audit", "baseline-audit")
+		mustSetBranchingTitle(t, first.DB("primary"), "primary", "changed-first-primary")
+		mustSetBranchingTitle(t, first.DB("audit"), "audit", "changed-first-audit")
+		if err := first.Close(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if err := first.Close(ctx); err != nil {
+			t.Fatalf("second Close(): %v", err)
+		}
+
+		second, err := checkpoint.Branch(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = second.Close(ctx) }()
+		assertGroupFresh(t, second, map[string]dal.DB{
+			"primary": primary,
+			"audit":   audit,
+		})
+		if second.DB("primary") == first.DB("primary") || second.DB("audit") == first.DB("audit") {
+			t.Fatal("sibling groups share a database handle")
+		}
+		assertBranchingDBTitle(t, second.DB("primary"), "primary", "baseline-primary")
+		assertBranchingDBTitle(t, second.DB("audit"), "audit", "baseline-audit")
+	})
+
+	t.Run("checkpoint failure releases partial captures", func(t *testing.T) {
+		firstProvider := &trackingProvider{inner: NewBranchingProvider()}
+		group := testMemoryGroup{
+			{name: "primary", source: NewDB(), provider: firstProvider},
+			{name: "audit", source: NewDB(), provider: failingProvider{err: errTestCapture}},
+		}
+		checkpoint, err := group.Capture(context.Background())
+		if !errors.Is(err, errTestCapture) || checkpoint != nil {
+			t.Fatalf("Capture() = (%v, %v), want (nil, errTestCapture)", checkpoint, err)
+		}
+		if firstProvider.checkpoint == nil || firstProvider.checkpoint.releases != 1 {
+			t.Fatalf("partial checkpoint releases = %v, want 1", firstProvider.releaseCount())
+		}
+	})
+
+	t.Run("branch failure closes partial branches", func(t *testing.T) {
+		firstProvider := &trackingProvider{inner: NewBranchingProvider()}
+		secondProvider := branchFailingProvider{inner: NewBranchingProvider(), err: errTestBranch}
+		group := testMemoryGroup{
+			{name: "primary", source: NewDB(), provider: firstProvider},
+			{name: "audit", source: NewDB(), provider: secondProvider},
+		}
+		checkpoint, err := group.Capture(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = checkpoint.Release(context.Background()) }()
+		branch, err := checkpoint.Branch(context.Background())
+		if !errors.Is(err, errTestBranch) || branch != nil {
+			t.Fatalf("Branch() = (%v, %v), want (nil, errTestBranch)", branch, err)
+		}
+		if firstProvider.checkpoint == nil || firstProvider.checkpoint.lastBranch == nil || firstProvider.checkpoint.lastBranch.closes != 1 {
+			t.Fatalf("partial branch closes = %v, want 1", firstProvider.closeCount())
+		}
+	})
+}
+
+func assertGroupFresh(t testing.TB, branch *testMemoryGroupBranch, sources map[string]dal.DB) {
+	t.Helper()
+	for name, source := range sources {
+		if branch.DB(name) == nil {
+			t.Fatalf("group branch database %q is nil", name)
+		}
+		if branch.DB(name) == source {
+			t.Fatalf("group branch reused source database %q", name)
+		}
+	}
+}
+
+func mustSetBranchingTitle(t testing.TB, db dal.DB, id, title string) {
+	t.Helper()
+	if err := db.(branchingWriter).Set(context.Background(), record.NewRecordWithData(branchingRootKey(id), &branchingRecord{Title: title})); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertBranchingDBTitle(t testing.TB, db dal.DB, id, want string) {
+	t.Helper()
+	var got branchingRecord
+	if err := db.Get(context.Background(), record.NewRecordWithData(branchingRootKey(id), &got)); err != nil {
+		t.Fatal(err)
+	}
+	if got.Title != want {
+		t.Fatalf("record %q title = %q, want %q", id, got.Title, want)
+	}
+}
+
+type testMemoryGroupMember struct {
+	name     string
+	source   dal.DB
+	provider branching.Provider
+}
+
+type testMemoryGroup []testMemoryGroupMember
+
+func (g testMemoryGroup) Capture(ctx context.Context) (*testMemoryGroupCheckpoint, error) {
+	members := append(testMemoryGroup(nil), g...)
+	captured := make([]testMemoryGroupCheckpointMember, 0, len(members))
+	for _, member := range members {
+		checkpoint, err := member.provider.Capture(ctx, member.source)
+		if err != nil {
+			for i := len(captured) - 1; i >= 0; i-- {
+				_ = captured[i].checkpoint.Release(context.Background())
+			}
+			return nil, err
+		}
+		captured = append(captured, testMemoryGroupCheckpointMember{name: member.name, checkpoint: checkpoint})
+	}
+	return &testMemoryGroupCheckpoint{members: captured}, nil
+}
+
+type testMemoryGroupCheckpointMember struct {
+	name       string
+	checkpoint branching.Checkpoint
+}
+
+type testMemoryGroupCheckpoint struct {
+	members  []testMemoryGroupCheckpointMember
+	released bool
+}
+
+func (c *testMemoryGroupCheckpoint) Branch(ctx context.Context) (*testMemoryGroupBranch, error) {
+	if c.released {
+		return nil, branching.ErrReleased
+	}
+	started := make([]testMemoryGroupBranchMember, 0, len(c.members))
+	for _, member := range c.members {
+		branch, err := member.checkpoint.Branch(ctx)
+		if err != nil {
+			for i := len(started) - 1; i >= 0; i-- {
+				_ = started[i].branch.Close(context.Background())
+			}
+			return nil, err
+		}
+		started = append(started, testMemoryGroupBranchMember{name: member.name, branch: branch})
+	}
+	return &testMemoryGroupBranch{members: started}, nil
+}
+
+func (c *testMemoryGroupCheckpoint) Release(ctx context.Context) error {
+	if c.released {
+		return nil
+	}
+	c.released = true
+	var errs []error
+	for i := len(c.members) - 1; i >= 0; i-- {
+		if err := c.members[i].checkpoint.Release(ctx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+type testMemoryGroupBranchMember struct {
+	name   string
+	branch branching.Branch
+}
+
+type testMemoryGroupBranch struct {
+	members []testMemoryGroupBranchMember
+	closed  bool
+}
+
+func (b *testMemoryGroupBranch) DB(name string) dal.DB {
+	for _, member := range b.members {
+		if member.name == name {
+			return member.branch.DB()
+		}
+	}
+	return nil
+}
+
+func (b *testMemoryGroupBranch) Close(ctx context.Context) error {
+	if b.closed {
+		return nil
+	}
+	b.closed = true
+	var errs []error
+	for i := len(b.members) - 1; i >= 0; i-- {
+		if err := b.members[i].branch.Close(ctx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+var (
+	errTestCapture = errors.New("test capture failure")
+	errTestBranch  = errors.New("test branch failure")
+)
+
+type failingProvider struct {
+	err error
+}
+
+func (f failingProvider) Capability() branching.Capability { return branching.Capability{} }
+func (f failingProvider) Capture(context.Context, dal.DB) (branching.Checkpoint, error) {
+	return nil, f.err
+}
+
+type branchFailingProvider struct {
+	inner branching.Provider
+	err   error
+}
+
+func (p branchFailingProvider) Capability() branching.Capability { return p.inner.Capability() }
+func (p branchFailingProvider) Capture(ctx context.Context, db dal.DB) (branching.Checkpoint, error) {
+	checkpoint, err := p.inner.Capture(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	return branchFailingCheckpoint{Checkpoint: checkpoint, err: p.err}, nil
+}
+
+type branchFailingCheckpoint struct {
+	branching.Checkpoint
+	err error
+}
+
+func (c branchFailingCheckpoint) Branch(context.Context) (branching.Branch, error) {
+	return nil, c.err
+}
+
+type trackingProvider struct {
+	inner      branching.Provider
+	checkpoint *trackingCheckpoint
+}
+
+func (p *trackingProvider) Capability() branching.Capability { return p.inner.Capability() }
+func (p *trackingProvider) Capture(ctx context.Context, db dal.DB) (branching.Checkpoint, error) {
+	checkpoint, err := p.inner.Capture(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	p.checkpoint = &trackingCheckpoint{Checkpoint: checkpoint}
+	return p.checkpoint, nil
+}
+
+func (p *trackingProvider) releaseCount() int {
+	if p.checkpoint == nil {
+		return 0
+	}
+	return p.checkpoint.releases
+}
+
+func (p *trackingProvider) closeCount() int {
+	if p.checkpoint == nil || p.checkpoint.lastBranch == nil {
+		return 0
+	}
+	return p.checkpoint.lastBranch.closes
+}
+
+type trackingCheckpoint struct {
+	branching.Checkpoint
+	releases   int
+	lastBranch *trackingBranch
+}
+
+func (c *trackingCheckpoint) Branch(ctx context.Context) (branching.Branch, error) {
+	branch, err := c.Checkpoint.Branch(ctx)
+	if err != nil {
+		return nil, err
+	}
+	c.lastBranch = &trackingBranch{Branch: branch}
+	return c.lastBranch, nil
+}
+
+func (c *trackingCheckpoint) Release(ctx context.Context) error {
+	c.releases++
+	return c.Checkpoint.Release(ctx)
+}
+
+type trackingBranch struct {
+	branching.Branch
+	closes int
+}
+
+func (b *trackingBranch) Close(ctx context.Context) error {
+	b.closes++
+	return b.Branch.Close(ctx)
+}
+
+func mustBranch(t testing.TB, checkpoint branching.Checkpoint) branching.Branch {
+	t.Helper()
+	branch, err := checkpoint.Branch(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if branch == nil || branch.DB() == nil {
+		t.Fatal("Branch() returned nil branch or database")
+	}
+	return branch
+}
+
+func closeTestBranch(t testing.TB, branch branching.Branch) {
+	t.Helper()
+	if err := branch.Close(context.Background()); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestBranchingCapability(t *testing.T) {
+	got := NewBranchingProvider().Capability()
+	want := branching.Capability{Provider: "dalgo2memory", Version: "1", Mode: "serialized"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Capability() = %#v, want %#v", got, want)
+	}
+}

--- a/adapters/dalgo2memory/branching_test.go
+++ b/adapters/dalgo2memory/branching_test.go
@@ -209,10 +209,10 @@ func TestBranchingRejectsColumnarEngine(t *testing.T) {
 		initialize bool
 		wantMode   string
 	}{
-		{name: "configured columnar", collection: WithColumnarStorage(), wantMode: "columnar"},
+		{name: "configured columnar", collection: WithColumnarStorage(), wantMode: "non-serialized"},
 		{name: "initialized columnar", collection: WithColumnarStorage(), initialize: true, wantMode: "columnar"},
-		{name: "configured custom", collection: withBranchingCustomStorage(), wantMode: "custom"},
-		{name: "configured custom returning serialized", collection: withBranchingCustomSerializedStorage(), wantMode: "custom"},
+		{name: "configured custom", collection: withBranchingCustomStorage(), wantMode: "non-serialized"},
+		{name: "configured custom returning serialized", collection: withBranchingCustomSerializedStorage(), wantMode: "non-serialized"},
 		{name: "initialized custom", collection: withBranchingCustomStorage(), initialize: true, wantMode: "custom"},
 	}
 	for _, tc := range tests {
@@ -240,6 +240,34 @@ func TestBranchingRejectsColumnarEngine(t *testing.T) {
 				t.Fatalf("unsupported mode = %q, want %q", unsupported.Mode, tc.wantMode)
 			}
 		})
+	}
+}
+
+func TestBranchingRejectsConfiguredFactoryWithoutInvokingIt(t *testing.T) {
+	invoked := false
+	panicStorage := func(def *collectionDef) {
+		def.newEngine = func(string, func() any, bool) storageEngine {
+			invoked = true
+			panic("configured custom engine factory must not run during Capture")
+		}
+	}
+	db := NewDB(WithSchema(false,
+		WithCollection[branchingRecord]("items", nil, panicStorage),
+	))
+
+	checkpoint, err := NewBranchingProvider().Capture(context.Background(), db)
+	if checkpoint != nil {
+		t.Fatal("unsupported configured factory published a checkpoint")
+	}
+	var unsupported *branching.UnsupportedError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("Capture() error = %v, want *branching.UnsupportedError", err)
+	}
+	if unsupported.Mode != "non-serialized" {
+		t.Fatalf("unsupported mode = %q, want %q", unsupported.Mode, "non-serialized")
+	}
+	if invoked {
+		t.Fatal("Capture invoked an unsupported configured engine factory")
 	}
 }
 

--- a/branching/branching.go
+++ b/branching/branching.go
@@ -1,0 +1,68 @@
+// Package branching defines optional database checkpoint and branching capabilities.
+//
+// The contracts deliberately live beside dal rather than inside dal.DB. A
+// provider can opt in without widening the mandatory data-access interface.
+package branching
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/dal-go/dalgo/dal"
+)
+
+var (
+	// ErrUnsupportedCapability identifies a database configuration a provider
+	// cannot safely checkpoint or branch.
+	ErrUnsupportedCapability = errors.New("dalgo branching: unsupported capability")
+
+	ErrNilSourceDB     = errors.New("dalgo branching: source database is nil")
+	ErrNilBranchDB     = errors.New("dalgo branching: branch database is nil")
+	ErrReleased        = errors.New("dalgo branching: checkpoint is released")
+	ErrEmptyGeneration = errors.New("dalgo branching: checkpoint generation is empty")
+)
+
+// UnsupportedError names the provider mode rejected by an optional capability.
+type UnsupportedError struct {
+	Provider string
+	Mode     string
+	Reason   string
+}
+
+func (e *UnsupportedError) Error() string {
+	if e.Reason == "" {
+		return fmt.Sprintf("%s: provider=%q mode=%q", ErrUnsupportedCapability, e.Provider, e.Mode)
+	}
+	return fmt.Sprintf("%s: provider=%q mode=%q: %s", ErrUnsupportedCapability, e.Provider, e.Mode, e.Reason)
+}
+
+// Unwrap supports errors.Is(err, ErrUnsupportedCapability).
+func (e *UnsupportedError) Unwrap() error { return ErrUnsupportedCapability }
+
+// Capability is stable provider metadata recorded in a state-holder manifest.
+type Capability struct {
+	Provider string
+	Version  string
+	Mode     string
+}
+
+// Provider captures immutable state from one source database.
+type Provider interface {
+	Capability() Capability
+	Capture(context.Context, dal.DB) (Checkpoint, error)
+}
+
+// Checkpoint is immutable provider state from which fresh branches are created.
+// Release must be idempotent.
+type Checkpoint interface {
+	Generation() string
+	Branch(context.Context) (Branch, error)
+	Release(context.Context) error
+}
+
+// Branch owns a fresh database handle. Close must be idempotent.
+type Branch interface {
+	DB() dal.DB
+	Close(context.Context) error
+}

--- a/branching/branching_test.go
+++ b/branching/branching_test.go
@@ -42,3 +42,10 @@ func TestUnsupportedError(t *testing.T) {
 		t.Fatal("unsupported error is empty")
 	}
 }
+
+func TestUnsupportedErrorWithoutReason(t *testing.T) {
+	err := &branching.UnsupportedError{Provider: "memory", Mode: "custom"}
+	if got, want := err.Error(), `dalgo branching: unsupported capability: provider="memory" mode="custom"`; got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+}

--- a/branching/branching_test.go
+++ b/branching/branching_test.go
@@ -1,0 +1,44 @@
+package branching_test
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/dal-go/dalgo/branching"
+	"github.com/dal-go/dalgo/dal"
+)
+
+func TestDBInterfaceIsNotWidened(t *testing.T) {
+	dbType := reflect.TypeOf((*dal.DB)(nil)).Elem()
+	got := make([]string, dbType.NumMethod())
+	for i := range dbType.NumMethod() {
+		got[i] = dbType.Method(i).Name
+	}
+	want := []string{
+		"Adapter",
+		"ExecuteQueryToRecordsReader",
+		"ExecuteQueryToRecordsetReader",
+		"Exists",
+		"Get",
+		"GetMulti",
+		"ID",
+		"RunReadonlyTransaction",
+		"RunReadwriteTransaction",
+		"Schema",
+		"SupportsConcurrentConnections",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("dal.DB methods changed; branching must remain additive\ngot:  %v\nwant: %v", got, want)
+	}
+}
+
+func TestUnsupportedError(t *testing.T) {
+	err := &branching.UnsupportedError{Provider: "memory", Mode: "columnar", Reason: "not cloneable"}
+	if !errors.Is(err, branching.ErrUnsupportedCapability) {
+		t.Fatalf("errors.Is(%v, ErrUnsupportedCapability) = false", err)
+	}
+	if got := err.Error(); got == "" {
+		t.Fatal("unsupported error is empty")
+	}
+}

--- a/branchingtest/conformance.go
+++ b/branchingtest/conformance.go
@@ -1,0 +1,199 @@
+// Package branchingtest provides reusable conformance tests for DALgo branching providers.
+package branchingtest
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dal-go/dalgo/branching"
+	"github.com/dal-go/dalgo/dal"
+)
+
+// Factory returns a fresh source database and a provider configured for it.
+// Each conformance subtest receives a new pair.
+type Factory func(testing.TB) (dal.DB, branching.Provider)
+
+// Callbacks describe a provider-specific semantic fixture. Generic dal.DB does
+// not promise enumeration, so conformance never guesses collections or records.
+type Callbacks struct {
+	New    Factory
+	Seed   func(context.Context, dal.DB) error
+	Mutate func(context.Context, dal.DB) error
+	Digest func(context.Context, dal.DB) (string, error)
+}
+
+// RunConformance proves immutable checkpoints, source/sibling isolation, fresh
+// handles, semantic fidelity and idempotent cleanup.
+func RunConformance(t *testing.T, callbacks Callbacks) {
+	t.Helper()
+	validate(t, callbacks)
+
+	t.Run("empty database", func(t *testing.T) {
+		source, provider := callbacks.New(t)
+		checkpoint := capture(t, provider, source)
+		defer release(t, checkpoint)
+
+		baseline := digest(t, callbacks, source)
+		branch := startBranch(t, checkpoint, source)
+		if got := digest(t, callbacks, branch.DB()); got != baseline {
+			t.Fatalf("empty branch digest = %q, want %q", got, baseline)
+		}
+		closeBranch(t, branch)
+		closeBranch(t, branch)
+	})
+
+	t.Run("seed fidelity and fresh handle", func(t *testing.T) {
+		source, provider := callbacks.New(t)
+		seed(t, callbacks, source)
+		baseline := digest(t, callbacks, source)
+		checkpoint := capture(t, provider, source)
+		defer release(t, checkpoint)
+
+		branch := startBranch(t, checkpoint, source)
+		defer closeBranch(t, branch)
+		if got := digest(t, callbacks, branch.DB()); got != baseline {
+			t.Fatalf("seeded branch digest = %q, want %q", got, baseline)
+		}
+	})
+
+	t.Run("source mutation does not change checkpoint", func(t *testing.T) {
+		source, provider := callbacks.New(t)
+		seed(t, callbacks, source)
+		baseline := digest(t, callbacks, source)
+		checkpoint := capture(t, provider, source)
+		defer release(t, checkpoint)
+
+		mutate(t, callbacks, source)
+		if got := digest(t, callbacks, source); got == baseline {
+			t.Fatalf("mutation did not change source digest %q", baseline)
+		}
+		branch := startBranch(t, checkpoint, source)
+		defer closeBranch(t, branch)
+		if got := digest(t, callbacks, branch.DB()); got != baseline {
+			t.Fatalf("branch after source mutation digest = %q, want checkpoint %q", got, baseline)
+		}
+	})
+
+	t.Run("sibling isolation", func(t *testing.T) {
+		source, provider := callbacks.New(t)
+		seed(t, callbacks, source)
+		baseline := digest(t, callbacks, source)
+		checkpoint := capture(t, provider, source)
+		defer release(t, checkpoint)
+
+		first := startBranch(t, checkpoint, source)
+		mutate(t, callbacks, first.DB())
+		firstDigest := digest(t, callbacks, first.DB())
+		if firstDigest == baseline {
+			t.Fatalf("first sibling mutation did not change digest %q", baseline)
+		}
+		closeBranch(t, first)
+
+		second := startBranch(t, checkpoint, source)
+		if second.DB() == first.DB() {
+			t.Fatal("siblings received the same dal.DB handle")
+		}
+		if got := digest(t, callbacks, second.DB()); got != baseline {
+			t.Fatalf("second sibling digest = %q, want %q", got, baseline)
+		}
+		closeBranch(t, second)
+
+		third := startBranch(t, checkpoint, source)
+		if got := digest(t, callbacks, third.DB()); got != baseline {
+			t.Fatalf("checkpoint changed after sibling mutation: got %q, want %q", got, baseline)
+		}
+		closeBranch(t, third)
+	})
+
+	t.Run("release is idempotent", func(t *testing.T) {
+		source, provider := callbacks.New(t)
+		checkpoint := capture(t, provider, source)
+		if err := checkpoint.Release(context.Background()); err != nil {
+			t.Fatalf("first Release(): %v", err)
+		}
+		if err := checkpoint.Release(context.Background()); err != nil {
+			t.Fatalf("second Release(): %v", err)
+		}
+		if _, err := checkpoint.Branch(context.Background()); !errors.Is(err, branching.ErrReleased) {
+			t.Fatalf("Branch() after Release() error = %v, want ErrReleased", err)
+		}
+	})
+}
+
+func validate(t testing.TB, callbacks Callbacks) {
+	t.Helper()
+	if callbacks.New == nil || callbacks.Seed == nil || callbacks.Mutate == nil || callbacks.Digest == nil {
+		t.Fatal("branchingtest: New, Seed, Mutate and Digest callbacks are required")
+	}
+}
+
+func capture(t testing.TB, provider branching.Provider, source dal.DB) branching.Checkpoint {
+	t.Helper()
+	if source == nil || provider == nil {
+		t.Fatal("branchingtest: factory returned nil source or provider")
+	}
+	checkpoint, err := provider.Capture(context.Background(), source)
+	if err != nil {
+		t.Fatalf("Capture(): %v", err)
+	}
+	if checkpoint == nil {
+		t.Fatal("Capture() returned nil checkpoint")
+	}
+	if checkpoint.Generation() == "" {
+		t.Fatal("checkpoint generation is empty")
+	}
+	return checkpoint
+}
+
+func startBranch(t testing.TB, checkpoint branching.Checkpoint, source dal.DB) branching.Branch {
+	t.Helper()
+	branch, err := checkpoint.Branch(context.Background())
+	if err != nil {
+		t.Fatalf("Branch(): %v", err)
+	}
+	if branch == nil || branch.DB() == nil {
+		t.Fatal("Branch() returned nil branch or database")
+	}
+	if branch.DB() == source {
+		t.Fatal("Branch() returned the live source dal.DB handle")
+	}
+	return branch
+}
+
+func seed(t testing.TB, callbacks Callbacks, db dal.DB) {
+	t.Helper()
+	if err := callbacks.Seed(context.Background(), db); err != nil {
+		t.Fatalf("Seed(): %v", err)
+	}
+}
+
+func mutate(t testing.TB, callbacks Callbacks, db dal.DB) {
+	t.Helper()
+	if err := callbacks.Mutate(context.Background(), db); err != nil {
+		t.Fatalf("Mutate(): %v", err)
+	}
+}
+
+func digest(t testing.TB, callbacks Callbacks, db dal.DB) string {
+	t.Helper()
+	digest, err := callbacks.Digest(context.Background(), db)
+	if err != nil {
+		t.Fatalf("Digest(): %v", err)
+	}
+	return digest
+}
+
+func closeBranch(t testing.TB, branch branching.Branch) {
+	t.Helper()
+	if err := branch.Close(context.Background()); err != nil {
+		t.Fatalf("Close(): %v", err)
+	}
+}
+
+func release(t testing.TB, checkpoint branching.Checkpoint) {
+	t.Helper()
+	if err := checkpoint.Release(context.Background()); err != nil {
+		t.Fatalf("Release(): %v", err)
+	}
+}

--- a/branchingtest/conformance_test.go
+++ b/branchingtest/conformance_test.go
@@ -1,0 +1,371 @@
+package branchingtest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/dal-go/dalgo/adapters/dalgo2memory"
+	"github.com/dal-go/dalgo/branching"
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/record"
+)
+
+type conformanceItem struct {
+	Count int `json:"count"`
+}
+
+var conformanceKey = record.NewKeyWithID("items", "one")
+
+type conformanceProvider struct{}
+
+func (conformanceProvider) Capability() branching.Capability {
+	return branching.Capability{Provider: "test", Version: "1", Mode: "serialized"}
+}
+
+func (conformanceProvider) Capture(ctx context.Context, source dal.DB) (branching.Checkpoint, error) {
+	item, exists, err := readConformanceItem(ctx, source)
+	if err != nil {
+		return nil, err
+	}
+	return &conformanceCheckpoint{item: item, exists: exists}, nil
+}
+
+type conformanceCheckpoint struct {
+	item     conformanceItem
+	exists   bool
+	released bool
+}
+
+func (*conformanceCheckpoint) Generation() string { return "test-generation" }
+
+func (c *conformanceCheckpoint) Branch(ctx context.Context) (branching.Branch, error) {
+	if c.released {
+		return nil, branching.ErrReleased
+	}
+	db := dalgo2memory.NewDB()
+	if c.exists {
+		if err := setConformanceItem(ctx, db, c.item.Count); err != nil {
+			return nil, err
+		}
+	}
+	return &conformanceBranch{db: db}, nil
+}
+
+func (c *conformanceCheckpoint) Release(context.Context) error {
+	c.released = true
+	return nil
+}
+
+type conformanceBranch struct {
+	db     dal.DB
+	closed bool
+}
+
+func (b *conformanceBranch) DB() dal.DB { return b.db }
+
+func (b *conformanceBranch) Close(context.Context) error {
+	b.closed = true
+	return nil
+}
+
+func TestRunConformance(t *testing.T) {
+	RunConformance(t, Callbacks{
+		New: func(testing.TB) (dal.DB, branching.Provider) {
+			return dalgo2memory.NewDB(), conformanceProvider{}
+		},
+		Seed: func(ctx context.Context, db dal.DB) error {
+			return setConformanceItem(ctx, db, 1)
+		},
+		Mutate: func(ctx context.Context, db dal.DB) error {
+			return setConformanceItem(ctx, db, 2)
+		},
+		Digest: func(ctx context.Context, db dal.DB) (string, error) {
+			item, exists, err := readConformanceItem(ctx, db)
+			if err != nil {
+				return "", err
+			}
+			if !exists {
+				return "empty", nil
+			}
+			return fmt.Sprintf("count=%d", item.Count), nil
+		},
+	})
+}
+
+func TestFailurePathCoverage(t *testing.T) {
+	tests := map[string]struct {
+		subtest  string
+		expected string
+	}{
+		"validate":                  {expected: "New, Seed, Mutate and Digest callbacks are required"},
+		"capture nil input":         {expected: "factory returned nil source or provider"},
+		"capture error":             {expected: "Capture(): capture failed"},
+		"capture nil checkpoint":    {expected: "Capture() returned nil checkpoint"},
+		"capture empty generation":  {expected: "checkpoint generation is empty"},
+		"branch error":              {expected: "Branch(): branch failed"},
+		"branch nil":                {expected: "Branch() returned nil branch or database"},
+		"branch source handle":      {expected: "Branch() returned the live source dal.DB handle"},
+		"seed error":                {expected: "Seed(): seed failed"},
+		"mutate error":              {expected: "Mutate(): mutate failed"},
+		"digest error":              {expected: "Digest(): digest failed"},
+		"close error":               {expected: "Close(): close failed"},
+		"release error":             {expected: "Release(): release failed"},
+		"empty digest mismatch":     {subtest: "empty_database", expected: "empty branch digest"},
+		"seed digest mismatch":      {subtest: "seed_fidelity_and_fresh_handle", expected: "seeded branch digest"},
+		"source mutation unchanged": {subtest: "source_mutation_does_not_change_checkpoint", expected: "mutation did not change source digest"},
+		"checkpoint follows source": {subtest: "source_mutation_does_not_change_checkpoint", expected: "branch after source mutation digest"},
+		"first sibling unchanged":   {subtest: "sibling_isolation", expected: "first sibling mutation did not change digest"},
+		"siblings same handle":      {subtest: "sibling_isolation", expected: "siblings received the same dal.DB handle"},
+		"second sibling mismatch":   {subtest: "sibling_isolation", expected: "second sibling digest"},
+		"third sibling mismatch":    {subtest: "sibling_isolation", expected: "checkpoint changed after sibling mutation"},
+		"first release error":       {subtest: "release_is_idempotent", expected: "first Release(): release failed"},
+		"second release error":      {subtest: "release_is_idempotent", expected: "second Release(): release failed"},
+		"branch after release":      {subtest: "release_is_idempotent", expected: "want ErrReleased"},
+	}
+	for failureCase, test := range tests {
+		t.Run(failureCase, func(t *testing.T) {
+			runPattern := "^TestConformanceFailureHelper$"
+			if test.subtest != "" {
+				runPattern += "/^" + test.subtest + "$"
+			}
+			cmd := exec.Command(os.Args[0], append([]string{
+				"-test.run=" + runPattern,
+				"-test.count=1",
+			}, coverageArguments()...)...)
+			cmd.Env = append(os.Environ(), "DALGO_BRANCHINGTEST_FAILURE="+failureCase)
+			output, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("failure helper unexpectedly passed:\n%s", output)
+			}
+			if !strings.Contains(string(output), test.expected) {
+				t.Fatalf("failure helper output did not contain %q:\n%s", test.expected, output)
+			}
+		})
+	}
+}
+
+func TestConformanceFailureHelper(t *testing.T) {
+	failureCase := os.Getenv("DALGO_BRANCHINGTEST_FAILURE")
+	if failureCase == "" {
+		t.Skip("only run as a subprocess by TestFailurePathCoverage")
+	}
+	source := dalgo2memory.NewDB()
+	switch failureCase {
+	case "validate":
+		validate(t, Callbacks{})
+	case "capture nil input":
+		capture(t, nil, nil)
+	case "capture error":
+		capture(t, failureProvider{captureErr: errors.New("capture failed")}, source)
+	case "capture nil checkpoint":
+		capture(t, failureProvider{}, source)
+	case "capture empty generation":
+		capture(t, failureProvider{checkpoint: &failureCheckpoint{}}, source)
+	case "branch error":
+		startBranch(t, &failureCheckpoint{generation: "generation", branchErr: errors.New("branch failed")}, source)
+	case "branch nil":
+		startBranch(t, &failureCheckpoint{generation: "generation"}, source)
+	case "branch source handle":
+		startBranch(t, &failureCheckpoint{
+			generation: "generation",
+			branch:     &failureBranch{db: source},
+		}, source)
+	case "seed error":
+		seed(t, Callbacks{Seed: func(context.Context, dal.DB) error {
+			return errors.New("seed failed")
+		}}, source)
+	case "mutate error":
+		mutate(t, Callbacks{Mutate: func(context.Context, dal.DB) error {
+			return errors.New("mutate failed")
+		}}, source)
+	case "digest error":
+		digest(t, Callbacks{Digest: func(context.Context, dal.DB) (string, error) {
+			return "", errors.New("digest failed")
+		}}, source)
+	case "close error":
+		closeBranch(t, &failureBranch{closeErr: errors.New("close failed")})
+	case "release error":
+		release(t, &failureCheckpoint{releaseErr: errors.New("release failed")})
+	case "empty digest mismatch", "seed digest mismatch", "source mutation unchanged",
+		"checkpoint follows source", "first sibling unchanged", "siblings same handle",
+		"second sibling mismatch", "third sibling mismatch", "first release error",
+		"second release error", "branch after release":
+		RunConformance(t, scriptedFailureCallbacks(failureCase))
+	default:
+		t.Fatalf("unknown failure case %q", failureCase)
+	}
+}
+
+func coverageArguments() []string {
+	var args []string
+	for _, arg := range os.Args[1:] {
+		if strings.HasPrefix(arg, "-test.gocoverdir=") {
+			args = append(args, arg)
+		}
+	}
+	return args
+}
+
+type failureProvider struct {
+	checkpoint branching.Checkpoint
+	captureErr error
+}
+
+func (failureProvider) Capability() branching.Capability { return branching.Capability{} }
+
+func (p failureProvider) Capture(context.Context, dal.DB) (branching.Checkpoint, error) {
+	return p.checkpoint, p.captureErr
+}
+
+type failureCheckpoint struct {
+	generation string
+	branch     branching.Branch
+	branchErr  error
+	releaseErr error
+}
+
+func (c *failureCheckpoint) Generation() string { return c.generation }
+
+func (c *failureCheckpoint) Branch(context.Context) (branching.Branch, error) {
+	return c.branch, c.branchErr
+}
+
+func (c *failureCheckpoint) Release(context.Context) error { return c.releaseErr }
+
+type failureBranch struct {
+	db       dal.DB
+	closeErr error
+}
+
+func (b *failureBranch) DB() dal.DB { return b.db }
+
+func (b *failureBranch) Close(context.Context) error { return b.closeErr }
+
+type conformanceFailureScript struct {
+	failureCase string
+	source      dal.DB
+	states      map[dal.DB]string
+}
+
+func scriptedFailureCallbacks(failureCase string) Callbacks {
+	script := &conformanceFailureScript{
+		failureCase: failureCase,
+		states:      make(map[dal.DB]string),
+	}
+	return Callbacks{
+		New: func(testing.TB) (dal.DB, branching.Provider) {
+			script.source = dalgo2memory.NewDB()
+			return script.source, &scriptedProvider{script: script}
+		},
+		Seed: func(_ context.Context, db dal.DB) error {
+			script.states[db] = "baseline"
+			return nil
+		},
+		Mutate: func(_ context.Context, db dal.DB) error {
+			if failureCase == "source mutation unchanged" ||
+				(failureCase == "first sibling unchanged" && db != script.source) {
+				return nil
+			}
+			script.states[db] = "mutated"
+			return nil
+		},
+		Digest: func(_ context.Context, db dal.DB) (string, error) {
+			if state, ok := script.states[db]; ok {
+				return state, nil
+			}
+			return "empty", nil
+		},
+	}
+}
+
+type scriptedProvider struct {
+	script *conformanceFailureScript
+}
+
+func (*scriptedProvider) Capability() branching.Capability { return branching.Capability{} }
+
+func (p *scriptedProvider) Capture(context.Context, dal.DB) (branching.Checkpoint, error) {
+	state := "empty"
+	if captured, ok := p.script.states[p.script.source]; ok {
+		state = captured
+	}
+	return &scriptedCheckpoint{script: p.script, captured: state}, nil
+}
+
+type scriptedCheckpoint struct {
+	script       *conformanceFailureScript
+	captured     string
+	branchCalls  int
+	releaseCalls int
+	released     bool
+	sharedDB     dal.DB
+}
+
+func (*scriptedCheckpoint) Generation() string { return "scripted-generation" }
+
+func (c *scriptedCheckpoint) Branch(context.Context) (branching.Branch, error) {
+	if c.released {
+		if c.script.failureCase == "branch after release" {
+			return nil, nil
+		}
+		return nil, branching.ErrReleased
+	}
+	c.branchCalls++
+	db := dalgo2memory.NewDB()
+	if c.script.failureCase == "siblings same handle" {
+		if c.sharedDB == nil {
+			c.sharedDB = db
+		}
+		db = c.sharedDB
+	}
+	state := c.captured
+	switch {
+	case c.script.failureCase == "empty digest mismatch":
+		state = "different"
+	case c.script.failureCase == "seed digest mismatch":
+		state = "different"
+	case c.script.failureCase == "checkpoint follows source":
+		state = c.script.states[c.script.source]
+	case c.script.failureCase == "second sibling mismatch" && c.branchCalls == 2:
+		state = "different"
+	case c.script.failureCase == "third sibling mismatch" && c.branchCalls == 3:
+		state = "different"
+	}
+	if _, exists := c.script.states[db]; !exists || c.script.failureCase != "siblings same handle" {
+		c.script.states[db] = state
+	}
+	return &failureBranch{db: db}, nil
+}
+
+func (c *scriptedCheckpoint) Release(context.Context) error {
+	c.releaseCalls++
+	c.released = true
+	if (c.script.failureCase == "first release error" && c.releaseCalls == 1) ||
+		(c.script.failureCase == "second release error" && c.releaseCalls == 2) {
+		return errors.New("release failed")
+	}
+	return nil
+}
+
+func setConformanceItem(ctx context.Context, db dal.DB, count int) error {
+	writer, ok := db.(interface {
+		Set(context.Context, record.Record) error
+	})
+	if !ok {
+		return errors.New("database cannot set records")
+	}
+	return writer.Set(ctx, record.NewRecordWithData(conformanceKey, &conformanceItem{Count: count}))
+}
+
+func readConformanceItem(ctx context.Context, db dal.DB) (item conformanceItem, exists bool, err error) {
+	err = db.Get(ctx, record.NewRecordWithData(conformanceKey, &item))
+	if record.IsNotFound(err) {
+		return conformanceItem{}, false, nil
+	}
+	return item, err == nil, err
+}


### PR DESCRIPTION
## What changed

- add an optional provider-neutral database branching contract without widening `dal.DB`
- add the reusable provider conformance harness
- implement fresh checkpoint branches for default serialized `dalgo2memory`
- reject columnar and custom engines explicitly
- cover two-memory grouped branching and partial-failure cleanup

## Why

Chatwright needs immutable database checkpoints and fresh isolated database handles for sequential sibling scenarios.

## Validation

- full `go test ./...`
- full `go vet ./...`
- affected race tests
- provider and grouped-holder tests repeated 20 times
- repository pre-push/CI coverage gate: 100.0%
