### PR TITLE
build: use Go 1.26 with Go 1.27 toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/dal-go/dalgo
 
-go 1.24.0
+go 1.26.0
+
+toolchain go1.27.0
 
 require github.com/dal-go/record v0.1.3
 


### PR DESCRIPTION
Sets the Go language version to 1.26.0 for CodeQL compatibility and pins toolchain go1.27.0.