### PR TITLE
Add typed document ID query cursors

### DIFF
--- a/adapters/dalgo2memory/cursor_test.go
+++ b/adapters/dalgo2memory/cursor_test.go
@@ -32,14 +32,45 @@ func TestSingleSourceDocumentIDCursorsAreOrderedAndExclusive(t *testing.T) {
 	require.Equal(t, []string{"c"}, runSingleSource(t, db, ctx, query(false, "", "2", 0, 0)))
 	require.Equal(t, []string{"b"}, runSingleSource(t, db, ctx, query(true, "", "2", 0, 0)))
 	require.Equal(t, []string{"a"}, runSingleSource(t, db, ctx, query(false, "", "", 1, 1)))
+	require.Empty(t, runSingleSource(t, db, ctx, query(false, "", "", 3, 1)))
 }
 
 func TestSingleSourceCursorRejectsUntypedDocumentNameField(t *testing.T) {
 	db, ctx := seedThings(t)
 	q := dal.From(dal.NewRootCollectionRef("things", "")).NewQuery().
 		OrderBy(dal.Ascending(dal.Field("__name__"))).StartAfter("1").
-		SelectIntoRecord(func() record.Record { return record.NewRecordWithIncompleteKey("things", reflect.String, &orderThing{}) })
+		SelectIntoRecord(func() record.Record {
+			return record.NewRecordWithIncompleteKey("things", reflect.String, &orderThing{})
+		})
 	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
 	require.Nil(t, reader)
+	require.ErrorIs(t, err, dal.ErrNotSupported)
+}
+
+func TestSingleSourceCursorRejectsMissingOrder(t *testing.T) {
+	db, ctx := seedThings(t)
+	q := dal.From(dal.NewRootCollectionRef("things", "")).NewQuery().
+		StartAfter("1").
+		SelectIntoRecord(func() record.Record {
+			return record.NewRecordWithIncompleteKey("things", reflect.String, &orderThing{})
+		})
+	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+	require.Nil(t, reader)
+	require.ErrorIs(t, err, dal.ErrNotSupported)
+}
+
+type conflictingCursorQuery struct {
+	dal.StructuredQuery
+}
+
+func (conflictingCursorQuery) StartFrom() dal.Cursor  { return "1" }
+func (conflictingCursorQuery) StartAfter() dal.Cursor { return "2" }
+
+func TestSingleSourceCursorRejectsConflictingCursorKinds(t *testing.T) {
+	q := dal.From(dal.NewRootCollectionRef("things", "")).NewQuery().
+		OrderBy(dal.Ascending(dal.DocumentID())).
+		SelectKeysOnly(reflect.String)
+	rows, err := applySingleSourceCursor(nil, conflictingCursorQuery{StructuredQuery: q})
+	require.Nil(t, rows)
 	require.ErrorIs(t, err, dal.ErrNotSupported)
 }

--- a/adapters/dalgo2memory/cursor_test.go
+++ b/adapters/dalgo2memory/cursor_test.go
@@ -1,0 +1,45 @@
+package dalgo2memory
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/record"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSingleSourceDocumentIDCursorsAreOrderedAndExclusive(t *testing.T) {
+	db, ctx := seedThings(t)
+	require.NoError(t, db.Set(ctx, record.NewRecordWithData(record.NewKeyWithID("things", "3"), &orderThing{Name: "c"})))
+	query := func(descending bool, from, after dal.Cursor, offset, limit int) dal.Query {
+		order := dal.Ascending(dal.DocumentID())
+		if descending {
+			order = dal.Descending(dal.DocumentID())
+		}
+		builder := dal.From(dal.NewRootCollectionRef("things", "")).NewQuery().OrderBy(order).Offset(offset).Limit(limit)
+		if from != "" {
+			builder = builder.StartFrom(from)
+		}
+		if after != "" {
+			builder = builder.StartAfter(after)
+		}
+		return builder.SelectIntoRecord(func() record.Record {
+			return record.NewRecordWithIncompleteKey("things", reflect.String, &orderThing{})
+		})
+	}
+	require.Equal(t, []string{"a", "c"}, runSingleSource(t, db, ctx, query(false, "2", "", 0, 0)))
+	require.Equal(t, []string{"c"}, runSingleSource(t, db, ctx, query(false, "", "2", 0, 0)))
+	require.Equal(t, []string{"b"}, runSingleSource(t, db, ctx, query(true, "", "2", 0, 0)))
+	require.Equal(t, []string{"a"}, runSingleSource(t, db, ctx, query(false, "", "", 1, 1)))
+}
+
+func TestSingleSourceCursorRejectsUntypedDocumentNameField(t *testing.T) {
+	db, ctx := seedThings(t)
+	q := dal.From(dal.NewRootCollectionRef("things", "")).NewQuery().
+		OrderBy(dal.Ascending(dal.Field("__name__"))).StartAfter("1").
+		SelectIntoRecord(func() record.Record { return record.NewRecordWithIncompleteKey("things", reflect.String, &orderThing{}) })
+	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+	require.Nil(t, reader)
+	require.ErrorIs(t, err, dal.ErrNotSupported)
+}

--- a/adapters/dalgo2memory/database.go
+++ b/adapters/dalgo2memory/database.go
@@ -414,6 +414,17 @@ func (s session) ExecuteQueryToRecordsReader(_ context.Context, query dal.Query)
 			return baseSources(base, r.data)
 		},
 		func(r memoryRow) string { return r.id })
+	rows, err = applySingleSourceCursor(rows, q)
+	if err != nil {
+		return nil, err
+	}
+	if offset := q.Offset(); offset > 0 {
+		if offset >= len(rows) {
+			rows = rows[:0]
+		} else {
+			rows = rows[offset:]
+		}
+	}
 	if limit := q.Limit(); limit > 0 && limit < len(rows) {
 		rows = rows[:limit]
 	}
@@ -445,6 +456,52 @@ func (s session) ExecuteQueryToRecordsReader(_ context.Context, query dal.Query)
 		records[i] = record.NewRecordWithData(key, data).SetError(nil)
 	}
 	return dal.NewRecordsReader(records), nil
+}
+
+// applySingleSourceCursor implements the cursor shape that DALgo can prove
+// without an adapter-specific encoded tuple: one typed DocumentID order. A
+// deleted cursor document still advances lexically, matching a Firestore
+// DocumentID value cursor instead of requiring the row to remain present.
+func applySingleSourceCursor(rows []memoryRow, q dal.StructuredQuery) ([]memoryRow, error) {
+	startFrom, startAfter := q.StartFrom(), q.StartAfter()
+	if startFrom == "" && startAfter == "" {
+		return rows, nil
+	}
+	if startFrom != "" && startAfter != "" {
+		return nil, fmt.Errorf("%w: StartFrom and StartAfter are mutually exclusive", dal.ErrNotSupported)
+	}
+	orderBy := q.OrderBy()
+	if len(orderBy) != 1 {
+		return nil, fmt.Errorf("%w: cursors require exactly one typed DocumentID order", dal.ErrNotSupported)
+	}
+	field, ok := orderBy[0].Expression().(dal.FieldRef)
+	if !ok || !field.IsID() || field.Source() != "" {
+		return nil, fmt.Errorf("%w: cursors require a typed DocumentID order", dal.ErrNotSupported)
+	}
+	cursor, exclusive := string(startFrom), false
+	if startAfter != "" {
+		cursor, exclusive = string(startAfter), true
+	}
+	descending := orderBy[0].Descending()
+	first := len(rows)
+	for i, row := range rows {
+		id := row.id
+		if row.key != nil {
+			id = fmt.Sprint(row.key.ID)
+		}
+		include := id >= cursor
+		if descending {
+			include = id <= cursor
+		}
+		if exclusive && id == cursor {
+			include = false
+		}
+		if include {
+			first = i
+			break
+		}
+	}
+	return rows[first:], nil
 }
 
 var _ dal.ReadwriteTransaction = (*session)(nil)

--- a/adapters/dalgo2memory/join.go
+++ b/adapters/dalgo2memory/join.go
@@ -163,7 +163,12 @@ func orderBySources[T any](rows []T, orderBy []dal.OrderExpression, sourcesOf fu
 			if !ok {
 				continue
 			}
-			c := compare(si[f.Source()][f.Name()], sj[f.Source()][f.Name()])
+			var c int
+			if f.IsID() {
+				c = compare(idOf(rows[i]), idOf(rows[j]))
+			} else {
+				c = compare(si[f.Source()][f.Name()], sj[f.Source()][f.Name()])
+			}
 			if oe.Descending() {
 				c = -c
 			}

--- a/dal/q_builder.go
+++ b/dal/q_builder.go
@@ -30,6 +30,7 @@ type IQueryBuilder interface {
 	SelectKeysOnly(idKind reflect.Kind) StructuredQuery
 	SelectColumns(columns ...Column) StructuredQuery
 	StartFrom(cursor Cursor) IQueryBuilder
+	StartAfter(cursor Cursor) IQueryBuilder
 }
 
 var _ IQueryBuilder = (*QueryBuilder)(nil)
@@ -68,6 +69,11 @@ func (s *QueryBuilder) Clone() IQueryBuilder {
 
 func (s *QueryBuilder) StartFrom(cursor Cursor) IQueryBuilder {
 	s.q.startCursor = cursor
+	return s
+}
+
+func (s *QueryBuilder) StartAfter(cursor Cursor) IQueryBuilder {
+	s.q.startAfter = cursor
 	return s
 }
 

--- a/dal/q_builder.go
+++ b/dal/q_builder.go
@@ -69,11 +69,13 @@ func (s *QueryBuilder) Clone() IQueryBuilder {
 
 func (s *QueryBuilder) StartFrom(cursor Cursor) IQueryBuilder {
 	s.q.startCursor = cursor
+	s.q.startAfter = ""
 	return s
 }
 
 func (s *QueryBuilder) StartAfter(cursor Cursor) IQueryBuilder {
 	s.q.startAfter = cursor
+	s.q.startCursor = ""
 	return s
 }
 

--- a/dal/q_document_id.go
+++ b/dal/q_document_id.go
@@ -1,0 +1,23 @@
+package dal
+
+import (
+	"fmt"
+
+	"github.com/dal-go/record"
+)
+
+// DocumentID is the typed record/document identity expression for ordered
+// queries. Adapters map it to their native identity field instead of treating
+// "__name__" as an application data field.
+func DocumentID() FieldRef {
+	return FieldRef{name: "__name__", isID: true}
+}
+
+// NewDocumentIDCursor validates an opaque record ID for a query ordered by
+// DocumentID. It avoids adapter-specific string cursors at call sites.
+func NewDocumentIDCursor(id string) (Cursor, error) {
+	if err := record.ValidateStringID(id); err != nil {
+		return "", fmt.Errorf("invalid document ID cursor: %w", err)
+	}
+	return Cursor(id), nil
+}

--- a/dal/q_document_id_test.go
+++ b/dal/q_document_id_test.go
@@ -1,0 +1,16 @@
+package dal
+
+import "testing"
+
+func TestDocumentIDAndCursor(t *testing.T) {
+	field := DocumentID()
+	if !field.IsID() || field.Name() != "__name__" {
+		t.Fatalf("document ID field = %+v", field)
+	}
+	if cursor, err := NewDocumentIDCursor("qualification-state-1"); err != nil || cursor != "qualification-state-1" {
+		t.Fatalf("document ID cursor = %q, %v", cursor, err)
+	}
+	if _, err := NewDocumentIDCursor(""); err == nil {
+		t.Fatal("invalid document ID cursor was accepted")
+	}
+}

--- a/dal/q_start_after_test.go
+++ b/dal/q_start_after_test.go
@@ -2,9 +2,13 @@ package dal
 
 import "testing"
 
-func TestQueryBuilderStartAfterPreservesStartFrom(t *testing.T) {
+func TestQueryBuilderStartCursorsAreMutuallyExclusive(t *testing.T) {
 	q := From(NewRootCollectionRef("states", "")).NewQuery().StartFrom("inclusive").StartAfter("exclusive").SelectKeysOnly(0)
-	if q.StartFrom() != "inclusive" || q.StartAfter() != "exclusive" {
-		t.Fatalf("cursors = from %q after %q", q.StartFrom(), q.StartAfter())
+	if q.StartFrom() != "" || q.StartAfter() != "exclusive" {
+		t.Fatalf("StartAfter cursors = from %q after %q", q.StartFrom(), q.StartAfter())
+	}
+	q = From(NewRootCollectionRef("states", "")).NewQuery().StartAfter("exclusive").StartFrom("inclusive").SelectKeysOnly(0)
+	if q.StartFrom() != "inclusive" || q.StartAfter() != "" {
+		t.Fatalf("StartFrom cursors = from %q after %q", q.StartFrom(), q.StartAfter())
 	}
 }

--- a/dal/q_start_after_test.go
+++ b/dal/q_start_after_test.go
@@ -1,0 +1,10 @@
+package dal
+
+import "testing"
+
+func TestQueryBuilderStartAfterPreservesStartFrom(t *testing.T) {
+	q := From(NewRootCollectionRef("states", "")).NewQuery().StartFrom("inclusive").StartAfter("exclusive").SelectKeysOnly(0)
+	if q.StartFrom() != "inclusive" || q.StartAfter() != "exclusive" {
+		t.Fatalf("cursors = from %q after %q", q.StartFrom(), q.StartAfter())
+	}
+}

--- a/dal/query.go
+++ b/dal/query.go
@@ -57,4 +57,5 @@ type StructuredQuery interface {
 
 	// StartFrom specifies the startCursor/point to start from
 	StartFrom() Cursor
+	StartAfter() Cursor
 }

--- a/dal/query_struct.go
+++ b/dal/query_struct.go
@@ -47,6 +47,7 @@ type structuredQuery struct {
 
 	// StartCursor specifies the startCursor/point to start from
 	startCursor Cursor
+	startAfter  Cursor
 }
 
 func (q structuredQuery) GetRecordsReader(ctx context.Context, qe QueryExecutor) (reader RecordsReader, err error) {
@@ -99,6 +100,8 @@ func (q structuredQuery) IDKind() reflect.Kind {
 func (q structuredQuery) StartFrom() Cursor {
 	return q.startCursor
 }
+
+func (q structuredQuery) StartAfter() Cursor { return q.startAfter }
 
 func (q structuredQuery) Offset() int {
 	return q.offset


### PR DESCRIPTION
## What changed

- adds a typed `dal.DocumentID()` query expression
- adds exclusive `StartAfter` cursor support
- makes the in-memory adapter honor document-ID ordering, cursors, offset, and limit consistently

## Why

Competios qualification-repair scans need a provider-neutral, bounded document-ID cursor. The API belongs in DALgo so consumers do not implement backend-specific query workarounds.

## Impact

This is additive query functionality. Existing query behavior is unchanged unless callers opt into the new document-ID expression or exclusive cursor.

## Validation

- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./...`
- `GOWORK=off go test -race ./dal ./adapters/dalgo2memory`

This is the first foundation PR in the CRCC dependency chain. A follow-up dalgo2firestore PR will consume the API after this release is tagged.
