### PR TITLE
feat(dalgo2memory): snapshot reads in optimistic mode (snapshot-or-abort)

### DIFF
--- a/adapters/dalgo2memory/database.go
+++ b/adapters/dalgo2memory/database.go
@@ -79,14 +79,24 @@ type database struct {
 	optimisticConcurrency bool
 	// versions is the commit-version table optimistic-mode transactions
 	// validate their reads against at commit (see optimisticState.commit): it
-	// maps a conflictKey to the number of times a committed write has touched
-	// it. A key absent from the map has an implicit version of 0, which
-	// doubles as "does not exist yet", so a transaction that observed a key as
-	// absent still conflicts correctly if another transaction inserts it
-	// first. It is guarded by mu exactly like the storage engines are — see
+	// maps a conflictKey to the value commitSeq held when the key was last
+	// touched by a committed write. A key absent from the map has an implicit
+	// version of 0 — older than every possible snapshot — which doubles as
+	// "does not exist yet", so a transaction that observed a key as absent
+	// still conflicts correctly if another transaction inserts it first. It is
+	// guarded by mu exactly like the storage engines are — see
 	// optimisticState's doc comment for why one short-lived critical section
 	// covers both.
 	versions map[string]uint64
+	// commitSeq is the database's global commit sequence: it advances once per
+	// committed write batch — an optimistic transaction's successful commit, or
+	// a single top-level write — and the keys that batch touched are stamped
+	// with the new value in versions. Together they let a transaction ask the
+	// one question snapshot reads need: "was this key committed after the
+	// moment my snapshot was pinned?" (see optimisticState.observeAtSnapshot).
+	// Guarded by mu; only meaningful when optimisticConcurrency is set, since
+	// the default whole-database-lock mode leaves versions empty.
+	commitSeq uint64
 }
 
 func (db *database) ID() string {

--- a/adapters/dalgo2memory/optimistic.go
+++ b/adapters/dalgo2memory/optimistic.go
@@ -67,6 +67,18 @@ func IsTransactionConflict(err error) bool {
 // this transaction's own view, exactly as they are in the default mode — the
 // only thing that moves to commit time is telling this transaction whether
 // its view was still valid when it finished.
+//
+// Reads are SNAPSHOT reads, matching Firestore: every value a transaction
+// observes belongs to the single committed database state that existed at the
+// transaction's first observation (startSeq). A key committed after that
+// moment cannot be served without fracturing the view — handing the callback
+// values from two different committed states, a mix that never existed and
+// that Firestore never shows — so touching such a key fails with
+// ErrTransactionConflict from the read itself, and poisons the commit in case
+// the callback swallows the error (see observeAtSnapshot). No data is ever
+// cloned to achieve this: as long as nothing observed has been overwritten,
+// the live store IS the snapshot, and the moment that stops being true the
+// transaction aborts and is retried instead of being served history.
 type optimisticState struct {
 	db *database
 
@@ -92,12 +104,67 @@ type optimisticState struct {
 
 	// validateVersions is true only in optimistic mode, where commit checks
 	// this transaction's read set against the live commit-version table and
-	// advances the versions of the keys it writes. The default locked mode
-	// leaves it false: it holds db.mu for the callback's entire duration, so no
-	// other transaction can interleave and there is nothing to validate — and
-	// skipping the bookkeeping keeps db.versions empty rather than growing it
-	// with entries nothing ever reads.
+	// stamps the keys it writes with a fresh commit sequence. The default
+	// locked mode leaves it false: it holds db.mu for the callback's entire
+	// duration, so no other transaction can interleave and there is nothing to
+	// validate — and skipping the bookkeeping keeps db.versions empty rather
+	// than growing it with entries nothing ever reads.
 	validateVersions bool
+
+	// startSeq is the database commit sequence this transaction reads at:
+	// every value it observes belongs to the committed state that existed at
+	// startSeq. It is pinned LAZILY, at the transaction's first observing
+	// touch (a Get, Exists, Insert's duplicate check, or Update's merge —
+	// never a blind Set/Delete, which observes nothing), rather than when the
+	// transaction starts: Firestore's effective read time is likewise its
+	// first read's, and pinning earlier would abort transactions that merely
+	// began before an unrelated commit. Zero and meaningless until
+	// startSeqPinned; guarded by db.mu like everything else here.
+	startSeq       uint64
+	startSeqPinned bool
+
+	// conflict records the first snapshot violation an observing touch
+	// detected (see observeAtSnapshot). Once set, the transaction is
+	// poisoned: every later touch returns it and commit refuses, so a
+	// callback that swallows the read error cannot commit work derived from a
+	// fractured view. The real Firestore client gives the same protection by
+	// failing the commit of a transaction whose read came back ABORTED.
+	conflict error
+}
+
+// observeAtSnapshot enforces this transaction's read snapshot for one key
+// about to be observed for the first time. On the transaction's very first
+// observation it pins startSeq to the database's current commit sequence —
+// the moment that defines which committed state this transaction reads. On
+// every later first observation it checks whether the key was committed
+// AFTER startSeq: if so, no value can be served without fracturing the view
+// (mixing values from two different committed states — the read-committed
+// anomaly this mechanism exists to kill), so it poisons the transaction and
+// returns ErrTransactionConflict from the read itself. The real Firestore
+// client behaves the same way: a read inside a transaction can come back
+// ABORTED, and the SDK's retry loop re-runs the whole callback.
+//
+// Blind writes (Set, Delete) never come through here: they observe nothing,
+// and Firestore's blind writes likewise do not conflict on the written key's
+// prior state. Their write-write races are still caught by commit's
+// validation against the baseline firstTouchEntry records at touch time.
+//
+// The caller must already hold db.mu (it is touch's own precondition), so
+// reading db.commitSeq and db.versions here is synchronized with every
+// commit's stamping.
+func (tx *optimisticState) observeAtSnapshot(ck string) error {
+	if !tx.startSeqPinned {
+		tx.startSeqPinned = true
+		tx.startSeq = tx.db.commitSeq
+		return nil
+	}
+	if seq := tx.db.versions[ck]; seq > tx.startSeq {
+		tx.conflict = fmt.Errorf(
+			"%w: key %q was committed at sequence %d, after this transaction's read snapshot (sequence %d)",
+			ErrTransactionConflict, ck, seq, tx.startSeq)
+		return tx.conflict
+	}
+	return nil
 }
 
 // lock acquires db.mu unless the owning transaction already holds it for its
@@ -257,16 +324,19 @@ func (db *database) runLockedReadwriteTransaction(ctx context.Context, f dal.RWT
 	return tx.commit()
 }
 
-// bumpConflictVersion advances the commit-version counter for one key when
-// this database runs with WithOptimisticConcurrency, so an in-flight
-// optimistic transaction correctly treats a write made outside any
-// transaction as a conflicting external commit (a default-mode transaction
-// never reaches this: RunReadwriteTransaction routes every transaction
-// through runOptimisticReadwriteTransaction instead, once optimisticConcurrency
-// is set, so the only caller left here is a top-level, non-transactional
-// write). It is a no-op — adding no locking or bookkeeping cost — for a
-// database created without WithOptimisticConcurrency, keeping the default
-// path exactly as it was before this mode existed.
+// bumpConflictVersion stamps one key with a fresh commit sequence when this
+// database runs with WithOptimisticConcurrency, so an in-flight optimistic
+// transaction correctly treats a write made outside any transaction as a
+// conflicting external commit — both at its own commit (baseline validation)
+// and at read time (observeAtSnapshot sees the key committed after its
+// snapshot). Each top-level write is its own single-key commit, so it
+// advances db.commitSeq by one and stamps the key with the new value. (A
+// default-mode transaction never reaches this: RunReadwriteTransaction routes
+// every transaction through runOptimisticReadwriteTransaction instead, once
+// optimisticConcurrency is set, so the only caller left here is a top-level,
+// non-transactional write.) It is a no-op — adding no locking or bookkeeping
+// cost — for a database created without WithOptimisticConcurrency, keeping
+// the default path exactly as it was before this mode existed.
 //
 // Callers must already hold db.mu: every call site (session.save, the
 // non-optimistic session.Delete and session.UpdateRecord) does, since all
@@ -276,7 +346,8 @@ func (db *database) bumpConflictVersion(collection, id string) {
 	if !db.optimisticConcurrency {
 		return
 	}
-	db.versions[conflictKey(collection, id)]++
+	db.commitSeq++
+	db.versions[conflictKey(collection, id)] = db.commitSeq
 }
 
 // firstTouchEntry returns key's pendingEntry, creating it — and recording its
@@ -308,16 +379,33 @@ func (tx *optimisticState) firstTouchEntry(collection, id string, key *record.Ke
 // JSON-normalized value without going back to the engine again. Get, Exists
 // (via read), Insert's duplicate check, and Update's merge all go through it.
 // A later call for the same key, from any operation, always reuses the
-// existing entry instead — that is what gives read-your-own-writes within one
-// transaction even though nothing has actually reached the shared store yet.
-// A write that does not need the prior value (Set, Delete) uses
-// firstTouchEntry directly instead, since it can never fail. The caller must
-// already hold db.mu.
+// existing entry instead — that is both what gives read-your-own-writes
+// within one transaction even though nothing has reached the shared store,
+// and what keeps a re-read of the same key snapshot-stable after another
+// transaction commits over it (commit's baseline validation then reports the
+// conflict). A write that does not need the prior value (Set, Delete) uses
+// firstTouchEntry directly instead, since it can never fail.
+//
+// A key touched for the first time is checked against the transaction's read
+// snapshot BEFORE any entry is created (see observeAtSnapshot): a key
+// committed after startSeq fails right here, leaving no half-initialized
+// entry behind for a later same-transaction read to mistake for "absent".
+// The caller must already hold db.mu.
 func (tx *optimisticState) touch(collection, id string, key *record.Key) (*pendingEntry, error) {
-	entry, isNew := tx.firstTouchEntry(collection, id, key)
-	if !isNew {
-		return entry, nil
+	if tx.conflict != nil {
+		// The transaction is already poisoned by an earlier snapshot
+		// violation; no further observation can produce a usable result, and
+		// commit will refuse regardless.
+		return nil, tx.conflict
 	}
+	ck := conflictKey(collection, id)
+	if existing, ok := tx.pending[ck]; ok {
+		return existing, nil
+	}
+	if err := tx.observeAtSnapshot(ck); err != nil {
+		return nil, err
+	}
+	entry, _ := tx.firstTouchEntry(collection, id, key)
 	eng := tx.db.engine(collection)
 	var data map[string]any
 	target := record.NewRecordWithData(key, &data)
@@ -554,6 +642,16 @@ func (tx *optimisticState) commit() error {
 	tx.lock()
 	defer tx.unlock()
 
+	if tx.conflict != nil {
+		// A read in this transaction already observed a snapshot violation;
+		// the callback swallowed that error and returned nil, but its work is
+		// derived from a fractured view and must not become visible. Refusing
+		// here mirrors the real Firestore client, which fails the commit of a
+		// transaction whose read came back ABORTED regardless of what the
+		// callback returned.
+		return fmt.Errorf("commit refused: an earlier read in this transaction observed a snapshot conflict: %w", tx.conflict)
+	}
+
 	if tx.validateVersions {
 		for ck, baseline := range tx.reads {
 			if tx.db.versions[ck] != baseline {
@@ -562,6 +660,14 @@ func (tx *optimisticState) commit() error {
 		}
 	}
 
+	// appliedSeq is this commit's entry in the global commit sequence,
+	// allocated lazily at the first applied write so a read-only commit does
+	// not advance the sequence (it changed nothing, so no snapshot needs to
+	// know it happened). Every key this commit touches is stamped with the
+	// same value: the batch is one atomic commit, and stamping its keys with
+	// one sequence is what lets observeAtSnapshot ask "was this key committed
+	// after my snapshot?" with a single comparison.
+	var appliedSeq uint64
 	for ck, entry := range tx.pending {
 		w := entry.commit
 		if w == nil {
@@ -578,7 +684,11 @@ func (tx *optimisticState) commit() error {
 			}
 		}
 		if tx.validateVersions {
-			tx.db.versions[ck]++
+			if appliedSeq == 0 {
+				tx.db.commitSeq++
+				appliedSeq = tx.db.commitSeq
+			}
+			tx.db.versions[ck] = appliedSeq
 		}
 	}
 	return nil

--- a/adapters/dalgo2memory/snapshot_test.go
+++ b/adapters/dalgo2memory/snapshot_test.go
@@ -1,0 +1,228 @@
+package dalgo2memory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/record"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the snapshot-read semantics of optimistic mode: every value
+// a transaction observes belongs to the single committed state that existed
+// at its first observation. They are the regression suite for a measured
+// fidelity bug: before this mechanism, optimistic mode was read-committed —
+// a transaction could observe A from one committed state and B from a later
+// one, a combination that never existed and that real Firestore never shows.
+//
+// External commits are simulated with top-level (non-transactional) writes on
+// the same database: on an optimistic database each one is its own single-key
+// commit (see bumpConflictVersion), and being top-level it cannot deadlock
+// against the transaction under test.
+
+// readThingN reads "things/<id>" inside the transaction and returns its "n".
+func readThingN(ctx context.Context, tx dal.ReadTransaction, id string) (float64, error) {
+	var data map[string]any
+	rec := record.NewRecordWithData(thingKey(id), &data)
+	if err := tx.Get(ctx, rec); err != nil {
+		return 0, err
+	}
+	n, _ := data["n"].(float64)
+	return n, nil
+}
+
+// TestSnapshotReads_FracturedViewAbortsAtRead is the core regression: after
+// the transaction has observed key A, an external commit rewrites A and B;
+// reading B must fail with ErrTransactionConflict AT THE READ — never return
+// B's new value, which would fracture the view (A=1 and B=2 never coexisted).
+// A read of an UNCHANGED key between the two stays fine: the live store is
+// still the snapshot for everything the external commit did not touch.
+func TestSnapshotReads_FracturedViewAbortsAtRead(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+	require.NoError(t, db.Set(ctx, thingRecord("B", 1)))
+	require.NoError(t, db.Set(ctx, thingRecord("C", 1)))
+
+	var readErr error
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		a, err := readThingN(ctx, tx, "A") // pins the snapshot
+		require.NoError(t, err)
+		require.EqualValues(t, 1, a)
+
+		c, err := readThingN(ctx, tx, "C") // unchanged key: still consistent
+		require.NoError(t, err)
+		require.EqualValues(t, 1, c)
+
+		// External commit rewrites BOTH keys after the snapshot was pinned.
+		require.NoError(t, db.Set(ctx, thingRecord("A", 2)))
+		require.NoError(t, db.Set(ctx, thingRecord("B", 2)))
+
+		_, readErr = readThingN(ctx, tx, "B")
+		return readErr
+	})
+
+	require.Error(t, readErr, "reading B after A's snapshot was overwritten must fail at the read")
+	assert.True(t, IsTransactionConflict(readErr), "the read error must be retryable: %v", readErr)
+	assert.True(t, IsTransactionConflict(err))
+}
+
+// TestSnapshotReads_SwallowedConflictPoisonsCommit: a callback that swallows
+// the snapshot-conflict read error and returns nil must still fail to commit,
+// and none of its buffered writes may become visible — matching the real
+// Firestore client, which fails the commit of a transaction whose read came
+// back ABORTED regardless of what the callback returned. A later read in the
+// same transaction (of any key) also keeps failing: the transaction is dead.
+func TestSnapshotReads_SwallowedConflictPoisonsCommit(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+	require.NoError(t, db.Set(ctx, thingRecord("B", 1)))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		if _, err := readThingN(ctx, tx, "A"); err != nil { // pins the snapshot
+			return err
+		}
+		require.NoError(t, db.Set(ctx, thingRecord("B", 2)))
+
+		_, readErr := readThingN(ctx, tx, "B")
+		require.True(t, IsTransactionConflict(readErr))
+		// The poisoned transaction fails every subsequent observation too
+		// (this second read exercises touch's poisoned fast-path). It runs
+		// BEFORE the Set below: after a write, the default ordering rule
+		// would reject the read as read-after-write before the snapshot
+		// machinery is even consulted.
+		_, again := readThingN(ctx, tx, "B")
+		require.True(t, IsTransactionConflict(again))
+		// Swallow the conflicts and keep going, as buggy caller code might.
+		if err := tx.Set(ctx, thingRecord("C", 1)); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	require.Error(t, err, "a transaction that observed a snapshot conflict must not commit")
+	assert.True(t, IsTransactionConflict(err))
+	exists, existsErr := db.Exists(ctx, thingKey("C"))
+	require.NoError(t, existsErr)
+	assert.False(t, exists, "writes of a poisoned transaction must be discarded")
+}
+
+// TestSnapshotReads_UnrelatedNewerKeyAlsoAborts pins the read-time semantics
+// deliberately: the transaction observed A, an external commit then rewrote
+// only B, and the transaction's first read of B still aborts. Serving B's new
+// value would be provably safe here ONLY under a sliding revalidation scheme;
+// this implementation reads at a fixed sequence instead — the same shape as
+// Firestore's fixed read time — trading a spurious abort (absorbed by the
+// caller's retry) for an O(1) check and semantics that need one sentence to
+// state.
+func TestSnapshotReads_UnrelatedNewerKeyAlsoAborts(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+	require.NoError(t, db.Set(ctx, thingRecord("B", 1)))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		if _, err := readThingN(ctx, tx, "A"); err != nil { // pins the snapshot
+			return err
+		}
+		require.NoError(t, db.Set(ctx, thingRecord("B", 2)))
+		_, readErr := readThingN(ctx, tx, "B")
+		return readErr
+	})
+	assert.True(t, IsTransactionConflict(err))
+}
+
+// TestSnapshotReads_BlindWriteToNewerKeyCommits: blind writes observe nothing,
+// so writing a key that was committed after the snapshot neither aborts at
+// the write nor at commit — Firestore's blind writes likewise do not conflict
+// on the written key's prior state. The last writer simply wins.
+func TestSnapshotReads_BlindWriteToNewerKeyCommits(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+	require.NoError(t, db.Set(ctx, thingRecord("B", 1)))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		if _, err := readThingN(ctx, tx, "A"); err != nil { // pins the snapshot
+			return err
+		}
+		require.NoError(t, db.Set(ctx, thingRecord("B", 2)))
+		return tx.Set(ctx, thingRecord("B", 3)) // blind write to the newer key
+	})
+	require.NoError(t, err, "a blind write to a key committed after the snapshot must not conflict")
+
+	var got map[string]any
+	rec := record.NewRecordWithData(thingKey("B"), &got)
+	require.NoError(t, db.Get(ctx, rec))
+	assert.EqualValues(t, 3, got["n"])
+}
+
+// TestSnapshotReads_WriteWriteRaceStillConflicts: the blind-write exemption
+// above must not weaken write-write conflict detection. A key this
+// transaction blind-wrote and another transaction then committed over is
+// still caught at commit by the baseline validation.
+func TestSnapshotReads_WriteWriteRaceStillConflicts(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		if err := tx.Set(ctx, thingRecord("A", 10)); err != nil { // blind: baseline taken here
+			return err
+		}
+		require.NoError(t, db.Set(ctx, thingRecord("A", 2))) // external commit wins the race
+		return nil
+	})
+	assert.True(t, IsTransactionConflict(err),
+		"an external commit between a blind write and its commit must still conflict")
+}
+
+// TestSnapshotReads_PinsAtFirstReadNotAtStart: the snapshot is pinned at the
+// first observation, not when the transaction begins — a commit that lands
+// between the two is simply part of the state the transaction reads, exactly
+// as Firestore's effective read time is its first read's.
+func TestSnapshotReads_PinsAtFirstReadNotAtStart(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		// The transaction exists but has observed nothing yet.
+		require.NoError(t, db.Set(ctx, thingRecord("A", 2)))
+		a, err := readThingN(ctx, tx, "A")
+		if err != nil {
+			return err
+		}
+		assert.EqualValues(t, 2, a, "the first read pins the snapshot, so it sees the latest commit")
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// TestSnapshotReads_RereadStaysOnSnapshot: once a key is observed, re-reading
+// it after an external commit returns the SNAPSHOT value (the cached entry),
+// never the newer one — and the transaction then fails at commit via baseline
+// validation rather than ever showing the torn value.
+func TestSnapshotReads_RereadStaysOnSnapshot(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		if _, err := readThingN(ctx, tx, "A"); err != nil {
+			return err
+		}
+		require.NoError(t, db.Set(ctx, thingRecord("A", 2)))
+		a, err := readThingN(ctx, tx, "A") // re-read: served from the snapshot
+		if err != nil {
+			return err
+		}
+		assert.EqualValues(t, 1, a, "a re-read must stay on the transaction's snapshot")
+		return nil
+	})
+	assert.True(t, IsTransactionConflict(err),
+		"the transaction read a key another commit overwrote, so its commit must conflict")
+}


### PR DESCRIPTION
PR 2 of the 6-PR plan making `dalgo2memory` Firestore-faithful by default (follows #121, #122).

## The measured bug

Optimistic mode was **read-committed**: first touch of a key loaded the live committed value. Probed against published dalgo v0.68.0:

```
T1 read A = 1 (seeded 1)
T1 read B = 2   ← after a concurrent commit rewrote A and B
```

The callback observed `A=1, B=2` — a state that **never existed**. Commit conflicted afterwards, but only if the callback survived its fractured view; one that errored on the torn data surfaced a non-retryable error real Firestore never produces.

## Mechanism: snapshot-or-abort — no data is ever cloned

- `database.commitSeq`: a global commit sequence, advanced once per committed write batch. `db.versions` values change meaning from per-key counters to *"commitSeq when this key was last committed"* (no test asserted raw values; every baseline-equality comparison is unaffected).
- A transaction pins `startSeq` **lazily at its first observing touch** (Get/Exists/Insert's duplicate check/Update's merge — never a blind Set/Delete), matching Firestore's effective read time being its first read's.
- Touching a new key whose last-commit seq exceeds `startSeq` returns `ErrTransactionConflict` **from the read** and poisons the transaction: commit refuses even if the callback swallows the error — mirroring the real Firestore client, which fails the commit of a transaction whose read came back ABORTED (verified in `cloud.google.com/go/firestore@v1.25.0` source).
- As long as nothing observed has been overwritten, **the live store *is* the snapshot** — which is why no cloning is needed. (Cloning was also shown infeasible: the columnar engine's exported `ColumnStrategy` supports out-of-core implementations that cannot be deep-copied.)
- **Blind writes stay exempt**, as Firestore's are; their write-write races are still caught by the existing baseline validation at commit.

This deliberately reads at a **fixed** sequence rather than sliding the snapshot forward when revalidation could prove it safe: one O(1) comparison, semantics that need one sentence. The spurious aborts this admits will be absorbed by bounded auto-retry of conflicts (PR 4, matching the Firestore SDK's 5 attempts).

## Tests

Seven new regression tests in `snapshot_test.go`: fracture aborts at the read; swallowed conflict poisons the commit and discards writes (also exercises the poisoned fast-path); unrelated-newer-key abort (pins the fixed-read-time choice explicitly); blind write to a newer key commits; write-write race still conflicts; snapshot pins at first read, not transaction start; re-reads stay on the snapshot.

Full suite green under `-race` including every pre-existing choreographed concurrency test, `go vet` clean, `dalgo2memory` at **100.0%** statement coverage. Composes cleanly with #122's ordering-poisoning (merged in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jHJHbnHddXPJe72gzyhsx