### PR TITLE
fix(dalgo2memory): poison commit when a read-after-write rejection is swallowed

### DIFF
--- a/adapters/dalgo2memory/atomicity_test.go
+++ b/adapters/dalgo2memory/atomicity_test.go
@@ -304,3 +304,48 @@ func TestReadAfterWriteStillRejectedByDefault(t *testing.T) {
 	})
 	require.ErrorIs(t, err, ErrReadAfterWriteInTransaction)
 }
+
+// TestReadAfterWriteRejection_PoisonsCommitEvenIfSwallowed is the regression
+// test for the fidelity gap this covers: the real Firestore Go client
+// (cloud.google.com/go/firestore, transaction.go's readAfterWrite field)
+// records a rejected read-after-write and fails the transaction's commit
+// even when the callback swallows the read's error and returns nil. Before
+// this fix, dalgo2memory only surfaced the violation through the read call's
+// own return value — a callback that ignored it and returned nil got its
+// buffered writes committed anyway, which a real Firestore-backed caller
+// could never observe.
+//
+// It runs against BOTH transaction modes: the flag lives on transactionState,
+// which both runLockedReadwriteTransaction and runOptimisticReadwriteTransaction
+// share, and each has its own commit-refusal check to cover.
+func TestReadAfterWriteRejection_PoisonsCommitEvenIfSwallowed(t *testing.T) {
+	for _, mode := range []struct {
+		name string
+		opts []Option
+	}{
+		{"default locked mode", nil},
+		{"WithOptimisticConcurrency", []Option{WithOptimisticConcurrency()}},
+	} {
+		t.Run(mode.name, func(t *testing.T) {
+			ctx := context.Background()
+			db := newDatabase(mode.opts...)
+
+			err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+				if err := tx.Set(ctx, thingRecord("t1", 1)); err != nil {
+					return err
+				}
+				// Deliberately swallow the read-after-write error and return nil, as
+				// a careless caller might.
+				_, _ = tx.Exists(ctx, thingKey("t1"))
+				return nil
+			})
+			require.Error(t, err, "a swallowed read-after-write rejection must still fail the commit")
+			assert.ErrorIs(t, err, ErrReadAfterWriteInTransaction)
+
+			exists, existsErr := db.Exists(ctx, thingKey("t1"))
+			require.NoError(t, existsErr)
+			assert.False(t, exists,
+				"a write buffered before a swallowed read-after-write rejection must not be committed")
+		})
+	}
+}

--- a/adapters/dalgo2memory/database.go
+++ b/adapters/dalgo2memory/database.go
@@ -208,6 +208,17 @@ type session struct {
 type transactionState struct {
 	noReadsAfterWrites bool
 	hasWritten         bool
+	// readAfterWriteRejected is set by allowRead the first time it rejects a
+	// read for following a write in this transaction. It exists so the
+	// ordering violation still poisons the transaction's eventual commit even
+	// when the callback swallows the returned error and returns nil: the real
+	// Firestore Go client (cloud.google.com/go/firestore, transaction.go's
+	// readAfterWrite field) records the same fact and fails the commit
+	// regardless of what the callback returns — it does not rely on the
+	// callback propagating the read's own error. Both
+	// runLockedReadwriteTransaction and runOptimisticReadwriteTransaction check
+	// this flag after a nil callback return and refuse to commit if it is set.
+	readAfterWriteRejected bool
 	// optimistic is non-nil exactly when this transaction belongs to a
 	// database created with WithOptimisticConcurrency. Every session
 	// read/write method checks it first (via session.optimistic()) to route
@@ -223,6 +234,10 @@ var ErrReadAfterWriteInTransaction = errors.New("firestore: read after write in 
 
 func (s session) allowRead() error {
 	if s.txState != nil && s.txState.noReadsAfterWrites && s.txState.hasWritten {
+		// Record the violation on the transaction itself, not just in this call's
+		// return value: see readAfterWriteRejected's doc comment for why a
+		// swallowed error must still fail the eventual commit.
+		s.txState.readAfterWriteRejected = true
 		return ErrReadAfterWriteInTransaction
 	}
 	return nil

--- a/adapters/dalgo2memory/database_test.go
+++ b/adapters/dalgo2memory/database_test.go
@@ -237,9 +237,19 @@ func TestNoReadsAfterWritesInTransaction(t *testing.T) {
 			require.ErrorIs(t, err, ErrReadAfterWriteInTransaction)
 			_, err = tx.ExecuteQueryToRecordsetReader(ctx, q)
 			require.ErrorIs(t, err, ErrReadAfterWriteInTransaction)
+			// Swallow every rejection above and return nil anyway: the commit must
+			// still be poisoned (see transactionState.readAfterWriteRejected) —
+			// this matches the real Firestore Go client's transaction.go, which
+			// fails the commit for a recorded read-after-write regardless of what
+			// the callback returns.
 			return nil
 		})
-		require.NoError(t, err)
+		require.ErrorIs(t, err, ErrReadAfterWriteInTransaction,
+			"a swallowed read-after-write rejection must still fail the commit")
+
+		exists, existsErr := db.Exists(ctx, dalrecord.NewKeyWithID("Things", "new"))
+		require.NoError(t, existsErr)
+		require.False(t, exists, "the write buffered before the rejected reads must not be committed")
 	})
 
 	t.Run("each write operation blocks subsequent reads", func(t *testing.T) {
@@ -278,9 +288,13 @@ func TestNoReadsAfterWritesInTransaction(t *testing.T) {
 					}
 					_, err := tx.Exists(ctx, key)
 					require.ErrorIs(t, err, ErrReadAfterWriteInTransaction)
+					// Swallow it and return nil anyway: the commit must still be
+					// poisoned — see the "read then write then reads fail" subtest
+					// above and transactionState.readAfterWriteRejected's doc comment.
 					return nil
 				})
-				require.NoError(t, err)
+				require.ErrorIs(t, err, ErrReadAfterWriteInTransaction,
+					"a swallowed read-after-write rejection must still fail the commit")
 			})
 		}
 	})

--- a/adapters/dalgo2memory/optimistic.go
+++ b/adapters/dalgo2memory/optimistic.go
@@ -199,12 +199,21 @@ func (db *database) runOptimisticReadwriteTransaction(ctx context.Context, f dal
 		pending:          make(map[string]*pendingEntry),
 		validateVersions: true,
 	}
-	s := session{db: db, txState: &transactionState{
+	txState := &transactionState{
 		noReadsAfterWrites: db.noReadsAfterWritesInTransaction,
 		optimistic:         tx,
-	}}
+	}
+	s := session{db: db, txState: txState}
 	if err := f(ctx, s); err != nil {
 		return err
+	}
+	if txState.readAfterWriteRejected {
+		// The callback swallowed the read's ErrReadAfterWriteInTransaction and
+		// returned nil, but the violation still poisons the transaction — see
+		// transactionState.readAfterWriteRejected's doc comment for the
+		// Firestore-client parity this matches. Refusing the commit here, rather
+		// than calling tx.commit(), is what discards the buffered writes.
+		return fmt.Errorf("%w: commit refused because a read-after-write was rejected earlier in this transaction", ErrReadAfterWriteInTransaction)
 	}
 	return tx.commit()
 }
@@ -247,12 +256,21 @@ func (db *database) runLockedReadwriteTransaction(ctx context.Context, f dal.RWT
 		ownerHoldsLock:   true,
 		validateVersions: false,
 	}
-	s := session{db: db, txState: &transactionState{
+	txState := &transactionState{
 		noReadsAfterWrites: db.noReadsAfterWritesInTransaction,
 		optimistic:         tx,
-	}}
+	}
+	s := session{db: db, txState: txState}
 	if err := f(ctx, s); err != nil {
 		return err // buffered writes are discarded: this IS the rollback
+	}
+	if txState.readAfterWriteRejected {
+		// The callback swallowed the read's ErrReadAfterWriteInTransaction and
+		// returned nil, but the violation still poisons the transaction — see
+		// transactionState.readAfterWriteRejected's doc comment for the
+		// Firestore-client parity this matches. Refusing the commit here, rather
+		// than calling tx.commit(), is what discards the buffered writes.
+		return fmt.Errorf("%w: commit refused because a read-after-write was rejected earlier in this transaction", ErrReadAfterWriteInTransaction)
 	}
 	return tx.commit()
 }


### PR DESCRIPTION
## Summary

Fixes a fidelity gap between `dalgo2memory`'s in-memory transaction emulation and the real Firestore Go client (`cloud.google.com/go/firestore`).

`transaction.go` in the real Firestore client tracks read-after-write violations in a `readAfterWrite` field and fails the transaction's commit based on that recorded fact — regardless of what the transaction callback itself returns. `dalgo2memory` previously only surfaced `ErrReadAfterWriteInTransaction` through the rejected read call's own return value: a callback that swallowed that error (logged it, ignored it, whatever) and returned `nil` still got its buffered writes committed. A caller relying on that in tests against `dalgo2memory` would see behavior a real Firestore-backed transaction could never produce.

## Change

- `adapters/dalgo2memory/database.go`: `transactionState` gains `readAfterWriteRejected bool`, set inside `session.allowRead()` at the point it rejects a read for following a write.
- `adapters/dalgo2memory/optimistic.go`: both `runLockedReadwriteTransaction` (default whole-database-lock mode) and `runOptimisticReadwriteTransaction` (`WithOptimisticConcurrency` mode) check the flag after the callback returns `nil` and, if set, return `ErrReadAfterWriteInTransaction` (wrapped with an explanation) instead of calling `tx.commit()` — discarding the buffered writes, matching Firestore's failed-commit behavior.
- Two `database_test.go` subtests exercised exactly this swallow pattern and asserted the transaction *succeeded*; updated to assert the now-correct poisoned-commit outcome (and, in one case, that the buffered write was discarded).
- `atomicity_test.go` gains `TestReadAfterWriteRejection_PoisonsCommitEvenIfSwallowed`, table-driven across both transaction modes, asserting both the returned error and that the written record does not exist afterwards.

Scope is exactly this poisoning fix — no other semantic changes.

## Test plan
- [x] `go test ./adapters/dalgo2memory/... -coverprofile=...` → 100.0% of statements
- [x] `go vet ./...` clean
- [x] `go test -race ./...` all packages pass

https://claude.ai/code/session_016jHJHbnHddXPJe72gzyhsx