### PR TITLE
fix(dal): drop the panic workaround now record classifies records correctly

### DIFF
--- a/access/coverage_test.go
+++ b/access/coverage_test.go
@@ -163,7 +163,7 @@ func TestRemainingCoreBranches(t *testing.T) {
 func TestAllSessionFailureBranches(t *testing.T) {
 	ctx := context.Background()
 	key := record.NewKeyWithID("x", "1")
-	r := record.NewRecord(key)
+	r := record.NewRecordWithData(key, &struct{ Name string }{Name: "policy-test"})
 	rs := []record.Record{r}
 	ks := []*record.Key{key}
 	q := opaqueQ{}

--- a/access/session_test.go
+++ b/access/session_test.go
@@ -136,7 +136,10 @@ func TestSecuredSessionsAllMethods(t *testing.T) {
 	allow := MustPolicy("all", Root(Allow(ReadWrite, "all")), OpaqueQueryScope(Allow(Query, "opaque")), CollectionGroupScope("items", Allow(Query, "group")))
 	rw := SecureReadwriteSession(f, allow)
 	key := record.NewKeyWithID("items", "1")
-	r := record.NewRecord(key)
+	// A data-carrying record: these tests drive WRITE methods, and the write
+	// pipeline validates record data. A bare NewRecord is an envelope awaiting a
+	// load, whose Data() deliberately panics — see dal-go/record v0.1.1.
+	r := record.NewRecordWithData(key, &struct{ Name string }{Name: "policy-test"})
 	rs := []record.Record{r}
 	keys := []*record.Key{key}
 	if ok, err := rw.Exists(ctx, key); !ok || err != nil {
@@ -281,7 +284,7 @@ func TestSecureDBAndTransactions(t *testing.T) {
 	if bound.ID() != "db" || bound.Adapter().Name() != "a" || bound.Schema() == nil || !bound.SupportsConcurrentConnections() {
 		t.Fatal("metadata")
 	}
-	r := record.NewRecord(record.NewKeyWithID("x", "1"))
+	r := record.NewRecordWithData(record.NewKeyWithID("x", "1"), &struct{ Name string }{Name: "policy-test"})
 	if _, err := bound.Exists(context.Background(), r.Key()); err != nil {
 		t.Fatal(err)
 	}

--- a/dal/hooks.go
+++ b/dal/hooks.go
@@ -104,21 +104,21 @@ func beforeSave(_ context.Context, _ DB, r record.Record) error {
 
 // recordDataToValidate returns the data carried by r.
 //
-// record.Record.Data() panics when the record's retrieval state has never been
-// set — which is the normal state of a record about to be written, and the
-// reason this validation path could not have worked even if something had
-// called it. There is no non-panicking way to ask a record.Record whether its
-// state is set, so the pipeline recovers, marks the record error-free (exactly
-// what every storage adapter does before persisting) and reads the data again.
-func recordDataToValidate(r record.Record) (data any) {
+// This used to recover from a panic. record.Record.Data() panics when the
+// record's error has never been set — a deliberate guard against reading data
+// before anyone has checked how the load went — and a record about to be
+// written was landing in that state, so the pipeline caught the panic and
+// cleared the error itself. That was working around the guard rather than
+// respecting it.
+//
+// Fixed properly upstream in github.com/dal-go/record v0.1.1: a record built
+// with caller-supplied data (NewRecordWithData, NewRecordWithoutKey) now sets
+// ErrNoError at construction, because the caller supplied the data and there is
+// no retrieval to wait for. NewRecord — an empty envelope awaiting a load —
+// still guards its data, which is the half of the invariant worth keeping.
+func recordDataToValidate(r record.Record) any {
 	if r == nil {
 		return nil
 	}
-	defer func() {
-		if recover() != nil {
-			r.SetError(nil)
-			data = r.Data()
-		}
-	}()
 	return r.Data()
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/dal-go/dalgo
 
 go 1.24.0
 
-require github.com/dal-go/record v0.1.0
+require github.com/dal-go/record v0.1.1
 
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.24.0

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,9 @@
-github.com/RoaringBitmap/roaring/v2 v2.21.0 h1:RKVgkD+c9ouyCydF2PW/mztDyZTsb7ksas/IofnguDg=
-github.com/RoaringBitmap/roaring/v2 v2.21.0/go.mod h1:SfT3of9nYh3vis1dIbCj4Yw6KQGujTN+f345nrN/0JA=
 github.com/RoaringBitmap/roaring/v2 v2.24.0 h1:zQkkBZtG3WRP4j+P3A5DO221SvL1Br88TJkhyqEQRZo=
 github.com/RoaringBitmap/roaring/v2 v2.24.0/go.mod h1:SfT3of9nYh3vis1dIbCj4Yw6KQGujTN+f345nrN/0JA=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/dal-go/record v0.1.0 h1:hA4143oZwIgtBH/1BRTUEZMCpDfXQr3ONlVXX8USCNg=
-github.com/dal-go/record v0.1.0/go.mod h1:quwsVJTT0f6y3Mhx+yHpTobY7luX1M6kyO6fdJ/AFYE=
+github.com/dal-go/record v0.1.1 h1:N2WVDBnm2tOb83h5DJqFyINB5kH0vLjKlYFAgCJWv2g=
+github.com/dal-go/record v0.1.1/go.mod h1:quwsVJTT0f6y3Mhx+yHpTobY7luX1M6kyO6fdJ/AFYE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=


### PR DESCRIPTION
Follow-up to #105, correcting something that PR got wrong.

## What was wrong

`recordDataToValidate` recovered from a panic. `record.Record.Data()` panics when the error has never been set — and #105 characterised that as a defect making `dal.BeforeSave` unusable.

**It isn't a defect. It's a deliberate guard**: you must not read record data before checking how the load went. The founder confirmed the intent. So #105 worked around its own framework's guard rather than respecting it.

## The actual bug, fixed upstream

Two of `record`'s four constructors misclassified their records:

| Constructor | Data supplied? | Set `ErrNoError` | |
|---|---|---|---|
| `NewRecord(key)` | no | no | ✅ envelope awaiting a load |
| `NewRecordWithData(key, data)` | **yes** | **no** | ❌ |
| `NewRecordWithIncompleteKey(…, data)` | yes | yes | ✅ already right |
| `NewRecordWithoutKey(data)` | **yes** | **no** | ❌ |

Fixed in [dal-go/record v0.1.1](https://github.com/dal-go/record): data supplied by the caller is readable immediately, because there is no retrieval to wait for. An empty envelope still guards its data.

So this PR bumps to record v0.1.1 and deletes the `recover()`.

## Test changes

Three `access` tests passed a bare `NewRecord` to **write** methods. They exercise policy, not data — the record was a placeholder — so they now carry data, which is what a write actually takes. Nothing else changed.

## Two things flagged rather than fixed

1. **`Exists()` now returns `true` for a supplied-but-not-inserted record.** `ErrNoError` conflates "loaded and present" with "supplied, never loaded", and `Exists()` can't tell them apart. `NewRecordWithIncompleteKey` already behaved this way, so this makes constructors consistent rather than introducing something new — but the conflation is real and may deserve a distinct sentinel.
2. **There is still no non-panicking way to ask whether a record's data is readable**, so a data-less record reaching a write panics rather than returning an error.

## Gates

`gofmt` clean · `go vet` clean · `go test -race -count=1 ./...` → 19 packages ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkkrXdtf8mU2GRo2hHsHT1