### PR TITLE
feat(dalgo2memory): make read-write transactions atomic by default

### DIFF
--- a/adapters/dalgo2memory/atomicity_test.go
+++ b/adapters/dalgo2memory/atomicity_test.go
@@ -231,6 +231,64 @@ func TestInterleavedReadsSeeOwnWrites(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// genThing is the record type the top-level generated-insert tests below store.
+type genThing struct {
+	Name string `json:"name"`
+}
+
+// TestTopLevelInsert_WithGenerator covers session.Insert's NON-transactional
+// generated-id path.
+//
+// It exists because of the buffering change: an Insert issued inside a
+// read-write transaction now routes through the pending buffer
+// (optimisticState.insert), so the transaction-based generator tests in
+// generated_insert_test.go no longer reach the immediate engine path at all.
+// That path is still live for a top-level call on the backend, so it keeps its
+// own coverage here rather than being deleted as newly-unreachable — it is not
+// unreachable, only reached from somewhere else now.
+func TestTopLevelInsert_WithGenerator(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase()
+
+	rec := record.NewRecordWithIncompleteKey("things", reflect.String, &genThing{Name: "generated"})
+	require.NoError(t, db.Insert(ctx, rec, dal.WithRandomStringKey(16, 5)))
+
+	id, ok := rec.Key().ID.(string)
+	require.True(t, ok, "generator must assign a string id")
+	require.NotEmpty(t, id, "generated id must not be empty")
+
+	out := &genThing{}
+	require.NoError(t, db.Get(ctx, record.NewRecordWithData(record.NewKeyWithID("things", id), out)))
+	assert.Equal(t, "generated", out.Name)
+}
+
+// TestTopLevelInsert_GeneratorCollision covers the same non-transactional path's
+// collision branch: a deterministic generator that keeps producing an id which
+// is already taken must exhaust its attempts rather than overwrite the record
+// sitting there.
+func TestTopLevelInsert_GeneratorCollision(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase()
+
+	// A day-accuracy timestamp generator deterministically yields the same id
+	// throughout a single test run, so the second insert collides every attempt.
+	gen := dal.WithTimeStampStringID(dal.TimeStampAccuracyDay, 10, 5)
+
+	first := record.NewRecordWithIncompleteKey("days", reflect.String, &genThing{Name: "first"})
+	require.NoError(t, db.Insert(ctx, first, gen))
+	firstID, ok := first.Key().ID.(string)
+	require.True(t, ok)
+
+	second := record.NewRecordWithIncompleteKey("days", reflect.String, &genThing{Name: "second"})
+	err := db.Insert(ctx, second, gen)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, dal.ErrExceedsMaxNumberOfAttempts)
+
+	out := &genThing{}
+	require.NoError(t, db.Get(ctx, record.NewRecordWithData(record.NewKeyWithID("days", firstID), out)))
+	assert.Equal(t, "first", out.Name, "the colliding insert must not overwrite the record already there")
+}
+
 // TestReadAfterWriteStillRejectedByDefault re-asserts that buffering did not
 // weaken the v0.67.0 ordering rule.
 func TestReadAfterWriteStillRejectedByDefault(t *testing.T) {

--- a/adapters/dalgo2memory/atomicity_test.go
+++ b/adapters/dalgo2memory/atomicity_test.go
@@ -1,0 +1,248 @@
+package dalgo2memory
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/record"
+	"github.com/dal-go/record/update"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// errBoom is the callback failure these tests use to abort a transaction.
+var errBoom = errors.New("boom")
+
+func thingKey(id string) *record.Key {
+	return record.NewKeyWithID("things", id)
+}
+
+func thingRecord(id string, n int) record.Record {
+	return record.NewRecordWithData(thingKey(id), map[string]any{"n": n})
+}
+
+// TestTransactionRollback_DiscardsWrites is the regression test for the
+// in-memory adapter's atomicity gap: Firestore discards every write of a
+// transaction whose callback returns an error, and before this the default
+// (whole-database lock) mode applied writes to the storage engines as they
+// were made, so a failed transaction left its partial work committed for real.
+//
+// It runs against BOTH transaction modes, because the optimistic mode already
+// behaved correctly and must keep doing so.
+func TestTransactionRollback_DiscardsWrites(t *testing.T) {
+	for _, mode := range []struct {
+		name string
+		opts []Option
+	}{
+		{"default locked mode", nil},
+		{"WithOptimisticConcurrency", []Option{WithOptimisticConcurrency()}},
+	} {
+		t.Run(mode.name, func(t *testing.T) {
+			ctx := context.Background()
+			db := newDatabase(mode.opts...)
+
+			err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+				if err := tx.Set(ctx, thingRecord("t1", 1)); err != nil {
+					return err
+				}
+				if err := tx.Set(ctx, thingRecord("t2", 2)); err != nil {
+					return err
+				}
+				return errBoom
+			})
+			require.ErrorIs(t, err, errBoom)
+
+			for _, id := range []string{"t1", "t2"} {
+				exists, existsErr := db.Exists(ctx, thingKey(id))
+				require.NoError(t, existsErr)
+				assert.False(t, exists,
+					"record %q written by a FAILED transaction must not survive it", id)
+			}
+		})
+	}
+}
+
+// TestTransactionRollback_DiscardsDeletes proves the rollback covers deletes,
+// not only stores: a record removed inside a transaction that then fails must
+// still be there afterwards.
+func TestTransactionRollback_DiscardsDeletes(t *testing.T) {
+	for _, mode := range []struct {
+		name string
+		opts []Option
+	}{
+		{"default locked mode", nil},
+		{"WithOptimisticConcurrency", []Option{WithOptimisticConcurrency()}},
+	} {
+		t.Run(mode.name, func(t *testing.T) {
+			ctx := context.Background()
+			db := newDatabase(mode.opts...)
+			require.NoError(t, db.Set(ctx, thingRecord("keep", 1)))
+
+			err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+				if err := tx.Delete(ctx, thingKey("keep")); err != nil {
+					return err
+				}
+				return errBoom
+			})
+			require.ErrorIs(t, err, errBoom)
+
+			exists, existsErr := db.Exists(ctx, thingKey("keep"))
+			require.NoError(t, existsErr)
+			assert.True(t, exists,
+				"a record deleted by a FAILED transaction must still exist afterwards")
+		})
+	}
+}
+
+// TestTransactionCommit_AppliesAllWrites is the other half of atomicity: a
+// transaction that returns nil must apply every write it made. Without this,
+// "discard on error" could be satisfied by never writing anything at all.
+func TestTransactionCommit_AppliesAllWrites(t *testing.T) {
+	for _, mode := range []struct {
+		name string
+		opts []Option
+	}{
+		{"default locked mode", nil},
+		{"WithOptimisticConcurrency", []Option{WithOptimisticConcurrency()}},
+	} {
+		t.Run(mode.name, func(t *testing.T) {
+			ctx := context.Background()
+			db := newDatabase(mode.opts...)
+			require.NoError(t, db.Set(ctx, thingRecord("gone", 9)))
+
+			err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+				if err := tx.Set(ctx, thingRecord("t1", 1)); err != nil {
+					return err
+				}
+				if err := tx.Insert(ctx, thingRecord("t2", 2)); err != nil {
+					return err
+				}
+				return tx.Delete(ctx, thingKey("gone"))
+			})
+			require.NoError(t, err)
+
+			for _, id := range []string{"t1", "t2"} {
+				exists, existsErr := db.Exists(ctx, thingKey(id))
+				require.NoError(t, existsErr)
+				assert.True(t, exists, "record %q written by a COMMITTED transaction must survive", id)
+			}
+			exists, existsErr := db.Exists(ctx, thingKey("gone"))
+			require.NoError(t, existsErr)
+			assert.False(t, exists, "record deleted by a COMMITTED transaction must be gone")
+		})
+	}
+}
+
+// TestTransactionRollback_UpdateIsDiscarded proves an Update's merged result is
+// buffered like any other write rather than mutating stored data in place.
+func TestTransactionRollback_UpdateIsDiscarded(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase()
+	require.NoError(t, db.Set(ctx, thingRecord("t1", 1)))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		if err := tx.Update(ctx, thingKey("t1"), []update.Update{
+			update.ByFieldName("n", 42),
+		}); err != nil {
+			return err
+		}
+		return errBoom
+	})
+	require.ErrorIs(t, err, errBoom)
+
+	var got map[string]any
+	rec := record.NewRecordWithData(thingKey("t1"), &got)
+	require.NoError(t, db.Get(ctx, rec))
+	assert.EqualValues(t, 1, got["n"], "an Update in a FAILED transaction must not reach storage")
+}
+
+// TestQueryInsideReadwriteTransaction_StillWorks guards the default mode's
+// query support, which the buffering change must not regress: a query issued
+// before the transaction's first write reads committed storage, which is
+// exactly correct, because the default ordering rule means no write can
+// precede it.
+func TestQueryInsideReadwriteTransaction_StillWorks(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase()
+	require.NoError(t, db.Set(ctx, thingRecord("seed", 1)))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		q := dal.From(dal.NewRootCollectionRef("things", "")).NewQuery().SelectKeysOnly(reflect.String)
+		reader, qErr := tx.ExecuteQueryToRecordsReader(ctx, q)
+		if qErr != nil {
+			return qErr
+		}
+		records, readErr := dal.ReadAllToRecords(ctx, reader)
+		if readErr != nil {
+			return readErr
+		}
+		assert.Len(t, records, 1, "the query should see the seeded record")
+		// Writing afterwards is fine; only reading after a write is not.
+		return tx.Set(ctx, thingRecord("added", 2))
+	})
+	require.NoError(t, err)
+}
+
+// TestQueryAfterWrite_RefusedRatherThanStale covers the one configuration in
+// which a query can legitimately follow a write —
+// WithInterleavedReadsAndWritesInTransaction. A query scans committed storage
+// and so cannot see the transaction's buffered writes; it must say so rather
+// than quietly return a result that omits them.
+func TestQueryAfterWrite_RefusedRatherThanStale(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithInterleavedReadsAndWritesInTransaction())
+	require.NoError(t, db.Set(ctx, thingRecord("seed", 1)))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		if err := tx.Set(ctx, thingRecord("added", 2)); err != nil {
+			return err
+		}
+		q := dal.From(dal.NewRootCollectionRef("things", "")).NewQuery().SelectKeysOnly(reflect.String)
+		_, qErr := tx.ExecuteQueryToRecordsReader(ctx, q)
+		return qErr
+	})
+	require.ErrorIs(t, err, dal.ErrNotSupported)
+	assert.Contains(t, err.Error(), "cannot see that transaction's own uncommitted writes")
+}
+
+// TestInterleavedReadsSeeOwnWrites proves the opt-out still behaves like a
+// SQL-style session transaction: with the ordering rule off, a read by key
+// after a write returns the written value from the transaction's own pending
+// view, even though nothing has reached the shared store yet.
+func TestInterleavedReadsSeeOwnWrites(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithInterleavedReadsAndWritesInTransaction())
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		if err := tx.Set(ctx, thingRecord("t1", 7)); err != nil {
+			return err
+		}
+		var got map[string]any
+		rec := record.NewRecordWithData(thingKey("t1"), &got)
+		if err := tx.Get(ctx, rec); err != nil {
+			return err
+		}
+		assert.EqualValues(t, 7, got["n"], "a read after a write must see this transaction's own write")
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// TestReadAfterWriteStillRejectedByDefault re-asserts that buffering did not
+// weaken the v0.67.0 ordering rule.
+func TestReadAfterWriteStillRejectedByDefault(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase()
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		if err := tx.Set(ctx, thingRecord("t1", 1)); err != nil {
+			return err
+		}
+		_, existsErr := tx.Exists(ctx, thingKey("t1"))
+		return existsErr
+	})
+	require.ErrorIs(t, err, ErrReadAfterWriteInTransaction)
+}

--- a/adapters/dalgo2memory/database.go
+++ b/adapters/dalgo2memory/database.go
@@ -111,11 +111,7 @@ func (db *database) RunReadwriteTransaction(ctx context.Context, f dal.RWTxWorke
 	if db.optimisticConcurrency {
 		return db.runOptimisticReadwriteTransaction(ctx, f)
 	}
-	db.mu.Lock()
-	defer db.mu.Unlock()
-	return f(ctx, session{db: db, txState: &transactionState{
-		noReadsAfterWrites: db.noReadsAfterWritesInTransaction,
-	}})
+	return db.runLockedReadwriteTransaction(ctx, f)
 }
 
 func (db *database) Exists(ctx context.Context, key *record.Key) (bool, error) {
@@ -460,14 +456,30 @@ func (s session) ExecuteQueryToRecordsReader(_ context.Context, query dal.Query)
 	if err := s.allowRead(); err != nil {
 		return nil, err
 	}
-	if s.optimistic() != nil {
-		// A query scans committed storage directly (see loadCandidateRows), so
-		// inside an optimistic-mode transaction it would see neither this
-		// transaction's own buffered writes nor participate in its conflict
-		// detection — a correctness trap, not a convenience. Point reads/writes
-		// by key (Get, Exists, Set, Insert, Update, Delete) are fully supported;
-		// see WithOptimisticConcurrency's doc comment.
-		return nil, fmt.Errorf("%w: queries are not supported inside a WithOptimisticConcurrency read-write transaction; read by key, or run the query outside the transaction", dal.ErrNotSupported)
+	if opt := s.optimistic(); opt != nil {
+		// A query scans committed storage directly (see loadCandidateRows)
+		// rather than resolving keys through the transaction's pending view, so
+		// it cannot see writes this transaction has buffered but not committed.
+		// Answering it anyway would silently return a stale result — a
+		// correctness trap, not a convenience.
+		//
+		// In the default locked mode this is normally unreachable: the default
+		// noReadsAfterWritesInTransaction rule already rejects any read after a
+		// write, so a query can only run while the buffer is empty, and reading
+		// committed storage is then exactly correct. It becomes reachable only
+		// under WithInterleavedReadsAndWritesInTransaction, where a query may
+		// legitimately follow a write.
+		if opt.hasBufferedWrites() {
+			return nil, fmt.Errorf("%w: a query inside a read-write transaction cannot see that transaction's own uncommitted writes; issue the query before the first write, or read by key", dal.ErrNotSupported)
+		}
+		// In optimistic mode a query additionally takes no part in conflict
+		// detection: the rows it scans never enter the read set, so a
+		// concurrent commit that changes them will not be caught. Point
+		// reads/writes by key are fully supported — see
+		// WithOptimisticConcurrency's doc comment.
+		if s.db.optimisticConcurrency {
+			return nil, fmt.Errorf("%w: queries are not supported inside a WithOptimisticConcurrency read-write transaction; read by key, or run the query outside the transaction", dal.ErrNotSupported)
+		}
 	}
 	q, ok := query.(dal.StructuredQuery)
 	if !ok {

--- a/adapters/dalgo2memory/optimistic.go
+++ b/adapters/dalgo2memory/optimistic.go
@@ -79,6 +79,57 @@ type optimisticState struct {
 	// pending is this transaction's local, mutable view of every key it has
 	// touched so far, keyed by conflictKey. See pendingEntry and touch.
 	pending map[string]*pendingEntry
+
+	// ownerHoldsLock is true when the transaction owning this state already
+	// holds db.mu for its whole duration — the default (whole-database lock)
+	// mode, see runLockedReadwriteTransaction. Every method below reaches the
+	// shared store through lock/unlock rather than db.mu directly, because
+	// sync.Mutex is not reentrant: taking db.mu again from inside a
+	// default-mode transaction would deadlock instantly. In optimistic mode
+	// this stays false and lock/unlock take the mutex for real, one short
+	// critical section per operation, exactly as before this field existed.
+	ownerHoldsLock bool
+
+	// validateVersions is true only in optimistic mode, where commit checks
+	// this transaction's read set against the live commit-version table and
+	// advances the versions of the keys it writes. The default locked mode
+	// leaves it false: it holds db.mu for the callback's entire duration, so no
+	// other transaction can interleave and there is nothing to validate — and
+	// skipping the bookkeeping keeps db.versions empty rather than growing it
+	// with entries nothing ever reads.
+	validateVersions bool
+}
+
+// lock acquires db.mu unless the owning transaction already holds it for its
+// whole duration (the default locked mode). See ownerHoldsLock.
+func (tx *optimisticState) lock() {
+	if !tx.ownerHoldsLock {
+		tx.db.mu.Lock()
+	}
+}
+
+// unlock releases db.mu unless the owning transaction holds it for its whole
+// duration (the default locked mode). See ownerHoldsLock.
+func (tx *optimisticState) unlock() {
+	if !tx.ownerHoldsLock {
+		tx.db.mu.Unlock()
+	}
+}
+
+// hasBufferedWrites reports whether this transaction has staged a write that
+// has not yet reached the shared store. A query scans committed storage
+// directly, so it cannot see such writes; ExecuteQueryToRecordsReader consults
+// this to refuse the query rather than silently return a stale result.
+//
+// The caller must already hold db.mu (every caller runs inside a transaction
+// method that does), so this reads tx.pending directly rather than locking.
+func (tx *optimisticState) hasBufferedWrites() bool {
+	for _, entry := range tx.pending {
+		if entry.commit != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // pendingEntry is one key's transaction-local view: the outcome of every
@@ -143,9 +194,10 @@ func conflictKey(collection, id string) string {
 // it is not holding any lock while paused.
 func (db *database) runOptimisticReadwriteTransaction(ctx context.Context, f dal.RWTxWorker) error {
 	tx := &optimisticState{
-		db:      db,
-		reads:   make(map[string]uint64),
-		pending: make(map[string]*pendingEntry),
+		db:               db,
+		reads:            make(map[string]uint64),
+		pending:          make(map[string]*pendingEntry),
+		validateVersions: true,
 	}
 	s := session{db: db, txState: &transactionState{
 		noReadsAfterWrites: db.noReadsAfterWritesInTransaction,
@@ -153,6 +205,54 @@ func (db *database) runOptimisticReadwriteTransaction(ctx context.Context, f dal
 	}}
 	if err := f(ctx, s); err != nil {
 		return err
+	}
+	return tx.commit()
+}
+
+// runLockedReadwriteTransaction is RunReadwriteTransaction's default path: it
+// holds db.mu for the callback's entire duration, so read-write transactions
+// are fully serialized and cannot contend (see WithOptimisticConcurrency for
+// the mode where they can).
+//
+// Writes are nonetheless buffered through the same optimisticState machinery
+// rather than applied to the storage engines as they are made, because that is
+// what makes a transaction ATOMIC: Firestore discards every write of a
+// transaction whose callback returns an error, and before this the in-memory
+// adapter left them behind, so a failed transaction committed its partial work
+// for real. Returning early below — without calling commit — is the whole
+// rollback mechanism: nothing was ever written, so there is nothing to undo.
+//
+// No read-overlay logic is needed to make the buffer invisible, because the
+// default noReadsAfterWritesInTransaction rule already rejects any read that
+// follows a write in the same transaction: a read can only happen while the
+// buffer is still empty. The one configuration that can observe the buffer is
+// WithInterleavedReadsAndWritesInTransaction, and there reads DO consult it —
+// every read goes through optimisticState.touch, which returns this
+// transaction's own pending view of a key it has written. The single case
+// buffering cannot serve is a QUERY issued after a write, since a query scans
+// committed storage rather than resolving keys through touch; that is refused
+// explicitly rather than answered with a stale result (see
+// session.ExecuteQueryToRecordsReader).
+func (db *database) runLockedReadwriteTransaction(ctx context.Context, f dal.RWTxWorker) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	tx := &optimisticState{
+		db:      db,
+		reads:   make(map[string]uint64),
+		pending: make(map[string]*pendingEntry),
+		// The callback runs with db.mu held for its whole duration, so the
+		// per-operation locking inside optimisticState must be suppressed
+		// (sync.Mutex is not reentrant), and there is no concurrent commit to
+		// validate a read set against.
+		ownerHoldsLock:   true,
+		validateVersions: false,
+	}
+	s := session{db: db, txState: &transactionState{
+		noReadsAfterWrites: db.noReadsAfterWritesInTransaction,
+		optimistic:         tx,
+	}}
+	if err := f(ctx, s); err != nil {
+		return err // buffered writes are discarded: this IS the rollback
 	}
 	return tx.commit()
 }
@@ -237,8 +337,8 @@ func (tx *optimisticState) touch(collection, id string, key *record.Key) (*pendi
 // pendingEntry, and releases db.mu again before returning. Both session.Get
 // and session.Exists go through it.
 func (tx *optimisticState) read(collection, id string, key *record.Key) (*pendingEntry, error) {
-	tx.db.mu.Lock()
-	defer tx.db.mu.Unlock()
+	tx.lock()
+	defer tx.unlock()
 	return tx.touch(collection, id, key)
 }
 
@@ -303,12 +403,12 @@ func (tx *optimisticState) stage(rec record.Record) error {
 		return err
 	}
 
-	tx.db.mu.Lock()
+	tx.lock()
 	entry, _ := tx.firstTouchEntry(collection, keyID(key), key)
 	entry.present = true
 	entry.data = data
 	entry.commit = &pendingWrite{kind: pendingWriteStore, rec: rec, overwrite: true}
-	tx.db.mu.Unlock()
+	tx.unlock()
 
 	rec.SetError(nil)
 	return nil
@@ -343,7 +443,7 @@ func (tx *optimisticState) insert(rec record.Record) error {
 		return err
 	}
 
-	tx.db.mu.Lock()
+	tx.lock()
 	entry, touchErr := tx.touch(collection, keyID(key), key)
 	var resultErr error
 	switch {
@@ -356,7 +456,7 @@ func (tx *optimisticState) insert(rec record.Record) error {
 		entry.data = data
 		entry.commit = &pendingWrite{kind: pendingWriteStore, rec: rec, overwrite: false}
 	}
-	tx.db.mu.Unlock()
+	tx.unlock()
 
 	if resultErr != nil {
 		rec.SetError(resultErr)
@@ -371,8 +471,8 @@ func (tx *optimisticState) insert(rec record.Record) error {
 // no-op (never an error), and no schema-guard check is performed.
 func (tx *optimisticState) delete(key *record.Key) {
 	collection := key.Collection()
-	tx.db.mu.Lock()
-	defer tx.db.mu.Unlock()
+	tx.lock()
+	defer tx.unlock()
 	// A delete never needs the prior value, so firstTouchEntry (which never
 	// fails) is enough — no need for touch's live-engine load.
 	entry, _ := tx.firstTouchEntry(collection, keyID(key), key)
@@ -397,8 +497,8 @@ func (tx *optimisticState) updateRecord(rec record.Record, updates []update.Upda
 		return err
 	}
 
-	tx.db.mu.Lock()
-	defer tx.db.mu.Unlock()
+	tx.lock()
+	defer tx.unlock()
 	entry, err := tx.touch(collection, keyID(key), key)
 	if err != nil {
 		return err
@@ -451,12 +551,14 @@ func (tx *optimisticState) updateRecord(rec record.Record, updates []update.Upda
 // this adapter's Feature report for the trade-off this accepts rather than
 // building a full two-phase commit across the storageEngine interface.
 func (tx *optimisticState) commit() error {
-	tx.db.mu.Lock()
-	defer tx.db.mu.Unlock()
+	tx.lock()
+	defer tx.unlock()
 
-	for ck, baseline := range tx.reads {
-		if tx.db.versions[ck] != baseline {
-			return fmt.Errorf("%w: key %q changed after this transaction observed it", ErrTransactionConflict, ck)
+	if tx.validateVersions {
+		for ck, baseline := range tx.reads {
+			if tx.db.versions[ck] != baseline {
+				return fmt.Errorf("%w: key %q changed after this transaction observed it", ErrTransactionConflict, ck)
+			}
 		}
 	}
 
@@ -475,7 +577,9 @@ func (tx *optimisticState) commit() error {
 				return err
 			}
 		}
-		tx.db.versions[ck]++
+		if tx.validateVersions {
+			tx.db.versions[ck]++
+		}
 	}
 	return nil
 }

--- a/adapters/dalgo2memory/schema.go
+++ b/adapters/dalgo2memory/schema.go
@@ -95,8 +95,14 @@ func WithInterleavedReadsAndWritesInTransaction() Option {
 // forcing every adapter to grow an equivalent option and test hook just to
 // stay in the suite would be scope the other adapters never asked for.
 //
-// The default remains the whole-database lock; nothing changes unless this
-// option is passed to NewDB.
+// The default remains the whole-database lock, so transactions still cannot
+// contend unless this option is passed. What the default no longer differs on
+// is ATOMICITY: both modes buffer a transaction's writes and apply them only
+// once its callback returns nil, so a failed transaction discards its writes
+// exactly as Firestore does (see runLockedReadwriteTransaction). Contention is
+// therefore the one remaining transactional difference between the two modes,
+// alongside queries — which the default mode supports inside a read-write
+// transaction and this mode does not.
 func WithOptimisticConcurrency() Option {
 	return func(db *database) {
 		db.optimisticConcurrency = true


### PR DESCRIPTION
Follow-up to #120, answering the question that PR's lesson ended on: *for every remaining `WithX()` option that makes the double behave more like production, why isn't it the default?*

I probed `dalgo2memory` against Firestore's actual transaction semantics rather than reasoning from the option list. The result:

| Firestore semantic | `DEFAULT` | `WithOptimisticConcurrency` |
|---|---|---|
| Read-after-write rejected | ✅ *(v0.67.0)* | ✅ |
| **Failed transaction rolls back** | ❌ **writes persist** | ✅ |
| Transactions genuinely contend | ❌ serialized | ✅ |
| Query inside read-write tx | ✅ | ❌ `ErrNotSupported` |
| `Update` missing → NotFound | ✅ | — |
| `Insert` existing → AlreadyExists | ✅ | — |
| `Delete` missing → no-op | ✅ | — |

Measured, not assumed:

```
DEFAULT      write survives FAILED transaction = true   (Firestore: false)
OPTIMISTIC   write survives FAILED transaction = false  (Firestore: false)
```

**The default mode had no atomicity at all**, and no option to get it — a `RunReadwriteTransaction` was just "hold a lock and write things". A transaction that failed halfway committed its first half. This is the same shape as the bug #120 fixed: the faithful behaviour existed, implemented and working, behind an opt-in.

## What this changes

The default mode now buffers writes through the existing `optimisticState` machinery and applies them only when the callback returns `nil`. Returning early *is* the rollback — nothing was written, so there is nothing to undo.

Two small pieces make the reuse work:

- `optimisticState` reaches the shared store through `lock`/`unlock` rather than `db.mu` directly, so it can run under a lock the owning transaction already holds (`sync.Mutex` is not reentrant — this would otherwise deadlock instantly).
- Commit-version validation and bookkeeping are gated on a new `validateVersions`, set only in optimistic mode. The locked mode holds `db.mu` for the callback's whole duration, so nothing can interleave and there is nothing to validate.

**No read-overlay logic was needed**, which is what keeps this change small: the default `noReadsAfterWritesInTransaction` rule already rejects any read following a write, so the buffer can never be observed. Under `WithInterleavedReadsAndWritesInTransaction` reads *do* resolve through the pending view and see the transaction's own writes.

The one case buffering cannot serve is a **query** after a write — a query scans committed storage rather than resolving keys through `touch`. That is now refused with a descriptive error rather than silently returning a stale result. Queries issued before the first write (the only kind the default ordering rule permits) work exactly as before.

## What this deliberately does not change

Contention. The default still serializes transactions, and `WithOptimisticConcurrency` remains how a test proves a real concurrency guarantee. Making *that* the default is a genuine trade-off rather than a free win, because optimistic mode does not support queries inside a read-write transaction — so flipping it would swap one divergence for another. Closing that gap (overlaying buffered writes onto a transactional query scan, and registering the scanned rows in the read set) is a larger piece of work and belongs in its own PR.

## Verification

Full suite green under `-race`; `go vet` clean. The existing conformance suite (`dalgotest.RunConformance`, also run by `dalgo2firestore/end2end` against live Firestore) passes unchanged.

New tests in `atomicity_test.go`, run against **both** modes where applicable, so the optimistic mode's already-correct behaviour is pinned too:

- writes discarded on failure · deletes discarded on failure · updates discarded on failure
- all writes applied on success (so "discard on error" can't be satisfied by never writing)
- queries inside a read-write transaction still work
- a query after a write is refused, not stale
- interleaved reads still see own writes
- read-after-write still rejected by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jHJHbnHddXPJe72gzyhsx