### PR TITLE
build: bump Go to 1.27.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dal-go/dalgo
 
-go 1.24.0
+go 1.27.0
 
 require github.com/dal-go/record v0.1.3
 


### PR DESCRIPTION
Updates Go module and CI toolchain pins to Go 1.27.0.