### PR TITLE
Add opt-in optimistic-concurrency transactions to dalgo2memory

### DIFF
--- a/adapters/dalgo2memory/database.go
+++ b/adapters/dalgo2memory/database.go
@@ -31,6 +31,7 @@ func newDatabase(options ...Option) *database {
 	db := &database{
 		collections:       make(map[string]storageEngine),
 		schemaRefBreaking: true,
+		versions:          make(map[string]uint64),
 	}
 	for _, option := range options {
 		if option != nil {
@@ -59,6 +60,23 @@ type database struct {
 	// schemaRefBreaking is the schema-wide columnar fidelity default (faithful
 	// unless WithoutSchemaRefBreaking was used). NewDB initializes it to true.
 	schemaRefBreaking bool
+
+	// optimisticConcurrency selects the opt-in optimistic-concurrency
+	// read-write transaction mode (see WithOptimisticConcurrency) in place of
+	// the default whole-database lock RunReadwriteTransaction otherwise holds
+	// for a transaction's entire duration. Default false: nothing below
+	// changes behavior until it is set.
+	optimisticConcurrency bool
+	// versions is the commit-version table optimistic-mode transactions
+	// validate their reads against at commit (see optimisticState.commit): it
+	// maps a conflictKey to the number of times a committed write has touched
+	// it. A key absent from the map has an implicit version of 0, which
+	// doubles as "does not exist yet", so a transaction that observed a key as
+	// absent still conflicts correctly if another transaction inserts it
+	// first. It is guarded by mu exactly like the storage engines are — see
+	// optimisticState's doc comment for why one short-lived critical section
+	// covers both.
+	versions map[string]uint64
 }
 
 func (db *database) ID() string {
@@ -80,6 +98,9 @@ func (db *database) RunReadonlyTransaction(ctx context.Context, f dal.ROTxWorker
 }
 
 func (db *database) RunReadwriteTransaction(ctx context.Context, f dal.RWTxWorker, _ ...dal.TransactionOption) error {
+	if db.optimisticConcurrency {
+		return db.runOptimisticReadwriteTransaction(ctx, f)
+	}
 	db.mu.Lock()
 	defer db.mu.Unlock()
 	return f(ctx, session{db: db, txState: &transactionState{
@@ -181,6 +202,13 @@ type session struct {
 type transactionState struct {
 	noReadsAfterWrites bool
 	hasWritten         bool
+	// optimistic is non-nil exactly when this transaction belongs to a
+	// database created with WithOptimisticConcurrency. Every session
+	// read/write method checks it first (via session.optimistic()) to route
+	// through the buffered, commit-validated path in optimistic.go instead of
+	// the immediate engine access below, which only ever runs for a top-level
+	// (non-transactional) call or a default-mode transaction.
+	optimistic *optimisticState
 }
 
 // ErrReadAfterWriteInTransaction matches the ordering error returned by
@@ -200,6 +228,19 @@ func (s session) markWrite() {
 	}
 }
 
+// optimistic returns this session's optimisticState, or nil for a top-level
+// (non-transactional) call, a readonly transaction, or a read-write
+// transaction on a database created without WithOptimisticConcurrency. It is
+// the single branch point every read/write method below uses to choose
+// between the buffered path (optimistic.go) and the immediate engine access
+// that was this package's only behavior before that mode existed.
+func (s session) optimistic() *optimisticState {
+	if s.txState == nil {
+		return nil
+	}
+	return s.txState.optimistic
+}
+
 func (s session) ID() string {
 	return ""
 }
@@ -212,6 +253,9 @@ func (s session) Exists(_ context.Context, key *record.Key) (bool, error) {
 	if err := s.allowRead(); err != nil {
 		return false, err
 	}
+	if opt := s.optimistic(); opt != nil {
+		return opt.exists(key)
+	}
 	return s.db.engine(key.Collection()).exists(keyID(key)), nil
 }
 
@@ -219,6 +263,9 @@ func (s session) Get(_ context.Context, rec record.Record) error {
 	if err := s.allowRead(); err != nil {
 		rec.SetError(err)
 		return err
+	}
+	if opt := s.optimistic(); opt != nil {
+		return opt.get(rec)
 	}
 	if err := s.db.guardCollection(rec.Key().Collection()); err != nil {
 		rec.SetError(err)
@@ -245,6 +292,13 @@ func (s session) GetMulti(ctx context.Context, records []record.Record) error {
 }
 
 func (s session) Set(_ context.Context, rec record.Record) error {
+	if opt := s.optimistic(); opt != nil {
+		if err := opt.stage(rec); err != nil {
+			return err
+		}
+		s.markWrite()
+		return nil
+	}
 	if err := s.save(rec, true); err != nil {
 		return err
 	}
@@ -276,6 +330,34 @@ func (s session) Insert(ctx context.Context, rec record.Record, opts ...dal.Inse
 		// dal.WithAdapterGeneratedID contract fall back to the default random-string generator.
 		gen = dal.NewInsertOptions(dal.WithRandomStringKey(dal.DefaultRandomStringIDLength, 5)).IDGenerator()
 	}
+
+	if opt := s.optimistic(); opt != nil {
+		if gen != nil {
+			err := dal.InsertWithIdGenerator(ctx, rec, gen, insertWithGeneratorMaxAttempts,
+				func(key *record.Key) error {
+					present, err := opt.exists(key)
+					if err != nil {
+						return err
+					}
+					if present {
+						return nil // id is taken: signal "exists" so generation retries
+					}
+					return record.ErrRecordNotFound // id is free: signal "not found" so it is inserted
+				},
+				opt.insert,
+			)
+			if err == nil {
+				s.markWrite()
+			}
+			return err
+		}
+		if err := opt.insert(rec); err != nil {
+			return err
+		}
+		s.markWrite()
+		return nil
+	}
+
 	if gen != nil {
 		err := dal.InsertWithIdGenerator(ctx, rec, gen, insertWithGeneratorMaxAttempts,
 			func(key *record.Key) error {
@@ -310,7 +392,14 @@ func (s session) InsertMulti(ctx context.Context, records []record.Record, opts 
 }
 
 func (s session) Delete(_ context.Context, key *record.Key) error {
-	s.db.engine(key.Collection()).delete(keyID(key))
+	if opt := s.optimistic(); opt != nil {
+		opt.delete(key)
+		s.markWrite()
+		return nil
+	}
+	id := keyID(key)
+	s.db.engine(key.Collection()).delete(id)
+	s.db.bumpConflictVersion(key.Collection(), id)
 	s.markWrite()
 	return nil
 }
@@ -328,13 +417,22 @@ func (s session) Update(ctx context.Context, key *record.Key, updates []update.U
 }
 
 func (s session) UpdateRecord(_ context.Context, record record.Record, updates []update.Update, _ ...dal.Precondition) error {
+	if opt := s.optimistic(); opt != nil {
+		if err := opt.updateRecord(record, updates); err != nil {
+			return err
+		}
+		s.markWrite()
+		return nil
+	}
 	collectionName := record.Key().Collection()
 	if err := s.db.guardCollection(collectionName); err != nil {
 		return err
 	}
-	if err := s.db.engine(collectionName).update(keyID(record.Key()), updates); err != nil {
+	id := keyID(record.Key())
+	if err := s.db.engine(collectionName).update(id, updates); err != nil {
 		return err
 	}
+	s.db.bumpConflictVersion(collectionName, id)
 	s.markWrite()
 	return nil
 }
@@ -351,6 +449,15 @@ func (s session) UpdateMulti(ctx context.Context, keys []*record.Key, updates []
 func (s session) ExecuteQueryToRecordsReader(_ context.Context, query dal.Query) (dal.RecordsReader, error) {
 	if err := s.allowRead(); err != nil {
 		return nil, err
+	}
+	if s.optimistic() != nil {
+		// A query scans committed storage directly (see loadCandidateRows), so
+		// inside an optimistic-mode transaction it would see neither this
+		// transaction's own buffered writes nor participate in its conflict
+		// detection — a correctness trap, not a convenience. Point reads/writes
+		// by key (Get, Exists, Set, Insert, Update, Delete) are fully supported;
+		// see WithOptimisticConcurrency's doc comment.
+		return nil, fmt.Errorf("%w: queries are not supported inside a WithOptimisticConcurrency read-write transaction; read by key, or run the query outside the transaction", dal.ErrNotSupported)
 	}
 	q, ok := query.(dal.StructuredQuery)
 	if !ok {
@@ -520,10 +627,12 @@ func (s session) save(record record.Record, overwrite bool) error {
 		return err
 	}
 	record.SetError(nil)
-	if err := s.db.engine(collectionName).store(keyID(record.Key()), record, overwrite); err != nil {
+	id := keyID(record.Key())
+	if err := s.db.engine(collectionName).store(id, record, overwrite); err != nil {
 		record.SetError(err)
 		return err
 	}
+	s.db.bumpConflictVersion(collectionName, id)
 	record.SetError(nil)
 	return nil
 }

--- a/adapters/dalgo2memory/optimistic.go
+++ b/adapters/dalgo2memory/optimistic.go
@@ -1,0 +1,556 @@
+package dalgo2memory
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/record"
+	"github.com/dal-go/record/update"
+)
+
+// ErrTransactionConflict is returned by RunReadwriteTransaction, for a
+// database created with WithOptimisticConcurrency, when another transaction
+// committed a write to a key this transaction read or wrote before this
+// transaction reached its own commit. A caller that wants to retry should
+// test for it with IsTransactionConflict rather than a direct comparison,
+// since the error returned always wraps additional diagnostic context.
+//
+// Before adding this, both the dal and record packages (dalgo's own error
+// vocabulary) were searched for an existing conflict / retryable / aborted
+// error type or predicate to reuse instead — dalgo2mysql, dalgo2sql,
+// dalgo2postgres and dalgo2sqlite were checked too, in case a convention
+// already existed for a backend that has real serialization failures. None of
+// them define one. This sentinel-plus-predicate pair follows the same idiom
+// this package already uses for ErrReadAfterWriteInTransaction (a checked
+// sentinel) and that the record package uses for
+// ErrRecordNotFound/IsNotFound (a predicate function) — see IsTransactionConflict.
+var ErrTransactionConflict = errors.New("dalgo2memory: transaction conflict: another transaction committed a write to a key this transaction read or wrote")
+
+// IsTransactionConflict reports whether err is, or wraps, ErrTransactionConflict.
+// A caller of a WithOptimisticConcurrency database's RunReadwriteTransaction
+// should use this to decide whether a failed transaction is safe to retry.
+func IsTransactionConflict(err error) bool {
+	return err != nil && errors.Is(err, ErrTransactionConflict)
+}
+
+// optimisticState buffers one read-write transaction's reads and writes when
+// the owning database runs with WithOptimisticConcurrency, instead of the
+// whole-database lock RunReadwriteTransaction otherwise holds for the
+// callback's entire duration.
+//
+// Nothing here touches a storage engine until commit (see the commit method),
+// and that is not merely an optimization: it is what makes the failure mode
+// correct. Consider two transactions racing to claim the same slug with
+// Get-then-Insert. If Insert instead wrote through to the engine immediately
+// (as the default mode's session.save does), the loser would either get
+// whatever "duplicate" error the engine happens to raise — which depends on
+// write ordering, not on what either transaction actually observed — or, if
+// it happened to write first and got overtaken afterwards, its write would be
+// visible to any other reader for real before anyone had detected the
+// conflict, and undoing it would need its own undo log that the storage
+// engines don't have. Deferring every write to a single, lock-guarded commit
+// step sidesteps both problems: nothing is visible until it is valid, and the
+// side that loses the race always gets ErrTransactionConflict specifically,
+// which is the error a caller can actually retry on.
+//
+// The trade-off this buys: within one transaction, the immediate return value
+// of Get/Exists/Set/Insert/Update/Delete only ever reflects what that same
+// transaction has itself observed or written (see touch) — never a
+// concurrent transaction's uncommitted work, and, for a key this transaction
+// has not yet touched, never storage-fidelity validation a write's data would
+// eventually fail (see validateForCommit's doc comment for the narrow gap
+// that remains there). Existence-driven outcomes (Insert's duplicate check,
+// Update's not-found check) are still resolved eagerly and correctly against
+// this transaction's own view, exactly as they are in the default mode — the
+// only thing that moves to commit time is telling this transaction whether
+// its view was still valid when it finished.
+type optimisticState struct {
+	db *database
+
+	// reads is this transaction's read set: the commit version observed the
+	// first time each key was touched — by a read OR a write, see touch.
+	// commit fails the transaction if any of these versions has advanced by
+	// the time it runs.
+	reads map[string]uint64
+
+	// pending is this transaction's local, mutable view of every key it has
+	// touched so far, keyed by conflictKey. See pendingEntry and touch.
+	pending map[string]*pendingEntry
+}
+
+// pendingEntry is one key's transaction-local view: the outcome of every
+// Get/Exists/Set/Insert/Update/Delete this transaction has issued for the
+// key, kept current so a later operation on the same key in the same
+// transaction sees this transaction's own uncommitted writes (Firestore
+// transactions behave the same way: a read after a write in the same
+// transaction sees the write).
+type pendingEntry struct {
+	// key is the full key (with its parent chain) this entry was first
+	// touched through.
+	key *record.Key
+	// present and data together are this transaction's current view of the
+	// key's value: present is false for a key this transaction has observed
+	// as absent (never stored, or deleted within this transaction); when
+	// present, data is the fully decoded row, JSON-normalized the same way
+	// normalizeData produces it.
+	present bool
+	data    map[string]any
+	// commit describes how to apply this entry to the real storage engine at
+	// commit time, reflecting only the LAST write this transaction made to
+	// the key — an Update layered on an earlier Set in the same transaction
+	// collapses to just the net resolved value, since only the final state is
+	// ever visible to anyone once this transaction commits. It is nil for a
+	// key this transaction has only read.
+	commit *pendingWrite
+}
+
+// pendingWriteKind distinguishes the two things commit can do to a key.
+type pendingWriteKind int
+
+const (
+	pendingWriteStore pendingWriteKind = iota
+	pendingWriteDelete
+)
+
+// pendingWrite is how commit replays one key's net write against the real
+// storage engine. rec/overwrite are only meaningful for pendingWriteStore.
+type pendingWrite struct {
+	kind      pendingWriteKind
+	rec       record.Record
+	overwrite bool
+}
+
+// conflictKey identifies a stored record for optimistic-concurrency version
+// tracking. It is collection-prefixed because keyID's own doc comment already
+// notes that a root-level id is not namespaced by collection on its own (two
+// different collections can share a leaf id); a nested record's keyID already
+// carries its full collection/id chain, so the prefix is redundant there but
+// harmless.
+func conflictKey(collection, id string) string {
+	return collection + "\x00" + id
+}
+
+// runOptimisticReadwriteTransaction is RunReadwriteTransaction's
+// WithOptimisticConcurrency path — see optimisticState's doc comment for the
+// design. It never holds db.mu for the callback's duration, only briefly, once
+// per read/write operation, and once more (also briefly) for the final
+// commit, so unrelated transactions' callbacks run fully concurrently: a
+// transaction can even pause indefinitely between operations (as a test
+// driving a specific interleaving does) without blocking anyone else, since
+// it is not holding any lock while paused.
+func (db *database) runOptimisticReadwriteTransaction(ctx context.Context, f dal.RWTxWorker) error {
+	tx := &optimisticState{
+		db:      db,
+		reads:   make(map[string]uint64),
+		pending: make(map[string]*pendingEntry),
+	}
+	s := session{db: db, txState: &transactionState{
+		noReadsAfterWrites: db.noReadsAfterWritesInTransaction,
+		optimistic:         tx,
+	}}
+	if err := f(ctx, s); err != nil {
+		return err
+	}
+	return tx.commit()
+}
+
+// bumpConflictVersion advances the commit-version counter for one key when
+// this database runs with WithOptimisticConcurrency, so an in-flight
+// optimistic transaction correctly treats a write made outside any
+// transaction as a conflicting external commit (a default-mode transaction
+// never reaches this: RunReadwriteTransaction routes every transaction
+// through runOptimisticReadwriteTransaction instead, once optimisticConcurrency
+// is set, so the only caller left here is a top-level, non-transactional
+// write). It is a no-op — adding no locking or bookkeeping cost — for a
+// database created without WithOptimisticConcurrency, keeping the default
+// path exactly as it was before this mode existed.
+//
+// Callers must already hold db.mu: every call site (session.save, the
+// non-optimistic session.Delete and session.UpdateRecord) does, since all
+// three only ever run inside a top-level method or a default-mode
+// transaction, both of which hold it for the call's duration.
+func (db *database) bumpConflictVersion(collection, id string) {
+	if !db.optimisticConcurrency {
+		return
+	}
+	db.versions[conflictKey(collection, id)]++
+}
+
+// firstTouchEntry returns key's pendingEntry, creating it — and recording its
+// commit-version baseline in reads — on first contact. isNew reports whether
+// this call created it, which touch uses to decide whether the entry still
+// needs to be populated from the live engine. The caller must already hold
+// db.mu, so that creating the entry and snapshotting the live commit version
+// happen atomically with respect to any other transaction's commit.
+//
+// A key's first contact establishes this transaction's baseline for it
+// whether that contact is a read or a write, matching the rule that a
+// transaction conflicts on a key it wrote just as much as one it only read.
+func (tx *optimisticState) firstTouchEntry(collection, id string, key *record.Key) (entry *pendingEntry, isNew bool) {
+	ck := conflictKey(collection, id)
+	if existing, ok := tx.pending[ck]; ok {
+		return existing, false
+	}
+	if _, ok := tx.reads[ck]; !ok {
+		tx.reads[ck] = tx.db.versions[ck] // implicit 0 for a key with no committed write yet
+	}
+	entry = &pendingEntry{key: key}
+	tx.pending[ck] = entry
+	return entry, true
+}
+
+// touch is the read-side entry point into a key's transaction-local view: it
+// returns the pendingEntry, loading it from the live engine on first contact
+// so this and later reads in the same transaction see a stable,
+// JSON-normalized value without going back to the engine again. Get, Exists
+// (via read), Insert's duplicate check, and Update's merge all go through it.
+// A later call for the same key, from any operation, always reuses the
+// existing entry instead — that is what gives read-your-own-writes within one
+// transaction even though nothing has actually reached the shared store yet.
+// A write that does not need the prior value (Set, Delete) uses
+// firstTouchEntry directly instead, since it can never fail. The caller must
+// already hold db.mu.
+func (tx *optimisticState) touch(collection, id string, key *record.Key) (*pendingEntry, error) {
+	entry, isNew := tx.firstTouchEntry(collection, id, key)
+	if !isNew {
+		return entry, nil
+	}
+	eng := tx.db.engine(collection)
+	var data map[string]any
+	target := record.NewRecordWithData(key, &data)
+	switch err := eng.load(id, target); {
+	case err == nil:
+		entry.present = true
+		entry.data = data
+	case record.IsNotFound(err):
+		// leave entry.present at its zero value (false)
+	default:
+		return nil, err
+	}
+	return entry, nil
+}
+
+// read performs one read-side touch: it takes db.mu, resolves the key's
+// pendingEntry, and releases db.mu again before returning. Both session.Get
+// and session.Exists go through it.
+func (tx *optimisticState) read(collection, id string, key *record.Key) (*pendingEntry, error) {
+	tx.db.mu.Lock()
+	defer tx.db.mu.Unlock()
+	return tx.touch(collection, id, key)
+}
+
+// get implements session.Get for an optimistic-mode transaction.
+func (tx *optimisticState) get(rec record.Record) error {
+	key := rec.Key()
+	collection := key.Collection()
+	if err := tx.db.guardCollection(collection); err != nil {
+		rec.SetError(err)
+		return err
+	}
+	entry, err := tx.read(collection, keyID(key), key)
+	if err != nil {
+		rec.SetError(err)
+		return err
+	}
+	if !entry.present {
+		notFoundErr := dal.NewErrNotFoundByKey(key, nil)
+		rec.SetError(notFoundErr)
+		return notFoundErr
+	}
+	rec.SetError(nil)
+	if err := materializeInto(entry.data, rec.Data()); err != nil {
+		rec.SetError(err)
+		return err
+	}
+	return nil
+}
+
+// exists implements session.Exists for an optimistic-mode transaction. Like
+// the default mode's session.Exists, it performs no schema-guard check.
+func (tx *optimisticState) exists(key *record.Key) (bool, error) {
+	entry, err := tx.read(key.Collection(), keyID(key), key)
+	if err != nil {
+		return false, err
+	}
+	return entry.present, nil
+}
+
+// stage implements session.Set for an optimistic-mode transaction: rec's data
+// becomes this transaction's resolved value for its key, replacing whatever
+// this transaction observed there before (an earlier read, or an earlier
+// write of its own). Nothing reaches the shared storage engine until commit —
+// see optimisticState's doc comment. Unlike insert, staging a Set can never
+// fail once its data has validated, since Set has no duplicate check to
+// consult the key's prior value for.
+func (tx *optimisticState) stage(rec record.Record) error {
+	key := rec.Key()
+	collection := key.Collection()
+	factory, err := tx.db.recordFactory(collection)
+	if err != nil {
+		rec.SetError(err)
+		return err
+	}
+	data, err := normalizeData(rec.Data())
+	if err != nil {
+		rec.SetError(err)
+		return err
+	}
+	if err := validateForCommit(collection, factory, data); err != nil {
+		rec.SetError(err)
+		return err
+	}
+
+	tx.db.mu.Lock()
+	entry, _ := tx.firstTouchEntry(collection, keyID(key), key)
+	entry.present = true
+	entry.data = data
+	entry.commit = &pendingWrite{kind: pendingWriteStore, rec: rec, overwrite: true}
+	tx.db.mu.Unlock()
+
+	rec.SetError(nil)
+	return nil
+}
+
+// insert implements session.Insert for an optimistic-mode transaction.
+// Unlike stage, it first consults this transaction's own view of the key
+// (via touch, which loads from the live engine only on the key's first
+// contact) and fails immediately, with the same "record already exists"
+// shape the engines themselves use, if this transaction has already observed
+// the key as present. That keeps a same-transaction duplicate (e.g. Insert
+// after a Get that found the key) an immediate, ordinary error exactly as in
+// the default mode (see TestInsertDuplicateAndMissingUpdate); a race with a
+// *different*, concurrently-committing transaction is instead only caught
+// later, at commit, as ErrTransactionConflict — see optimisticState's doc
+// comment for why the two cases need different errors.
+func (tx *optimisticState) insert(rec record.Record) error {
+	key := rec.Key()
+	collection := key.Collection()
+	factory, err := tx.db.recordFactory(collection)
+	if err != nil {
+		rec.SetError(err)
+		return err
+	}
+	data, err := normalizeData(rec.Data())
+	if err != nil {
+		rec.SetError(err)
+		return err
+	}
+	if err := validateForCommit(collection, factory, data); err != nil {
+		rec.SetError(err)
+		return err
+	}
+
+	tx.db.mu.Lock()
+	entry, touchErr := tx.touch(collection, keyID(key), key)
+	var resultErr error
+	switch {
+	case touchErr != nil:
+		resultErr = touchErr
+	case entry.present:
+		resultErr = fmt.Errorf("record already exists: %s", key)
+	default:
+		entry.present = true
+		entry.data = data
+		entry.commit = &pendingWrite{kind: pendingWriteStore, rec: rec, overwrite: false}
+	}
+	tx.db.mu.Unlock()
+
+	if resultErr != nil {
+		rec.SetError(resultErr)
+		return resultErr
+	}
+	rec.SetError(nil)
+	return nil
+}
+
+// delete implements session.Delete for an optimistic-mode transaction. Like
+// the default mode's session.Delete, deleting an already-absent key is a
+// no-op (never an error), and no schema-guard check is performed.
+func (tx *optimisticState) delete(key *record.Key) {
+	collection := key.Collection()
+	tx.db.mu.Lock()
+	defer tx.db.mu.Unlock()
+	// A delete never needs the prior value, so firstTouchEntry (which never
+	// fails) is enough — no need for touch's live-engine load.
+	entry, _ := tx.firstTouchEntry(collection, keyID(key), key)
+	entry.present = false
+	entry.data = nil
+	entry.commit = &pendingWrite{kind: pendingWriteDelete}
+}
+
+// updateRecord implements session.UpdateRecord for an optimistic-mode
+// transaction. Like the live engines' update, it requires the key to already
+// exist — checked eagerly against this transaction's own view, matching the
+// default mode's immediate not-found behavior — then applies updates to a
+// copy of this transaction's local snapshot via the same applyUpdatesToMap
+// the live engines use, so a second Update of the same key later in the same
+// transaction compounds on top of the first rather than the value the
+// transaction started with.
+func (tx *optimisticState) updateRecord(rec record.Record, updates []update.Update) error {
+	key := rec.Key()
+	collection := key.Collection()
+	factory, err := tx.db.recordFactory(collection)
+	if err != nil {
+		return err
+	}
+
+	tx.db.mu.Lock()
+	defer tx.db.mu.Unlock()
+	entry, err := tx.touch(collection, keyID(key), key)
+	if err != nil {
+		return err
+	}
+	if !entry.present {
+		return dal.NewErrNotFoundByKey(key, nil)
+	}
+	// Work on a defensive copy so a failure below (an unknown field, say)
+	// cannot leave entry.data half-updated for a later read in this same
+	// transaction to observe. cloneEntryData, unlike normalizeData, cannot
+	// itself fail: entry.data is already valid, previously round-tripped JSON
+	// data (see cloneEntryData's doc comment).
+	merged := cloneEntryData(entry.data)
+	if err := applyUpdatesToMap(merged, updates); err != nil {
+		return err
+	}
+	if err := validateForCommit(collection, factory, merged); err != nil {
+		return err
+	}
+	entry.data = merged
+	entry.commit = &pendingWrite{
+		kind:      pendingWriteStore,
+		rec:       record.NewRecordWithData(key, merged),
+		overwrite: true,
+	}
+	return nil
+}
+
+// commit is called once, synchronously, when the transaction's callback
+// returns nil (see runOptimisticReadwriteTransaction). It validates this
+// transaction's full read set — every key it touched, by a read or a write,
+// see touch — against the live commit-version table and, only if nothing has
+// changed since this transaction first touched it, applies its buffered
+// writes for real and advances their versions. Both steps run inside one
+// critical section so that validating and applying are atomic with respect to
+// every other transaction's own commit: that atomicity is the entire point,
+// since two separate steps here is exactly what a concurrent commit could
+// interleave between.
+//
+// A deferred validation failure — a buffered write whose data passed the
+// eager validateForCommit check at the point of the call, but still somehow
+// fails the target storage engine's own validation (a declared columnar
+// column's type mismatch discovered only during the real engine.store, for
+// instance) — can leave a multi-key commit partially applied: an earlier
+// key's write in the same commit may already have been applied to the engine
+// before a later key's write fails. This is a narrow, documented gap, not a
+// silent one: it cannot happen for the Serialized engine, nor for any of the
+// failure modes validateForCommit already screens for (unknown fields,
+// non-marshalable data) — see WithOptimisticConcurrency's doc comment and
+// this adapter's Feature report for the trade-off this accepts rather than
+// building a full two-phase commit across the storageEngine interface.
+func (tx *optimisticState) commit() error {
+	tx.db.mu.Lock()
+	defer tx.db.mu.Unlock()
+
+	for ck, baseline := range tx.reads {
+		if tx.db.versions[ck] != baseline {
+			return fmt.Errorf("%w: key %q changed after this transaction observed it", ErrTransactionConflict, ck)
+		}
+	}
+
+	for ck, entry := range tx.pending {
+		w := entry.commit
+		if w == nil {
+			continue // touched only by a read; nothing to apply
+		}
+		collection := entry.key.Collection()
+		id := keyID(entry.key)
+		switch w.kind {
+		case pendingWriteDelete:
+			tx.db.engine(collection).delete(id)
+		case pendingWriteStore:
+			if err := tx.db.engine(collection).store(id, w.rec, w.overwrite); err != nil {
+				return err
+			}
+		}
+		tx.db.versions[ck]++
+	}
+	return nil
+}
+
+// validateForCommit runs the same generic checks the real storage engines
+// perform before persisting — the data marshals to JSON, and, when factory is
+// non-nil (the collection has a schema), contains no field the schema does
+// not declare — so a malformed write fails immediately at the point of the
+// Set/Insert/Update call instead of being silently accepted into the buffer
+// and only discovered at commit. It mirrors serializedEngine.store's own
+// validation exactly (that engine performs no other checks); a storage
+// engine with additional validation of its own — the columnar engine's
+// per-column typed decode, for instance — can still fail at commit for a
+// reason this eager check does not catch. See commit's doc comment for the
+// resulting trade-off.
+//
+// factory is resolved once by the caller (stage/insert/updateRecord, via
+// recordFactory) rather than re-resolved here, since re-resolving it would
+// only ever repeat a check the caller already made successfully — by the
+// time any of them calls this, recordFactory has already been asked about
+// this exact collection and returned no error.
+func validateForCommit(collection string, factory func() any, data any) error {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	if factory != nil {
+		return checkUnknownFields(collection, factory, b)
+	}
+	return nil
+}
+
+// normalizeData JSON-round-trips a record's data into a generic
+// map[string]any, matching the shape the Serialized engine actually persists
+// (and the shape the columnar engine's own rowData/materializeSlot produce)
+// so every later same-transaction operation on the key — materializeInto,
+// Update's merge, a later Insert's duplicate check — has a stable,
+// engine-independent snapshot to work from, isolated from the original data
+// the caller passed in.
+func normalizeData(data any) (map[string]any, error) {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// cloneEntryData deep-copies a pendingEntry's data via the same JSON round
+// trip normalizeData uses, but — unlike normalizeData — cannot itself fail:
+// its input is always already-valid, previously round-tripped JSON data (it
+// came from normalizeData or from an engine's own generic decode in touch),
+// and a generic map[string]any decoded from JSON contains only
+// JSON-representable values, which always re-marshal, and re-marshaled JSON
+// always re-decodes.
+func cloneEntryData(data map[string]any) map[string]any {
+	b, _ := json.Marshal(data)
+	var out map[string]any
+	_ = json.Unmarshal(b, &out)
+	return out
+}
+
+// materializeInto decodes data into target via a JSON round-trip, so the
+// result shares no references with the transaction's own snapshot or any
+// other read — the same isolation columnarEngine.materializeSlot already
+// gives query results. Only the decode into target can fail here (target is
+// a caller-supplied Get destination, which may not match what was stored):
+// the marshal side cannot, because every write path validates
+// marshalability before a value ever reaches a pendingEntry (see
+// normalizeData and cloneEntryData's doc comments), and get is
+// materializeInto's only caller, always with a pendingEntry's data.
+func materializeInto(data map[string]any, target any) error {
+	b, _ := json.Marshal(data)
+	return json.Unmarshal(b, target)
+}

--- a/adapters/dalgo2memory/optimistic_test.go
+++ b/adapters/dalgo2memory/optimistic_test.go
@@ -1,0 +1,727 @@
+package dalgo2memory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/dal-go/dalgo/dal"
+	dalrecord "github.com/dal-go/record"
+	"github.com/dal-go/record/update"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOptimisticConcurrencyOption checks WithOptimisticConcurrency's own
+// bookkeeping: off by default, on when requested. Everything else in this
+// file exercises the behavior that flag switches on.
+func TestOptimisticConcurrencyOption(t *testing.T) {
+	require.False(t, newDatabase().optimisticConcurrency)
+	require.True(t, newDatabase(WithOptimisticConcurrency()).optimisticConcurrency)
+}
+
+// TestIsTransactionConflict is the direct unit test for the predicate the
+// package doc promises callers can retry on — separate from the concurrency
+// tests below, which prove the error actually gets produced under real
+// contention.
+func TestIsTransactionConflict(t *testing.T) {
+	require.False(t, IsTransactionConflict(nil))
+	require.False(t, IsTransactionConflict(errors.New("unrelated")))
+	require.True(t, IsTransactionConflict(ErrTransactionConflict))
+	require.True(t, IsTransactionConflict(fmt.Errorf("wrapped: %w", ErrTransactionConflict)))
+}
+
+// TestDefaultTransactionsRemainSerialized is the regression guard for the
+// behavior this whole feature must not touch: without
+// WithOptimisticConcurrency, RunReadwriteTransaction still takes a
+// whole-database lock for a transaction's entire duration, so a second
+// read-write transaction cannot even START running until the first one's
+// callback returns. This is exactly what makes a "two concurrent claims,
+// exactly one wins" test meaningless against the default mode (see
+// WithOptimisticConcurrency's doc comment) — proving it still holds is what
+// justifies every other test in this file bothering to exist.
+func TestDefaultTransactionsRemainSerialized(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase() // no WithOptimisticConcurrency: the pre-existing default
+
+	firstEntered := make(chan struct{})
+	release := make(chan struct{})
+	secondEntered := make(chan struct{})
+	firstDone := make(chan error, 1)
+	secondDone := make(chan error, 1)
+
+	go func() {
+		firstDone <- db.RunReadwriteTransaction(ctx, func(context.Context, dal.ReadwriteTransaction) error {
+			close(firstEntered)
+			<-release
+			return nil
+		})
+	}()
+	<-firstEntered
+
+	go func() {
+		secondDone <- db.RunReadwriteTransaction(ctx, func(context.Context, dal.ReadwriteTransaction) error {
+			close(secondEntered)
+			return nil
+		})
+	}()
+
+	select {
+	case <-secondEntered:
+		t.Fatal("a second read-write transaction started before the first one finished: the default whole-database lock was not held")
+	case <-time.After(20 * time.Millisecond):
+		// Expected: the second transaction is still blocked trying to acquire
+		// db.mu, because the first one is still holding it inside its callback.
+	}
+
+	close(release)
+	require.NoError(t, <-firstDone)
+	<-secondEntered // now unblocks
+	require.NoError(t, <-secondDone)
+}
+
+// slugThing is this file's stand-in for the sneat-co/bookius pattern the
+// WithOptimisticConcurrency doc comment cites: a Get-then-Insert used to
+// claim a unique key.
+type slugThing struct {
+	Owner string
+}
+
+// TestOptimisticConcurrencyGetThenInsertSameKeyExactlyOneWins is the
+// headline required test: two transactions run the same Get-then-Insert
+// slug claim concurrently for the same key. Exactly one must succeed, and
+// the other must fail specifically with ErrTransactionConflict — not a
+// "duplicate" error, since from that transaction's own point of view (it
+// read the slug before either side had claimed it) nothing it did was
+// wrong; it lost a race after the fact.
+//
+// bothRead/proceed force both transactions' Get to complete — recording the
+// same commit-version baseline for the key — before either is allowed to
+// reach its own Insert and commit. Without that, one transaction's entire
+// Get-Insert-commit could occasionally finish before the other's Get even
+// ran, which would make the second transaction's Get correctly find the key
+// already claimed and take a different, though equally valid, code path —
+// turning this into a flaky test of the wrong thing. See
+// TestOptimisticConcurrencyReadWriteConflict's doc comment for why ordinary
+// channels are enough to force this deterministically, with no dedicated
+// test hook needed.
+func TestOptimisticConcurrencyGetThenInsertSameKeyExactlyOneWins(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	key := dalrecord.NewKeyWithID("Slugs", "shared-slug")
+
+	bothRead := make(chan struct{}, 2)
+	proceed := make(chan struct{})
+	results := make(chan error, 2)
+
+	claim := func(owner string) {
+		results <- db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+			var existing slugThing
+			err := tx.Get(ctx, dalrecord.NewRecordWithData(key, &existing))
+			if err != nil && !dalrecord.IsNotFound(err) {
+				return err
+			}
+			if err == nil {
+				return fmt.Errorf("test setup: %s found the slug already claimed by %q before either side wrote", owner, existing.Owner)
+			}
+			bothRead <- struct{}{}
+			<-proceed
+			return tx.Insert(ctx, dalrecord.NewRecordWithData(key, &slugThing{Owner: owner}))
+		})
+	}
+
+	go claim("alice")
+	go claim("bob")
+
+	<-bothRead
+	<-bothRead
+	close(proceed)
+
+	err1, err2 := <-results, <-results
+
+	successes, conflicts := 0, 0
+	for _, err := range []error{err1, err2} {
+		switch {
+		case err == nil:
+			successes++
+		case IsTransactionConflict(err):
+			conflicts++
+		default:
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	require.Equal(t, 1, successes, "exactly one concurrent claim of the same slug should succeed")
+	require.Equal(t, 1, conflicts, "the losing claim should fail with ErrTransactionConflict, not some other error")
+
+	// The stored value must be whichever claim actually won — not corrupted,
+	// not both, not neither.
+	var stored slugThing
+	require.NoError(t, db.RunReadonlyTransaction(ctx, func(ctx context.Context, tx dal.ReadTransaction) error {
+		return tx.Get(ctx, dalrecord.NewRecordWithData(key, &stored))
+	}))
+	require.Contains(t, []string{"alice", "bob"}, stored.Owner)
+}
+
+// TestOptimisticConcurrencyReadWriteConflict drives the exact interleaving
+// the Feature calls for: tx A reads key K, then tx B reads and writes K and
+// commits, then tx A writes K and commits — and A's commit must fail with
+// ErrTransactionConflict, even though a plain, lock-free write of K by A
+// would not itself have errored (Set has no duplicate check the way Insert
+// does). This is the case that proves the conflict detection is genuine
+// optimistic concurrency control and not just Insert's pre-existing
+// duplicate check wearing a new name.
+//
+// The interleaving is deterministic with nothing beyond ordinary channels:
+// tx A's callback blocks on <-releaseA after its Get, holding no lock while
+// it waits (RunReadwriteTransaction never holds db.mu across a paused
+// callback in optimistic mode — see optimisticState's doc comment), so tx
+// B's own RunReadwriteTransaction call — run synchronously on the test
+// goroutine — is free to read, write and fully commit before releaseA is
+// closed. That gives a real happens-before edge from B's commit to A's
+// resumption, which is all the determinism this test needs; a bespoke
+// test-only hook would buy nothing beyond what the callback itself already
+// provides as a synchronization point.
+func TestOptimisticConcurrencyReadWriteConflict(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	key := dalrecord.NewKeyWithID("Things", "contended")
+	require.NoError(t, db.Set(ctx, dalrecord.NewRecordWithData(key, &thing{Name: "initial", Count: 0})))
+
+	aReached := make(chan struct{})
+	releaseA := make(chan struct{})
+	resultA := make(chan error, 1)
+
+	go func() {
+		resultA <- db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+			var got thing
+			if err := tx.Get(ctx, dalrecord.NewRecordWithData(key, &got)); err != nil {
+				return err
+			}
+			close(aReached)
+			<-releaseA
+			return tx.Set(ctx, dalrecord.NewRecordWithData(key, &thing{Name: "from-a", Count: got.Count + 1}))
+		})
+	}()
+
+	<-aReached // A has read K; it is now paused, holding no lock
+
+	// B reads and writes K and commits, fully, before A is allowed to continue.
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		var got thing
+		if err := tx.Get(ctx, dalrecord.NewRecordWithData(key, &got)); err != nil {
+			return err
+		}
+		return tx.Set(ctx, dalrecord.NewRecordWithData(key, &thing{Name: "from-b", Count: got.Count + 1}))
+	})
+	require.NoError(t, err, "B's own transaction should commit cleanly")
+
+	close(releaseA)
+	err = <-resultA
+	require.Error(t, err, "A must not be allowed to commit over B's committed write to a key A read before B ran")
+	require.True(t, IsTransactionConflict(err), "A's failure must be classifiable as a conflict so a caller knows to retry: got %v", err)
+
+	// B's write must be what is actually stored — A's conflicting write must
+	// never have reached storage.
+	var stored thing
+	require.NoError(t, db.Get(ctx, dalrecord.NewRecordWithData(key, &stored)))
+	require.Equal(t, "from-b", stored.Name)
+}
+
+// TestOptimisticConcurrencyDisjointKeysDoNotConflict is the required
+// negative case: two transactions that read and write different keys must
+// both commit cleanly, even when forced into the same worst-case overlap in
+// timing as the conflicting cases above use to prove a conflict. Optimistic
+// concurrency that conflicted on unrelated keys would be worthless — it
+// would recreate the whole-database lock's serialization by a different
+// name.
+func TestOptimisticConcurrencyDisjointKeysDoNotConflict(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	keyA := dalrecord.NewKeyWithID("Things", "alpha")
+	keyB := dalrecord.NewKeyWithID("Things", "beta")
+
+	bothRead := make(chan struct{}, 2)
+	proceed := make(chan struct{})
+	results := make(chan error, 2)
+
+	run := func(key *dalrecord.Key, name string) {
+		results <- db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+			var existing thing
+			err := tx.Get(ctx, dalrecord.NewRecordWithData(key, &existing))
+			if err != nil && !dalrecord.IsNotFound(err) {
+				return err
+			}
+			bothRead <- struct{}{}
+			<-proceed
+			return tx.Set(ctx, dalrecord.NewRecordWithData(key, &thing{Name: name}))
+		})
+	}
+
+	go run(keyA, "alpha-value")
+	go run(keyB, "beta-value")
+
+	<-bothRead
+	<-bothRead
+	close(proceed)
+
+	require.NoError(t, <-results)
+	require.NoError(t, <-results)
+
+	var gotA, gotB thing
+	require.NoError(t, db.Get(ctx, dalrecord.NewRecordWithData(keyA, &gotA)))
+	require.NoError(t, db.Get(ctx, dalrecord.NewRecordWithData(keyB, &gotB)))
+	require.Equal(t, "alpha-value", gotA.Name)
+	require.Equal(t, "beta-value", gotB.Name)
+}
+
+// TestOptimisticConcurrencyReadYourOwnWrites is not one of the Feature's
+// required tests, but it is the load-bearing property that makes the
+// buffered design usable at all: within a single optimistic transaction, a
+// Get after a Set/Insert/Update/Delete of the same key must see that
+// transaction's own pending write, even though nothing has reached the
+// shared engine yet.
+func TestOptimisticConcurrencyReadYourOwnWrites(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	key := dalrecord.NewKeyWithID("Things", "rmw")
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		if err := tx.Set(ctx, dalrecord.NewRecordWithData(key, &thing{Name: "first", Count: 1})); err != nil {
+			return err
+		}
+		var got thing
+		if err := tx.Get(ctx, dalrecord.NewRecordWithData(key, &got)); err != nil {
+			return err
+		}
+		if got.Name != "first" || got.Count != 1 {
+			return fmt.Errorf("read-your-own-write: got %+v, want {first 1}", got)
+		}
+		exists, err := tx.Exists(ctx, key)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return errors.New("Exists after Set within the same transaction reported false")
+		}
+		return tx.Delete(ctx, key)
+	})
+	require.NoError(t, err)
+
+	// The Set must never have reached the shared engine (it was superseded by
+	// the Delete before commit), so nothing should be stored afterwards.
+	exists, err := db.Exists(ctx, key)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+// TestOptimisticConcurrencyUpdateCompoundsAndCommits checks that Update
+// inside an optimistic transaction (a) requires the key to already exist,
+// eagerly, like the default mode does, (b) compounds correctly when called
+// twice on the same key in the same transaction, and (c) actually reaches
+// the storage engine once the transaction commits.
+func TestOptimisticConcurrencyUpdateCompoundsAndCommits(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	key := dalrecord.NewKeyWithID("Things", "update-me")
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Update(ctx, key, []update.Update{update.ByFieldName("Count", 1)})
+	})
+	require.Error(t, err, "Update of a key that does not exist yet must fail immediately, like the default mode")
+	require.True(t, dalrecord.IsNotFound(err))
+
+	require.NoError(t, db.Set(ctx, dalrecord.NewRecordWithData(key, &thing{Name: "base", Count: 1})))
+
+	err = db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		if err := tx.Update(ctx, key, []update.Update{update.ByFieldName("Count", 2)}); err != nil {
+			return err
+		}
+		return tx.Update(ctx, key, []update.Update{update.ByFieldName("Name", "updated")})
+	})
+	require.NoError(t, err)
+
+	var got thing
+	require.NoError(t, db.Get(ctx, dalrecord.NewRecordWithData(key, &got)))
+	require.Equal(t, thing{Name: "updated", Count: 2}, got)
+}
+
+// TestOptimisticConcurrencyQueryUnsupported documents and locks in the one
+// deliberate gap in this mode: a query inside an optimistic transaction reads
+// committed storage directly, so it would see neither the transaction's own
+// buffered writes nor participate in its conflict detection. Rather than
+// silently returning a semantically inconsistent result, it fails clearly.
+func TestOptimisticConcurrencyQueryUnsupported(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		q := dal.From(dal.NewRootCollectionRef("Things", "")).NewQuery().SelectKeysOnly(reflect.String)
+		_, err := tx.ExecuteQueryToRecordsReader(ctx, q)
+		return err
+	})
+	require.ErrorIs(t, err, dal.ErrNotSupported)
+}
+
+// TestOptimisticConcurrencyInsertWithGenerator checks that Insert's
+// id-generator retry loop (dal.InsertWithIdGenerator) is wired correctly
+// under optimistic mode: its "does this id already exist" probe must consult
+// this transaction's own buffered/tracked view (via optimisticState.exists),
+// not the live engine directly.
+func TestOptimisticConcurrencyInsertWithGenerator(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Insert(ctx, dalrecord.NewRecordWithIncompleteKey("Things", reflect.String, &thing{Name: "generated"}),
+			dal.WithRandomStringKey(8, 3))
+	})
+	require.NoError(t, err)
+
+	q := dal.From(dal.NewRootCollectionRef("Things", "")).NewQuery().SelectKeysOnly(reflect.String)
+	reader, err := db.ExecuteQueryToRecordsReader(ctx, q)
+	require.NoError(t, err)
+	rec, err := reader.Next()
+	require.NoError(t, err)
+	require.NotNil(t, rec.Key().ID)
+}
+
+// TestOptimisticConcurrencyInsertWithGeneratorRetriesOnCollision checks the
+// generator callback's "id is taken, retry" branch deterministically: every
+// one of the 62 possible single-character ids random.ID(1) can produce is
+// pre-occupied, so a WithRandomStringKey(1, ...) generator collides on every
+// attempt, exhausting insertWithGeneratorMaxAttempts — exactly
+// TestSession_Insert_GeneratorExhaustion's technique, adapted so the
+// collision is guaranteed by exhausting the id space instead of relying on a
+// day-granularity timestamp.
+func TestOptimisticConcurrencyInsertWithGeneratorRetriesOnCollision(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+	require.NoError(t, db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		for _, c := range charset {
+			if err := tx.Insert(ctx, dalrecord.NewRecordWithData(dalrecord.NewKeyWithID("Slots", string(c)), &thing{Name: "taken"})); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		rec := dalrecord.NewRecordWithIncompleteKey("Slots", reflect.String, &thing{Name: "new"})
+		return tx.Insert(ctx, rec, dal.WithRandomStringKey(1, 5))
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, dal.ErrExceedsMaxNumberOfAttempts)
+}
+
+// TestOptimisticConcurrencyInsertWithGeneratorPropagatesExistsError checks
+// that a genuine engine error from the generator callback's existence probe
+// (as opposed to an ordinary "does/doesn't exist" answer) is propagated
+// rather than silently treated as either. A day-accuracy timestamp generator
+// produces the same id deterministically within a run (see
+// TestSession_Insert_GeneratorExhaustion), so the id to corrupt can be
+// computed up front.
+func TestOptimisticConcurrencyInsertWithGeneratorPropagatesExistsError(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	gen := dal.WithTimeStampStringID(dal.TimeStampAccuracyDay, 10, 5)
+	generator := dal.NewInsertOptions(gen).IDGenerator()
+
+	probe := dalrecord.NewRecordWithIncompleteKey("Days", reflect.String, &thing{})
+	require.NoError(t, generator(ctx, probe))
+	id, ok := probe.Key().ID.(string)
+	require.True(t, ok)
+	db.collections["Days"] = &serializedEngine{records: map[string][]byte{id: []byte("{")}}
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		rec := dalrecord.NewRecordWithIncompleteKey("Days", reflect.String, &thing{Name: "x"})
+		return tx.Insert(ctx, rec, gen)
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to check if record exists")
+}
+
+// TestOptimisticConcurrencyGuardedCollectionErrors checks that the schema
+// guard (guardCollection's error, surfaced via recordFactory) still applies
+// to every optimistic-mode write/read path — Get, Set, Insert, Update — the
+// same way it already does in the default mode.
+func TestOptimisticConcurrencyGuardedCollectionErrors(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency(), WithSchema(false, WithCollection[thing]("Known", nil)))
+	key := dalrecord.NewKeyWithID("Unknown", "x")
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		var got thing
+		return tx.Get(ctx, dalrecord.NewRecordWithData(key, &got))
+	})
+	require.Error(t, err, "Get on an undeclared collection must be rejected")
+
+	err = db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Set(ctx, dalrecord.NewRecordWithData(key, &thing{Name: "x"}))
+	})
+	require.Error(t, err, "Set on an undeclared collection must be rejected")
+
+	err = db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Insert(ctx, dalrecord.NewRecordWithData(key, &thing{Name: "x"}))
+	})
+	require.Error(t, err, "Insert on an undeclared collection must be rejected")
+
+	err = db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Update(ctx, key, []update.Update{update.ByFieldName("Name", "y")})
+	})
+	require.Error(t, err, "Update on an undeclared collection must be rejected")
+}
+
+// TestOptimisticConcurrencyMalformedRecordDataErrors checks that Set and
+// Insert both fail immediately — at the point of the call, not deferred to
+// commit — for a record whose data cannot even be marshaled to JSON. This is
+// the same class of failure TestBadRecordDataAndUnsupportedQuery already
+// covers for the default mode.
+func TestOptimisticConcurrencyMalformedRecordDataErrors(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	badRecord := func() dalrecord.Record {
+		return dalrecord.NewRecordWithData(dalrecord.NewKeyWithID("Bad", "json"), func() {})
+	}
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Set(ctx, badRecord())
+	})
+	require.Error(t, err)
+
+	err = db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Insert(ctx, badRecord())
+	})
+	require.Error(t, err)
+}
+
+// strictThing is a schema type with no field named "Extra", used to prove
+// validateForCommit's eager unknown-field check runs for Set/Insert/Update
+// under optimistic mode exactly as the live engines' own checkUnknownFields
+// call already does in the default mode.
+type strictThing struct {
+	Name string
+}
+
+// TestOptimisticConcurrencyUnknownFieldValidation checks that Set and Insert
+// both fail immediately for data containing a field the schema does not
+// declare, and that Update's merged result is validated the same way.
+func TestOptimisticConcurrencyUnknownFieldValidation(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency(), WithSchema(false, WithCollection[strictThing]("Strict", nil)))
+	key := dalrecord.NewKeyWithID("Strict", "x")
+	withExtraField := map[string]any{"Name": "ok", "Extra": "not declared"}
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Set(ctx, dalrecord.NewRecordWithData(key, withExtraField))
+	})
+	require.Error(t, err, "Set of a record with an undeclared field must be rejected")
+
+	err = db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Insert(ctx, dalrecord.NewRecordWithData(key, withExtraField))
+	})
+	require.Error(t, err, "Insert of a record with an undeclared field must be rejected")
+
+	require.NoError(t, db.Set(ctx, dalrecord.NewRecordWithData(key, &strictThing{Name: "ok"})))
+	err = db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Update(ctx, key, []update.Update{update.ByFieldName("Extra", "not declared")})
+	})
+	require.Error(t, err, "Update that merges in an undeclared field must be rejected")
+}
+
+// TestOptimisticConcurrencyEngineLoadErrorPropagates checks that a genuine
+// storage error — as opposed to a plain not-found — surfaces correctly from
+// every optimistic-mode operation that has to consult the live engine on a
+// key's first touch: Get, Exists, Insert's duplicate check, and Update. It
+// mirrors TestMalformedStoredData's technique of corrupting the underlying
+// Serialized engine's bytes directly.
+func TestOptimisticConcurrencyEngineLoadErrorPropagates(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	key := dalrecord.NewKeyWithID("Bad", "json")
+	db.collections[key.Collection()] = &serializedEngine{records: map[string][]byte{keyID(key): []byte("{")}}
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		var got thing
+		return tx.Get(ctx, dalrecord.NewRecordWithData(key, &got))
+	})
+	require.Error(t, err, "Get must propagate a genuine engine-load error rather than mistaking it for not-found")
+
+	var existsErr error
+	err = db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		_, existsErr = tx.Exists(ctx, key)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Error(t, existsErr)
+
+	err = db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Insert(ctx, dalrecord.NewRecordWithData(key, &thing{Name: "x"}))
+	})
+	require.Error(t, err, "Insert's own existence probe must also surface the engine error rather than treating the key as absent")
+
+	err = db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Update(ctx, key, []update.Update{update.ByFieldName("Name", "y")})
+	})
+	require.Error(t, err, "Update must also surface the engine error")
+}
+
+// TestOptimisticConcurrencyGetMaterializeError checks that Get reports an
+// error — rather than silently zero-filling or panicking — when a
+// transaction's own normalized snapshot cannot be decoded into the caller's
+// target type.
+func TestOptimisticConcurrencyGetMaterializeError(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	key := dalrecord.NewKeyWithID("Mismatched", "x")
+	require.NoError(t, db.Set(ctx, dalrecord.NewRecordWithData(key, &thing{Name: "n", Count: 5})))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		var mismatch struct{ Count string }
+		return tx.Get(ctx, dalrecord.NewRecordWithData(key, &mismatch))
+	})
+	require.Error(t, err)
+}
+
+// TestOptimisticConcurrencyInsertDuplicateWithinTransaction checks the
+// same-transaction duplicate case insert's doc comment calls out
+// specifically: Insert of a key this same transaction already inserted must
+// fail immediately with an ordinary error, never with ErrTransactionConflict
+// — nothing else committed anything, so there is nothing for this
+// transaction to have lost a race against.
+func TestOptimisticConcurrencyInsertDuplicateWithinTransaction(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	key := dalrecord.NewKeyWithID("Things", "dup")
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		if err := tx.Insert(ctx, dalrecord.NewRecordWithData(key, &thing{Name: "first"})); err != nil {
+			return err
+		}
+		dupErr := tx.Insert(ctx, dalrecord.NewRecordWithData(key, &thing{Name: "second"}))
+		if dupErr == nil {
+			return errors.New("test setup: second insert of the same key in the same transaction unexpectedly succeeded")
+		}
+		if IsTransactionConflict(dupErr) {
+			return fmt.Errorf("a same-transaction duplicate must not be reported as ErrTransactionConflict: %w", dupErr)
+		}
+		return nil // the duplicate was correctly rejected with an ordinary error
+	})
+	require.NoError(t, err)
+}
+
+// TestOptimisticConcurrencyUpdateWithNonMarshalableValueFails checks that an
+// Update whose merged result cannot be marshaled fails immediately, and —
+// since updateRecord works on a defensive copy of the transaction's own
+// snapshot — leaves that snapshot (and the eventually-committed value)
+// unaffected.
+func TestOptimisticConcurrencyUpdateWithNonMarshalableValueFails(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	key := dalrecord.NewKeyWithID("Things", "bad-update")
+	require.NoError(t, db.Set(ctx, dalrecord.NewRecordWithData(key, &thing{Name: "ok"})))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Update(ctx, key, []update.Update{update.ByFieldName("Bad", func() {})})
+	})
+	require.Error(t, err)
+
+	var got thing
+	require.NoError(t, db.Get(ctx, dalrecord.NewRecordWithData(key, &got)))
+	require.Equal(t, "ok", got.Name)
+}
+
+// TestOptimisticConcurrencyCommitAppliesWritesAndSkipsReadOnlyKeys checks
+// commit's handling of a transaction that touches more than one key with a
+// mix of outcomes: a key it only read must be left alone (and must not
+// somehow block or corrupt the commit), while a key it wrote must actually
+// reach the storage engine.
+func TestOptimisticConcurrencyCommitAppliesWritesAndSkipsReadOnlyKeys(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	readOnlyKey := dalrecord.NewKeyWithID("Things", "read-only")
+	writeKey := dalrecord.NewKeyWithID("Things", "written")
+	require.NoError(t, db.Set(ctx, dalrecord.NewRecordWithData(readOnlyKey, &thing{Name: "untouched"})))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		var got thing
+		if err := tx.Get(ctx, dalrecord.NewRecordWithData(readOnlyKey, &got)); err != nil {
+			return err
+		}
+		return tx.Set(ctx, dalrecord.NewRecordWithData(writeKey, &thing{Name: "new"}))
+	})
+	require.NoError(t, err)
+
+	var stillThere thing
+	require.NoError(t, db.Get(ctx, dalrecord.NewRecordWithData(readOnlyKey, &stillThere)))
+	require.Equal(t, "untouched", stillThere.Name)
+
+	var written thing
+	require.NoError(t, db.Get(ctx, dalrecord.NewRecordWithData(writeKey, &written)))
+	require.Equal(t, "new", written.Name)
+}
+
+// TestOptimisticConcurrencyCommitDeferredValidationFailure exercises the
+// narrow gap documented on commit and validateForCommit: a buffered write
+// whose data passes the eager, generic validateForCommit check (a JSON
+// marshal plus, for a map-backed collection, an unknown-field check that a
+// map target can never actually fail) can still fail the columnar engine's
+// own per-column typed decode once commit actually calls engine.store. This
+// is the same scenario TestMixed_DeclaredValueWrongTypeErrors proves for the
+// default mode, replayed here to prove the deferral doesn't hide it, only
+// moves it from the point of the call to the point of commit.
+func TestOptimisticConcurrencyCommitDeferredValidationFailure(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency(), WithSchema(false,
+		WithCollection[map[string]any]("m", nil, WithColumnarStorage(WithDeclaredColumn[int]("age"))),
+	))
+	key := dalrecord.NewKeyWithID("m", "u1")
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		// This Set itself must succeed: validateForCommit's generic checks have
+		// nothing to object to for a map-backed collection.
+		return tx.Set(ctx, dalrecord.NewRecordWithData(key, map[string]any{"age": "old", "name": "Alice"}))
+	})
+	require.Error(t, err, "the type mismatch must still surface, just at commit instead of at the point of the call")
+	require.ErrorContains(t, err, "age")
+	require.False(t, IsTransactionConflict(err), "a deferred storage-fidelity failure is not an optimistic-concurrency conflict")
+
+	exists, existsErr := db.Exists(ctx, key)
+	require.NoError(t, existsErr)
+	require.False(t, exists, "the rejected write must not have been persisted")
+}
+
+// TestOptimisticConcurrencyUpdatePathThroughNonMapFails checks updateRecord's
+// applyUpdatesToMap error path: a FieldPath update that tries to descend
+// through an existing, non-map value must fail with a descriptive error
+// rather than panicking — the same behavior applyUpdatesToMap's own doc
+// comment promises for the default mode.
+func TestOptimisticConcurrencyUpdatePathThroughNonMapFails(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	key := dalrecord.NewKeyWithID("Things", "bad-path")
+	require.NoError(t, db.Set(ctx, dalrecord.NewRecordWithData(key, &thing{Name: "text"})))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Update(ctx, key, []update.Update{update.ByFieldPath(update.FieldPath{"Name", "Sub"}, "x")})
+	})
+	require.Error(t, err)
+}
+
+// TestOptimisticConcurrencySetOfNonObjectDataFails checks normalizeData's own
+// error path: data that marshals to a JSON array (or any other non-object
+// JSON value) cannot decode into the generic map[string]any every
+// optimistic-mode operation works with, and Set must report that rather than
+// buffering something Get could never materialize back out.
+func TestOptimisticConcurrencySetOfNonObjectDataFails(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Set(ctx, dalrecord.NewRecordWithData(dalrecord.NewKeyWithID("Things", "array-data"), []int{1, 2, 3}))
+	})
+	require.Error(t, err)
+}

--- a/adapters/dalgo2memory/schema.go
+++ b/adapters/dalgo2memory/schema.go
@@ -21,6 +21,58 @@ func WithNoReadsAfterWritesInTransaction() Option {
 	}
 }
 
+// WithOptimisticConcurrency selects optimistic-concurrency read-write
+// transactions for this in-memory database instead of the default: without
+// it, RunReadwriteTransaction takes a whole-database lock for the callback's
+// entire duration, so read-write transactions are fully serialized and can
+// never actually contend with one another.
+//
+// That default is exactly right for most tests, but it makes one specific
+// class of test lie: a test that claims to prove a real concurrency
+// guarantee — "two concurrent claims of a unique slug, exactly one wins", or
+// "two concurrent bookings for the last remaining place, one is refused" —
+// passes trivially against the default lock, because the two transactions it
+// spawns can never actually run at the same time. It proves nothing about a
+// database, like Firestore, whose transactions really do contend. Production
+// code in this ecosystem relies on exactly this guarantee (see
+// sneat-co/bookius's facade4bookius/booking.go, which does a Get-then-Insert
+// inside RunReadwriteTransaction for slug uniqueness and for capacity), so a
+// test standing in for Firestore needs a mode where the contention is real.
+//
+// With this option, transactions may run concurrently: each buffers the keys
+// it reads and the writes it makes locally, touching no shared storage until
+// it commits (when its callback returns nil). At that point it fails with
+// ErrTransactionConflict (test with IsTransactionConflict) if another
+// transaction has committed a write to any key this one read or wrote since
+// it first touched that key — whether this one only read the key or wrote it
+// too. Buffering writes rather than applying them immediately is what makes
+// the LOSING side of a race get the conflict error specifically, rather than
+// some other error that happens to depend on write ordering: see
+// optimisticState's doc comment in optimistic.go for the full reasoning.
+//
+// A query (ExecuteQueryToRecordsReader / ExecuteQueryToRecordsetReader)
+// inside such a transaction returns dal.ErrNotSupported: a scan reads
+// committed storage directly, so it would see neither this transaction's own
+// buffered writes nor participate in its conflict detection. Point reads and
+// writes by key (Get, Exists, Set, Insert, Update, Delete and their -Multi
+// forms) are fully supported.
+//
+// This is deliberately adapter-local rather than part of dalgotest's shared
+// conformance suite: the suite proves record-validation invariants every
+// dal.DB adapter can be held to uniformly, but optimistic-concurrency
+// contention is not such a capability — a real backend like Firestore or a
+// SQL database already has its own genuine transactional contention, and
+// forcing every adapter to grow an equivalent option and test hook just to
+// stay in the suite would be scope the other adapters never asked for.
+//
+// The default remains the whole-database lock; nothing changes unless this
+// option is passed to NewDB.
+func WithOptimisticConcurrency() Option {
+	return func(db *database) {
+		db.optimisticConcurrency = true
+	}
+}
+
 // collectionDef describes a single collection in an in-memory schema.
 // It is produced by WithCollection and consumed by WithSchema.
 type collectionDef struct {


### PR DESCRIPTION
## Summary

- `RunReadwriteTransaction` currently takes a whole-database lock for a transaction's entire callback, so two read-write transactions can never actually run concurrently. That makes a test like "two concurrent claims of a unique slug, exactly one wins" pass trivially — it proves nothing about a database (Firestore, say) whose transactions really do contend, even though production code (e.g. `sneat-co/bookius`'s `facade4bookius/booking.go`) relies on exactly that guarantee via Get-then-Insert inside a transaction.
- Adds `WithOptimisticConcurrency()`, an opt-in `NewDB`/`newDatabase` option (same idiom as the existing `WithoutSchemaRefBreaking` / `WithNoReadsAfterWritesInTransaction`). With it, transactions run concurrently: each buffers the keys it reads and the writes it makes locally, touching no shared storage until it commits, and fails with the new `ErrTransactionConflict` (test via `IsTransactionConflict`) if another transaction committed a write to a key this one read or wrote since it first touched that key.
- Buffering writes (rather than applying them immediately and validating afterwards) is what makes the *losing* side of a race get the conflict error specifically, instead of some other error that happens to depend on write ordering — see `optimisticState`'s doc comment in `optimistic.go`.
- Default behavior is untouched: every pre-existing test still exercises the same whole-database-lock path as before, unmodified.

## Conflict error

Searched `dal` and `record` (and, for good measure, `dalgo2mysql`/`dalgo2sql`/`dalgo2postgres`/`dalgo2sqlite`) for an existing conflict/retryable/aborted error type or predicate to reuse — none exists. Added `ErrTransactionConflict` + `IsTransactionConflict`, following the same sentinel-plus-predicate idiom already used by `ErrReadAfterWriteInTransaction` and `record.ErrRecordNotFound`/`record.IsNotFound`.

## Conformance suite

Deliberately **not** added to `dalgotest`'s shared conformance suite. That suite proves record-validation invariants every `dal.DB` adapter can be held to uniformly; optimistic-concurrency contention isn't such a capability — a real backend like Firestore or a SQL database already has its own genuine transactional contention, and forcing every adapter to grow an equivalent option and test hook just to stay in the suite would be scope the other adapters never asked for. Kept adapter-local and opt-in.

## Deterministic test interleaving

The brief called for a deterministic interleaving affordance for tests. No dedicated hook was added: a transaction callback in this mode never holds `db.mu` while paused, so an ordinary channel inside the callback already gives full determinism (block until another transaction's `RunReadwriteTransaction` call — run synchronously — has fully committed). See `TestOptimisticConcurrencyReadWriteConflict`'s doc comment for the reasoning.

## Tests

New `optimistic_test.go` covers (among others) the four required cases:
- Concurrent Get-then-Insert of the same key: exactly one wins, the other gets `ErrTransactionConflict`.
- The specified read-write interleaving (tx A reads K → tx B reads+writes+commits K → tx A writes+commits K → conflict).
- Disjoint keys never conflict.
- Default mode remains fully serialized (`TestDefaultTransactionsRemainSerialized`).

Plus edge-case coverage (schema guards, malformed/non-marshalable data, unknown-field validation, engine-load errors, same-transaction duplicates, ID-generator collision/retry, a documented narrow gap where a columnar declared-column type mismatch is only caught at commit instead of at the call).

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...` (whole module, all green)
- [x] `go test -coverprofile=... ./adapters/dalgo2memory/...` → 100.0% (this package)
- [x] `go test -race -count=50 -run 'TestOptimisticConcurrency|TestDefaultTransactionsRemainSerialized' ./adapters/dalgo2memory/...` (stress run, no flakiness)
- [x] `golangci-lint run ./...` → 0 issues
- [x] `gofmt -l` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)