### PR TITLE
feat(dalgo2memory)!: default to strict Firestore-style transaction ordering

### DIFF
--- a/adapters/dalgo2memory/branching_coverage_test.go
+++ b/adapters/dalgo2memory/branching_coverage_test.go
@@ -124,6 +124,51 @@ func assertSerializedSchemaClone(t testing.TB, db *database) {
 	}
 }
 
+// TestBranchingPropagatesDefaultStrictOrdering proves the inverted NewDB
+// default carries through Capture/Branch even when no ordering option was
+// passed at all: snapshotDatabase and databaseSnapshot.newBackend both copy
+// db.noReadsAfterWritesInTransaction verbatim (branching.go), so a source
+// database built with zero options is already strict, and a branch taken
+// from it stays strict too — this is a regression guard specifically for the
+// no-options case, complementing
+// TestBranchingPreservesSerializedSchemaConfiguration's explicit-option case.
+func TestBranchingPropagatesDefaultStrictOrdering(t *testing.T) {
+	ctx := context.Background()
+	source := newDatabase() // no options: strict ordering is the default
+	if !source.noReadsAfterWritesInTransaction {
+		t.Fatal("newDatabase() with no options must default to strict ordering")
+	}
+	key := branchingRootKey("milk")
+	if err := source.Set(ctx, record.NewRecordWithData(key, &branchingRecord{Title: "milk"})); err != nil {
+		t.Fatal(err)
+	}
+
+	checkpoint, err := NewBranchingProvider().Capture(ctx, dal.NewDB(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = checkpoint.Release(ctx) }()
+
+	branch := mustBranch(t, checkpoint)
+	defer closeTestBranch(t, branch)
+	branchDB := dal.BackendOf(branch.DB()).(*database)
+	if !branchDB.noReadsAfterWritesInTransaction {
+		t.Fatal("branch lost the default strict-ordering setting")
+	}
+
+	// Behavioral check, not just the field: a read-write transaction on the
+	// branch must actually reject a read that follows a write.
+	err = branch.DB().RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		if err := tx.Set(ctx, record.NewRecordWithData(key, &branchingRecord{Title: "eggs"})); err != nil {
+			return err
+		}
+		return tx.Get(ctx, record.NewRecordWithData(key, &branchingRecord{}))
+	})
+	if !errors.Is(err, ErrReadAfterWriteInTransaction) {
+		t.Fatalf("branch transaction err = %v, want ErrReadAfterWriteInTransaction", err)
+	}
+}
+
 func TestCloneRecordKeyHandlesIncompleteAndCompositeIDs(t *testing.T) {
 	t.Run("incomplete parent chain", func(t *testing.T) {
 		parent := record.NewIncompleteKey("spaces", reflect.String, nil)

--- a/adapters/dalgo2memory/database.go
+++ b/adapters/dalgo2memory/database.go
@@ -29,9 +29,14 @@ func NewDB(options ...Option) dal.DB {
 // NewDB.
 func newDatabase(options ...Option) *database {
 	db := &database{
-		collections:       make(map[string]storageEngine),
-		schemaRefBreaking: true,
-		versions:          make(map[string]uint64),
+		collections: make(map[string]storageEngine),
+		// noReadsAfterWritesInTransaction defaults to true: a plain NewDB()
+		// rejects a read after a write in a read-write transaction, matching
+		// Firestore's real ordering rule. See
+		// WithInterleavedReadsAndWritesInTransaction for the opt-out.
+		noReadsAfterWritesInTransaction: true,
+		schemaRefBreaking:               true,
+		versions:                        make(map[string]uint64),
 	}
 	for _, option := range options {
 		if option != nil {
@@ -55,7 +60,12 @@ type database struct {
 	enginesMu sync.Mutex
 	schema    *memorySchema
 	// noReadsAfterWritesInTransaction emulates Firestore's transaction ordering
-	// rule for databases created with WithNoReadsAfterWritesInTransaction.
+	// rule: a read-write transaction fails a read that follows a write. NewDB
+	// initializes it to true (see newDatabase); pass
+	// WithInterleavedReadsAndWritesInTransaction to turn it off for a backend
+	// that legitimately interleaves reads and writes, or
+	// WithNoReadsAfterWritesInTransaction to re-assert it explicitly
+	// (deprecated — redundant against the default on its own).
 	noReadsAfterWritesInTransaction bool
 	// schemaRefBreaking is the schema-wide columnar fidelity default (faithful
 	// unless WithoutSchemaRefBreaking was used). NewDB initializes it to true.

--- a/adapters/dalgo2memory/database_test.go
+++ b/adapters/dalgo2memory/database_test.go
@@ -285,16 +285,43 @@ func TestNoReadsAfterWritesInTransaction(t *testing.T) {
 		}
 	})
 
-	t.Run("default remains permissive", func(t *testing.T) {
-		db := newDatabase()
+	t.Run("default now rejects reads after writes", func(t *testing.T) {
+		db := newDatabase() // no options: strict ordering is the default
+		require.NoError(t, db.Set(ctx, dalrecord.NewRecordWithData(key, &thing{Name: "before", Count: 1})))
 		err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
 			if err := tx.Set(ctx, dalrecord.NewRecordWithData(key, &thing{Name: "stored"})); err != nil {
 				return err
 			}
 			return tx.Get(ctx, dalrecord.NewRecordWithData(key, &thing{}))
 		})
-		require.NoError(t, err)
+		require.ErrorIs(t, err, ErrReadAfterWriteInTransaction)
 	})
+}
+
+// TestInterleavedReadsAndWritesInTransaction proves
+// WithInterleavedReadsAndWritesInTransaction opts a database back out of the
+// default strict ordering, restoring the old permissive behavior for a
+// backend (SQL-like) that genuinely allows a transaction to read after it has
+// written.
+func TestInterleavedReadsAndWritesInTransaction(t *testing.T) {
+	ctx := context.Background()
+	key := dalrecord.NewKeyWithID("Things", "existing")
+
+	db := newDatabase(WithInterleavedReadsAndWritesInTransaction())
+	require.NoError(t, db.Set(ctx, dalrecord.NewRecordWithData(key, &thing{Name: "before", Count: 1})))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		if err := tx.Set(ctx, dalrecord.NewRecordWithData(key, &thing{Name: "stored"})); err != nil {
+			return err
+		}
+		got := &thing{}
+		if err := tx.Get(ctx, dalrecord.NewRecordWithData(key, got)); err != nil {
+			return err
+		}
+		require.Equal(t, "stored", got.Name)
+		return nil
+	})
+	require.NoError(t, err)
 }
 
 // TestConcurrentReadonlyQueriesInitializeEnginesSafely verifies that queries

--- a/adapters/dalgo2memory/optimistic_test.go
+++ b/adapters/dalgo2memory/optimistic_test.go
@@ -282,9 +282,20 @@ func TestOptimisticConcurrencyDisjointKeysDoNotConflict(t *testing.T) {
 // Get after a Set/Insert/Update/Delete of the same key must see that
 // transaction's own pending write, even though nothing has reached the
 // shared engine yet.
+//
+// This deliberately combines WithOptimisticConcurrency with
+// WithInterleavedReadsAndWritesInTransaction: the Set-then-Get-then-Exists
+// sequence below is exactly the ordering a real Firestore transaction
+// forbids (Firestore requires every read before any write), so under the
+// package's Firestore-compatible default this would correctly fail with
+// ErrReadAfterWriteInTransaction. The point of this test is a different,
+// orthogonal property — that the optimistic engine's local write buffer
+// itself is internally consistent — so it opts into the permissive ordering
+// a SQL-like backend would allow rather than asserting a Firestore ordering
+// rule it isn't testing.
 func TestOptimisticConcurrencyReadYourOwnWrites(t *testing.T) {
 	ctx := context.Background()
-	db := newDatabase(WithOptimisticConcurrency())
+	db := newDatabase(WithOptimisticConcurrency(), WithInterleavedReadsAndWritesInTransaction())
 	key := dalrecord.NewKeyWithID("Things", "rmw")
 
 	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
@@ -314,6 +325,32 @@ func TestOptimisticConcurrencyReadYourOwnWrites(t *testing.T) {
 	exists, err := db.Exists(ctx, key)
 	require.NoError(t, err)
 	require.False(t, exists)
+}
+
+// TestOptimisticConcurrencyInheritsDefaultOrdering proves the inverted
+// NewDB default (strict, Firestore-compatible read-after-write rejection)
+// propagates into WithOptimisticConcurrency transactions exactly like it does
+// for the default whole-database-lock mode: optimisticState routes
+// noReadsAfterWrites through from db.noReadsAfterWritesInTransaction (see
+// runOptimisticReadwriteTransaction), so a database built with
+// WithOptimisticConcurrency alone — no interleave opt-out — still rejects a
+// session-level read that follows a session-level write in the same
+// transaction. This combination (optimistic concurrency + strict ordering)
+// is in fact the more faithful emulation of real Firestore, which is both
+// optimistically concurrent and ordering-restricted at once.
+func TestOptimisticConcurrencyInheritsDefaultOrdering(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	key := dalrecord.NewKeyWithID("Things", "ordering")
+	require.NoError(t, db.Set(ctx, dalrecord.NewRecordWithData(key, &thing{Name: "before"})))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		if err := tx.Set(ctx, dalrecord.NewRecordWithData(key, &thing{Name: "after"})); err != nil {
+			return err
+		}
+		return tx.Get(ctx, dalrecord.NewRecordWithData(key, &thing{}))
+	})
+	require.ErrorIs(t, err, ErrReadAfterWriteInTransaction)
 }
 
 // TestOptimisticConcurrencyUpdateCompoundsAndCommits checks that Update

--- a/adapters/dalgo2memory/schema.go
+++ b/adapters/dalgo2memory/schema.go
@@ -13,11 +13,41 @@ type Option func(*database)
 // WithNoReadsAfterWritesInTransaction enables Firestore-compatible transaction
 // ordering for this in-memory database. In a read-write transaction, every
 // read after the first successful write returns ErrReadAfterWriteInTransaction.
-// It is intended for tests that need to catch Firestore-only ordering errors;
-// the default in-memory behavior remains permissive.
+//
+// Deprecated: this is now NewDB's default behavior, so calling this option is
+// redundant on a plain NewDB(). It still works — it re-asserts strict
+// ordering, which only matters when combined with an earlier
+// WithInterleavedReadsAndWritesInTransaction() in the same option list, since
+// options apply in order and the last one wins. New code should omit it and
+// rely on the default; existing callers (sneat-co/chessraiders among them)
+// are unaffected and may drop the call at their own pace.
 func WithNoReadsAfterWritesInTransaction() Option {
 	return func(db *database) {
 		db.noReadsAfterWritesInTransaction = true
+	}
+}
+
+// WithInterleavedReadsAndWritesInTransaction opts a database out of the
+// default Firestore-compatible transaction-ordering check: with it, a
+// read-write transaction may freely read a key after the transaction has
+// written (to that key or any other), the same way a SQL database's
+// session-local transaction behaves.
+//
+// Use this when the in-memory database stands in for a backend whose
+// transactions genuinely permit interleaving reads and writes — a SQL-style
+// adapter such as dalgo2mysql, dalgo2postgres, or dalgo2sqlite, or a test
+// double standing in for one of them. Do NOT reach for this just to make a
+// failing test pass: if the code under test also runs against Firestore
+// (dalgo2firestore) or another backend with the same read-after-write
+// restriction, a test failing with ErrReadAfterWriteInTransaction is
+// reporting a real ordering bug in the code under test — the same class of
+// bug that shipped a production 500 in sneat-core-modules's
+// set_user_country, undetected because its unit tests ran against the old
+// permissive default. Silencing that signal with this option would hide the
+// bug again, not fix it.
+func WithInterleavedReadsAndWritesInTransaction() Option {
+	return func(db *database) {
+		db.noReadsAfterWritesInTransaction = false
 	}
 }
 


### PR DESCRIPTION
Inverts `dalgo2memory`'s transaction-ordering default: a plain `NewDB()` now rejects a read that follows a write inside a read-write transaction, returning `ErrReadAfterWriteInTransaction` (message byte-identical to real Firestore's).

## Why

The machinery already existed behind `WithNoReadsAfterWritesInTransaction()`, but it was **opt-in**, so test fidelity required knowing the constraint exists — and the developers who write read-after-write are precisely those who don't. The permissive default made every in-memory test silently kinder than production.

That shipped a real 500 today: `facade4userus.txSetUserCountry` loops over spaces calling a read-then-write helper, so iteration 2 reads after iteration 1 wrote. Broken for **every user with 2+ spaces**, with green unit tests throughout.

A fleet impact assessment against this branch has already confirmed the same defect shape in unrelated repos — `competios` (paid-participation path), `debtus` (5 distinct bugs), and `bots-fw-store-dalgo`'s `EnsureLinked`. These are latent production bugs the old default was hiding, not test churn.

## Changes

- Default is now strict; `branching.go` and `optimistic.go` propagation verified by new tests.
- **New opt-out**: `WithInterleavedReadsAndWritesInTransaction()`, for when the in-memory DB stands in for a backend that genuinely permits interleaving (dalgo2mysql / dalgo2postgres / dalgo2sqlite). Named for intent, and documented to warn against reaching for it to silence a failing test — doing so hides exactly the class of bug this change surfaces.
- `WithNoReadsAfterWritesInTransaction()` kept working and marked deprecated (redundant on a plain `NewDB()`, still meaningful after an opt-out in the same option list, since last-wins). `sneat-co/chessraiders` calls it in 5+ places and is unaffected.

## Breaking

Behavioural, not source-level: consumers still compile. Their tests may newly fail — and where they do, that failure is the point. Consumers are pinned, so nothing changes for anyone until they bump; propagation is a separate controlled campaign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jHJHbnHddXPJe72gzyhsx