### PR TITLE
feat(dalgo2memory): transactional queries in optimistic mode

### DIFF
--- a/adapters/dalgo2memory/database.go
+++ b/adapters/dalgo2memory/database.go
@@ -37,6 +37,7 @@ func newDatabase(options ...Option) *database {
 		noReadsAfterWritesInTransaction: true,
 		schemaRefBreaking:               true,
 		versions:                        make(map[string]uint64),
+		collectionSeq:                   make(map[string]uint64),
 	}
 	for _, option := range options {
 		if option != nil {
@@ -97,6 +98,20 @@ type database struct {
 	// Guarded by mu; only meaningful when optimisticConcurrency is set, since
 	// the default whole-database-lock mode leaves versions empty.
 	commitSeq uint64
+	// collectionSeq maps a leaf collection name to the value commitSeq held
+	// when ANY record in that collection was last touched by a committed
+	// write. It is versions' coarse, collection-grained sibling, and exists
+	// for queries: a query's result depends on every record in the collection
+	// — including ones that do not exist yet, which per-key versions cannot
+	// name — so a transaction that queried a collection registers this value
+	// instead (see optimisticState.observeCollectionAtSnapshot). Any later
+	// committed write to the collection then conflicts the querying
+	// transaction. That is deliberately coarser than Firestore's own
+	// index-range locking (an unrelated write to the same collection
+	// conflicts too), but it can only err toward a spurious, retryable abort
+	// — never toward silently missing a phantom insert. Guarded by mu;
+	// populated only when optimisticConcurrency is set, like versions.
+	collectionSeq map[string]uint64
 }
 
 func (db *database) ID() string {
@@ -497,18 +512,34 @@ func (s session) ExecuteQueryToRecordsReader(_ context.Context, query dal.Query)
 		if opt.hasBufferedWrites() {
 			return nil, fmt.Errorf("%w: a query inside a read-write transaction cannot see that transaction's own uncommitted writes; issue the query before the first write, or read by key", dal.ErrNotSupported)
 		}
-		// In optimistic mode a query additionally takes no part in conflict
-		// detection: the rows it scans never enter the read set, so a
-		// concurrent commit that changes them will not be caught. Point
-		// reads/writes by key are fully supported — see
-		// WithOptimisticConcurrency's doc comment.
-		if s.db.optimisticConcurrency {
-			return nil, fmt.Errorf("%w: queries are not supported inside a WithOptimisticConcurrency read-write transaction; read by key, or run the query outside the transaction", dal.ErrNotSupported)
-		}
 	}
 	q, ok := query.(dal.StructuredQuery)
 	if !ok {
 		return nil, dal.ErrNotSupported
+	}
+	if opt := s.optimistic(); opt != nil && s.db.optimisticConcurrency {
+		// A query inside an optimistic-mode transaction participates in the
+		// transaction's snapshot and conflict detection at COLLECTION
+		// granularity: its result depends on every record in the collection,
+		// including ones that do not exist yet, which the per-key read set
+		// cannot name — so registering the collection is what makes phantom
+		// inserts conflict instead of slipping past commit validation. The
+		// registration (and the abort when the collection was already written
+		// after this transaction's snapshot) happens in
+		// observeCollectionAtSnapshot; db.mu is then held for the remainder of
+		// this call so the scan below reads exactly the registered state.
+		if len(q.From().Joins()) > 0 {
+			// Firestore — the backend a transactional query must stay
+			// faithful to — has no joins at all, and a join here would scan
+			// several collections in one result. Refuse rather than invent
+			// multi-collection transactional semantics no real backend has.
+			return nil, fmt.Errorf("%w: joins are not supported inside a read-write transaction; run the join outside the transaction", dal.ErrNotSupported)
+		}
+		opt.lock()
+		defer opt.unlock()
+		if err := opt.observeCollectionAtSnapshot(q.From().Base().Name()); err != nil {
+			return nil, err
+		}
 	}
 	if len(q.From().Joins()) > 0 {
 		return s.executeJoinQuery(q)

--- a/adapters/dalgo2memory/optimistic.go
+++ b/adapters/dalgo2memory/optimistic.go
@@ -130,6 +130,52 @@ type optimisticState struct {
 	// fractured view. The real Firestore client gives the same protection by
 	// failing the commit of a transaction whose read came back ABORTED.
 	conflict error
+
+	// collectionReads is the query-side sibling of reads: the collections
+	// this transaction has queried, each with the db.collectionSeq value
+	// observed at query time. commit fails the transaction if any of them has
+	// advanced — which is what catches PHANTOMS: an insert into a queried
+	// collection changes the query's result without touching any key the
+	// per-key read set could have named. Registered lazily by
+	// observeCollectionAtSnapshot; nil until the first transactional query.
+	collectionReads map[string]uint64
+}
+
+// observeCollectionAtSnapshot is observeAtSnapshot's collection-grained
+// counterpart, called once per transactional query (see
+// session.ExecuteQueryToRecordsReader). It pins the snapshot if this query is
+// the transaction's first observation; aborts — poisoning the transaction,
+// exactly like a point read — if the collection was committed to after the
+// snapshot was pinned, since the scan could then return rows from a state
+// newer than everything else this transaction has seen; and otherwise
+// registers the collection's current sequence in collectionReads for commit
+// to revalidate. Registering at collection granularity is deliberately
+// coarser than Firestore's index-range locking: an unrelated write to the
+// same collection conflicts too, but the error is a spurious retryable abort,
+// never a silently missed phantom — see database.collectionSeq's doc comment.
+//
+// The caller must already hold db.mu.
+func (tx *optimisticState) observeCollectionAtSnapshot(collection string) error {
+	if tx.conflict != nil {
+		// Poisoned by an earlier snapshot violation; see touch.
+		return tx.conflict
+	}
+	if !tx.startSeqPinned {
+		tx.startSeqPinned = true
+		tx.startSeq = tx.db.commitSeq
+	} else if seq := tx.db.collectionSeq[collection]; seq > tx.startSeq {
+		tx.conflict = fmt.Errorf(
+			"%w: collection %q was written at sequence %d, after this transaction's read snapshot (sequence %d)",
+			ErrTransactionConflict, collection, seq, tx.startSeq)
+		return tx.conflict
+	}
+	if tx.collectionReads == nil {
+		tx.collectionReads = make(map[string]uint64)
+	}
+	if _, ok := tx.collectionReads[collection]; !ok {
+		tx.collectionReads[collection] = tx.db.collectionSeq[collection]
+	}
+	return nil
 }
 
 // observeAtSnapshot enforces this transaction's read snapshot for one key
@@ -366,6 +412,10 @@ func (db *database) bumpConflictVersion(collection, id string) {
 	}
 	db.commitSeq++
 	db.versions[conflictKey(collection, id)] = db.commitSeq
+	// The collection-grained table advances in lockstep so a transaction that
+	// QUERIED this collection conflicts too — a top-level write can be the
+	// phantom insert its query would have missed. See database.collectionSeq.
+	db.collectionSeq[collection] = db.commitSeq
 }
 
 // firstTouchEntry returns key's pendingEntry, creating it — and recording its
@@ -676,6 +726,15 @@ func (tx *optimisticState) commit() error {
 				return fmt.Errorf("%w: key %q changed after this transaction observed it", ErrTransactionConflict, ck)
 			}
 		}
+		// The collection-grained read set is validated the same way: a queried
+		// collection whose sequence advanced means a commit — possibly a
+		// phantom insert the query could not have named as a key — changed
+		// what this transaction's query would return. See collectionReads.
+		for collection, baseline := range tx.collectionReads {
+			if tx.db.collectionSeq[collection] != baseline {
+				return fmt.Errorf("%w: collection %q was written after this transaction queried it", ErrTransactionConflict, collection)
+			}
+		}
 	}
 
 	// appliedSeq is this commit's entry in the global commit sequence,
@@ -707,6 +766,10 @@ func (tx *optimisticState) commit() error {
 				appliedSeq = tx.db.commitSeq
 			}
 			tx.db.versions[ck] = appliedSeq
+			// Keep the collection-grained table in lockstep, so transactions
+			// that QUERIED this collection conflict on this commit too — this
+			// write may be the phantom their query could not have named.
+			tx.db.collectionSeq[collection] = appliedSeq
 		}
 	}
 	return nil

--- a/adapters/dalgo2memory/optimistic_test.go
+++ b/adapters/dalgo2memory/optimistic_test.go
@@ -384,21 +384,27 @@ func TestOptimisticConcurrencyUpdateCompoundsAndCommits(t *testing.T) {
 	require.Equal(t, thing{Name: "updated", Count: 2}, got)
 }
 
-// TestOptimisticConcurrencyQueryUnsupported documents and locks in the one
-// deliberate gap in this mode: a query inside an optimistic transaction reads
-// committed storage directly, so it would see neither the transaction's own
-// buffered writes nor participate in its conflict detection. Rather than
-// silently returning a semantically inconsistent result, it fails clearly.
-func TestOptimisticConcurrencyQueryUnsupported(t *testing.T) {
+// TestOptimisticConcurrencyJoinQueryUnsupported locks in the one query shape
+// still refused inside an optimistic transaction: joins. Plain queries are
+// now supported with collection-grained snapshot/conflict participation (see
+// txquery_test.go); a join would scan several collections in one result, and
+// Firestore — the backend a transactional query must stay faithful to — has
+// no joins at all. This test previously asserted that ALL queries were
+// refused; that refusal was the gap blocking optimistic mode from ever
+// becoming the default, and removing it is the point of the transactional
+// query support.
+func TestOptimisticConcurrencyJoinQueryUnsupported(t *testing.T) {
 	ctx := context.Background()
 	db := newDatabase(WithOptimisticConcurrency())
 
 	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
-		q := dal.From(dal.NewRootCollectionRef("Things", "")).NewQuery().SelectKeysOnly(reflect.String)
+		join := dal.NewJoinedSource(ordersAlias(), dal.JoinInner, onUserEqOrder())
+		q := dal.From(usersAlias()).Join(join).NewQuery().SelectIntoRecord(intoMapRecord())
 		_, err := tx.ExecuteQueryToRecordsReader(ctx, q)
 		return err
 	})
 	require.ErrorIs(t, err, dal.ErrNotSupported)
+	require.Contains(t, err.Error(), "joins")
 }
 
 // TestOptimisticConcurrencyInsertWithGenerator checks that Insert's

--- a/adapters/dalgo2memory/schema.go
+++ b/adapters/dalgo2memory/schema.go
@@ -81,11 +81,16 @@ func WithInterleavedReadsAndWritesInTransaction() Option {
 // optimisticState's doc comment in optimistic.go for the full reasoning.
 //
 // A query (ExecuteQueryToRecordsReader / ExecuteQueryToRecordsetReader)
-// inside such a transaction returns dal.ErrNotSupported: a scan reads
-// committed storage directly, so it would see neither this transaction's own
-// buffered writes nor participate in its conflict detection. Point reads and
-// writes by key (Get, Exists, Set, Insert, Update, Delete and their -Multi
-// forms) are fully supported.
+// inside such a transaction is supported and participates in the
+// transaction's snapshot and conflict detection at COLLECTION granularity:
+// the query registers its collection, aborts with ErrTransactionConflict if
+// the collection was committed to after this transaction's snapshot, and the
+// commit revalidates it — which is what makes phantom inserts conflict
+// instead of slipping past the per-key read set (see
+// optimisticState.observeCollectionAtSnapshot). Joins are the one refused
+// shape (Firestore has none to stay faithful to). Point reads and writes by
+// key (Get, Exists, Set, Insert, Update, Delete and their -Multi forms) are
+// fully supported.
 //
 // This is deliberately adapter-local rather than part of dalgotest's shared
 // conformance suite: the suite proves record-validation invariants every

--- a/adapters/dalgo2memory/txquery_test.go
+++ b/adapters/dalgo2memory/txquery_test.go
@@ -1,0 +1,195 @@
+package dalgo2memory
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/record"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin transactional query support in optimistic mode: a query
+// inside a read-write transaction participates in the transaction's snapshot
+// and conflict detection at COLLECTION granularity (see
+// optimisticState.observeCollectionAtSnapshot). Before this, every query in
+// an optimistic transaction was refused outright with ErrNotSupported — the
+// gap that blocked optimistic mode from ever becoming the default, since the
+// default locked mode does support queries.
+//
+// As in snapshot_test.go, external commits are simulated with top-level
+// writes on the same database: each is its own single-key commit and cannot
+// deadlock against the transaction under test.
+
+// queryThingIDs runs a keys-only query over "things" inside the transaction
+// and returns how many records it saw.
+func queryThingIDs(ctx context.Context, tx dal.ReadTransaction) (int, error) {
+	q := dal.From(dal.NewRootCollectionRef("things", "")).NewQuery().SelectKeysOnly(reflect.String)
+	reader, err := tx.ExecuteQueryToRecordsReader(ctx, q)
+	if err != nil {
+		return 0, err
+	}
+	records, err := dal.ReadAllToRecords(ctx, reader)
+	if err != nil {
+		return 0, err
+	}
+	return len(records), nil
+}
+
+// TestTxQuery_WorksAndCommits: the basic capability — a query inside an
+// optimistic read-write transaction returns the committed rows, and the
+// transaction commits when nothing conflicted.
+func TestTxQuery_WorksAndCommits(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+	require.NoError(t, db.Set(ctx, thingRecord("B", 1)))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		n, err := queryThingIDs(ctx, tx)
+		if err != nil {
+			return err
+		}
+		assert.Equal(t, 2, n, "the query must see both committed records")
+		return tx.Set(ctx, thingRecord("C", 1))
+	})
+	require.NoError(t, err)
+}
+
+// TestTxQuery_PhantomInsertConflictsAtCommit is the reason collection-grained
+// registration exists: after this transaction queried "things", an external
+// commit INSERTS a new record there. No key in the per-key read set names the
+// new record — it did not exist — yet the query's result is now stale, so the
+// commit must conflict.
+func TestTxQuery_PhantomInsertConflictsAtCommit(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		if _, err := queryThingIDs(ctx, tx); err != nil {
+			return err
+		}
+		// The phantom: a record the query could not have named as a key.
+		require.NoError(t, db.Set(ctx, thingRecord("B", 1)))
+		return nil
+	})
+	assert.True(t, IsTransactionConflict(err),
+		"an insert into a queried collection must conflict the querying transaction: %v", err)
+}
+
+// TestTxQuery_UnrelatedCollectionWriteDoesNotConflict documents the
+// granularity: only writes to the QUERIED collection conflict. A commit to a
+// different collection leaves the querying transaction untouched.
+func TestTxQuery_UnrelatedCollectionWriteDoesNotConflict(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		if _, err := queryThingIDs(ctx, tx); err != nil {
+			return err
+		}
+		other := record.NewRecordWithData(record.NewKeyWithID("others", "x"), map[string]any{"n": 1})
+		require.NoError(t, db.Set(ctx, other))
+		return nil
+	})
+	require.NoError(t, err, "a write to an unrelated collection must not conflict a query on things")
+}
+
+// TestTxQuery_QueryAfterSnapshotFractureAborts: the transaction pinned its
+// snapshot with a point read; an external commit then wrote into "things";
+// querying "things" now cannot return rows consistent with what the
+// transaction already observed, so the query itself aborts — and a second
+// query attempt hits the poisoned fast-path, and the swallowed conflict still
+// refuses the commit.
+func TestTxQuery_QueryAfterSnapshotFractureAborts(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+	other := record.NewRecordWithData(record.NewKeyWithID("others", "x"), map[string]any{"n": 1})
+	require.NoError(t, db.Set(ctx, other))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		// Pin the snapshot with a point read of an unrelated collection.
+		var got map[string]any
+		rec := record.NewRecordWithData(record.NewKeyWithID("others", "x"), &got)
+		if err := tx.Get(ctx, rec); err != nil {
+			return err
+		}
+		require.NoError(t, db.Set(ctx, thingRecord("B", 2)))
+
+		_, qErr := queryThingIDs(ctx, tx)
+		require.True(t, IsTransactionConflict(qErr),
+			"querying a collection written after the snapshot must abort at the query: %v", qErr)
+		_, again := queryThingIDs(ctx, tx)
+		require.True(t, IsTransactionConflict(again), "the poisoned transaction fails every later query too")
+		return nil // swallow, as buggy caller code might
+	})
+	assert.True(t, IsTransactionConflict(err), "the swallowed query conflict must still refuse the commit")
+}
+
+// TestTxQuery_QueryPinsSnapshot: a query can be the transaction's FIRST
+// observation, pinning the snapshot exactly as a point read would — proven by
+// the point read AFTER a later external commit aborting.
+func TestTxQuery_QueryPinsSnapshot(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		if _, err := queryThingIDs(ctx, tx); err != nil { // first observation: pins
+			return err
+		}
+		require.NoError(t, db.Set(ctx, thingRecord("A", 2)))
+		var got map[string]any
+		rec := record.NewRecordWithData(thingKey("A"), &got)
+		readErr := tx.Get(ctx, rec)
+		require.True(t, IsTransactionConflict(readErr),
+			"a point read of a key committed after the query's snapshot must abort: %v", readErr)
+		return readErr
+	})
+	assert.True(t, IsTransactionConflict(err))
+}
+
+// TestTxQuery_SameCollectionQueriedTwice: repeat queries of one collection in
+// one transaction register a single baseline and both succeed while nothing
+// external has committed to it.
+func TestTxQuery_SameCollectionQueriedTwice(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		for i := 0; i < 2; i++ {
+			n, err := queryThingIDs(ctx, tx)
+			if err != nil {
+				return err
+			}
+			assert.Equal(t, 1, n)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// TestTxQuery_RecordsetReaderInsideTransaction: the recordset form delegates
+// to the records form, so it inherits the same snapshot participation.
+func TestTxQuery_RecordsetReaderInsideTransaction(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		q := dal.From(dal.NewRootCollectionRef("things", "")).NewQuery().SelectKeysOnly(reflect.String)
+		reader, err := tx.ExecuteQueryToRecordsetReader(ctx, q)
+		if err != nil {
+			return err
+		}
+		require.NotNil(t, reader)
+		return nil
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
PR 3 of the 6-PR plan making `dalgo2memory` Firestore-faithful by default (follows #121, #122, #123).

Queries inside an optimistic read-write transaction were refused with `ErrNotSupported` while the default locked mode supports them — the one capability gap blocking the eventual contention-default flip.

## Design

**Collection-grained snapshot participation.** `database.collectionSeq` is `versions`' coarse sibling — the `commitSeq` when *any* record of a collection was last committed to, stamped in lockstep by optimistic commits and top-level writes. A transactional query:

1. pins the snapshot if it's the transaction's first observation (a query can open a transaction's read time, same as a point read);
2. aborts — poisoning the transaction, exactly like a point read — if the collection was committed to after the snapshot;
3. otherwise registers the collection's sequence, which commit revalidates.

**Why collection-grained: phantoms.** An insert into a queried collection changes the query's result without touching any key the per-key read set could have named. Registering the collection catches it. This is deliberately coarser than Firestore's index-range locking — an unrelated write to the same collection conflicts too — but it errs only toward a spurious *retryable* abort, never toward silently missing a phantom. (Per-row registration alone was rejected during design review: with columnar index short-circuits, rows an index skips are never scanned, so an update that makes a non-matching row match would be invisible.) Bounded auto-retry (PR 4) absorbs the spurious aborts, matching how production code never sees the Firestore SDK's internal retries.

`db.mu` is held from registration through the scan, so the query reads exactly the registered state. Joins stay refused inside transactions — Firestore has no joins to stay faithful to. The recordset reader delegates and inherits everything.

## Tests

Seven new tests in `txquery_test.go` (basic query+commit; phantom insert conflicts at commit; unrelated-collection write does not; query aborts on fractured snapshot incl. poisoned fast-path and refused commit; query pins the snapshot; repeat queries; recordset form). `TestOptimisticConcurrencyQueryUnsupported` — which locked in the old blanket refusal — is repurposed to lock in only the join refusal, with the history documented in its comment.

Full suite green under `-race`, `go vet` clean, **100.0%** statement coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jHJHbnHddXPJe72gzyhsx