### PR TITLE
feat(dalgo2memory): forbid nested read-write transactions, matching Firestore

### DIFF
--- a/adapters/dalgo2memory/database.go
+++ b/adapters/dalgo2memory/database.go
@@ -111,13 +111,91 @@ func (db *database) Schema() dal.Schema {
 	return nil
 }
 
+// transactionInProgressKey is the context key dalgo2memory stamps onto the
+// context it hands a transaction callback, so a nested attempt to start
+// another transaction from inside that callback can be detected. It is an
+// unexported struct type used only as a context key (never as a value), the
+// same idiom the real Firestore Go client uses for the identical purpose (see
+// ErrNestedTransaction's doc comment) — and, like that key, it has no
+// exported accessor: RunReadonlyTransaction and RunReadwriteTransaction below
+// are the only places that set or check it.
+type transactionInProgressKey struct{}
+
+// ErrNestedTransaction is returned by RunReadonlyTransaction and
+// RunReadwriteTransaction when either is called with a context that is
+// already running inside another transaction's callback, in any combination
+// of read-only and read-write.
+//
+// This is Firestore parity, not an invented restriction. The real client
+// (cloud.google.com/go/firestore, transaction.go) keeps one
+// transactionInProgressKey and one RunTransaction method underneath both
+// Client.RunTransaction (read-write) and the ReadOnly() option (read-only):
+//
+//	if ctx.Value(transactionInProgressKey{}) != nil {
+//		return errNestedTransaction
+//	}
+//
+// That check runs before RunTransaction even looks at whether either side is
+// read-only, so all four nestings — read-write-in-read-write,
+// read-only-in-read-write, read-write-in-read-only, read-only-in-read-only —
+// are rejected identically. dalgo2memory mirrors that scope exactly, rather
+// than only guarding the read-write-in-read-write case, so code that runs
+// against this adapter cannot rely on a nesting shape that would fail against
+// real Firestore.
+//
+// Independently of parity, dalgo2memory has its own reason to refuse
+// read-write-in-read-write specifically: the default whole-database-lock
+// RunReadwriteTransaction (runLockedReadwriteTransaction) holds db.mu for its
+// callback's entire duration, so a nested RunReadwriteTransaction call would
+// deadlock trying to re-acquire it (sync.RWMutex is not reentrant). The
+// opt-in WithOptimisticConcurrency path (runOptimisticReadwriteTransaction)
+// holds no such lock, so the same nested call would instead silently succeed
+// as an independent, concurrently-committing transaction — legalizing
+// exactly the pattern real Firestore rejects outright. This guard closes
+// both wrong outcomes — a hang and a silent behavior change — before either
+// can happen, for every mode combination.
+//
+// A rejected nested attempt does not poison the outer transaction: this
+// error is returned directly by the nested RunReadonlyTransaction /
+// RunReadwriteTransaction call, before any transaction state for the nested
+// attempt is created, exactly like errNestedTransaction is returned by the
+// real client's RunTransaction with no effect on the outer *Transaction's
+// fields. A callback that treats the error as fatal and returns it aborts
+// the outer transaction (its writes are discarded, same as any other
+// callback error); a callback that swallows it and returns nil lets the
+// outer transaction commit its own work normally.
+//
+// To intentionally start a genuinely independent transaction from inside a
+// callback — rather than nesting one inside it — begin it with
+// dal.GetNonTransactionalContext(ctx) in place of ctx: dal core's sanctioned
+// escape for exactly this. It works here because it returns a context from
+// before dalgo2memory (or whatever wraps it) ever set this key, so the guard
+// sees no marker. It is only available when something upstream wrapped the
+// context with dal.NewContextWithTransaction before handing it to this
+// backend (e.g. an access.NewDB-style decorator) — dalgo2memory itself
+// performs no such wrapping, so with nothing upstream doing it,
+// GetNonTransactionalContext has nothing to return. Note that the escape
+// only sidesteps THIS guard: started against the default whole-database-lock
+// mode while the outer callback's db.mu is still held, an "independent"
+// transaction on the same *database still deadlocks on that pre-existing,
+// unrelated lock — the escape is only deadlock-free run against a
+// WithOptimisticConcurrency database, or once the outer transaction has
+// returned.
+var ErrNestedTransaction = errors.New("dalgo2memory: nested transactions are not supported: Firestore rejects a transaction started inside another transaction's callback")
+
 func (db *database) RunReadonlyTransaction(ctx context.Context, f dal.ROTxWorker, _ ...dal.TransactionOption) error {
+	if ctx.Value(transactionInProgressKey{}) != nil {
+		return ErrNestedTransaction
+	}
 	db.mu.RLock()
 	defer db.mu.RUnlock()
-	return f(ctx, session{db: db})
+	return f(context.WithValue(ctx, transactionInProgressKey{}, true), session{db: db})
 }
 
 func (db *database) RunReadwriteTransaction(ctx context.Context, f dal.RWTxWorker, _ ...dal.TransactionOption) error {
+	if ctx.Value(transactionInProgressKey{}) != nil {
+		return ErrNestedTransaction
+	}
 	if db.optimisticConcurrency {
 		return db.runOptimisticReadwriteTransaction(ctx, f)
 	}

--- a/adapters/dalgo2memory/nested_transaction_test.go
+++ b/adapters/dalgo2memory/nested_transaction_test.go
@@ -1,0 +1,249 @@
+package dalgo2memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/stretchr/testify/require"
+)
+
+// bothTransactionModes is the two RunReadwriteTransaction implementations
+// this package ships: the default whole-database-lock mode and the opt-in
+// WithOptimisticConcurrency mode. Firestore parity — and, independently, the
+// two different wrong behaviors each mode has today (deadlock vs. silent
+// success, see ErrNestedTransaction's doc comment) — must hold for both.
+var bothTransactionModes = []struct {
+	name string
+	opts []Option
+}{
+	{"default locked mode", nil},
+	{"WithOptimisticConcurrency", []Option{WithOptimisticConcurrency()}},
+}
+
+// runWithTimeout runs f in a goroutine and fails the test if it has not
+// returned within the deadline. Every nested-transaction test in this file
+// uses it instead of calling the outer RunReadwriteTransaction directly,
+// because the whole point of ErrNestedTransaction is to replace a deadlock
+// (see TestDefaultTransactionsRemainSerialized for how real the default
+// mode's whole-database lock is) with a prompt error — a test that merely
+// calls the outer transaction synchronously would hang forever, not fail,
+// if that guard ever regressed.
+func runWithTimeout(t *testing.T, f func() error) error {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- f() }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(2 * time.Second):
+		t.Fatal("transaction did not return: a nested transaction call likely deadlocked")
+		return nil // unreachable: t.Fatal stops this goroutine
+	}
+}
+
+// TestNestedReadwriteTransaction_Rejected is PR 5's headline case: a
+// RunReadwriteTransaction call made from inside another RunReadwriteTransaction
+// callback must fail with ErrNestedTransaction, in both transaction modes, and
+// must do so promptly rather than deadlocking. Before this guard, the default
+// locked mode deadlocked here (nested call blocks forever re-acquiring db.mu)
+// and the optimistic mode let the nested call run to completion as an
+// independent transaction — see ErrNestedTransaction's doc comment.
+func TestNestedReadwriteTransaction_Rejected(t *testing.T) {
+	for _, mode := range bothTransactionModes {
+		t.Run(mode.name, func(t *testing.T) {
+			ctx := context.Background()
+			db := newDatabase(mode.opts...)
+			nestedRan := false
+
+			err := runWithTimeout(t, func() error {
+				return db.RunReadwriteTransaction(ctx, func(ctx context.Context, _ dal.ReadwriteTransaction) error {
+					return db.RunReadwriteTransaction(ctx, func(context.Context, dal.ReadwriteTransaction) error {
+						nestedRan = true
+						return nil
+					})
+				})
+			})
+
+			require.ErrorIs(t, err, ErrNestedTransaction)
+			require.False(t, nestedRan, "the nested callback must never run: the guard rejects before entering it")
+		})
+	}
+}
+
+// TestNestedReadonlyInReadwriteTransaction_Rejected is the ro-in-rw case the
+// PR brief asked to resolve by checking the real Firestore client: Firestore's
+// Client.RunTransaction stamps and checks the same transactionInProgressKey
+// for BOTH RunReadwriteTransaction and RunReadonlyTransaction (ReadOnly() is
+// just an option on the same RunTransaction call), and the check runs before
+// either side's read-only flag is even inspected — so a read-only transaction
+// started inside a running read-write transaction is rejected exactly like a
+// read-write one would be. dalgo2memory mirrors that: RunReadonlyTransaction
+// checks the same marker RunReadwriteTransaction sets.
+func TestNestedReadonlyInReadwriteTransaction_Rejected(t *testing.T) {
+	for _, mode := range bothTransactionModes {
+		t.Run(mode.name, func(t *testing.T) {
+			ctx := context.Background()
+			db := newDatabase(mode.opts...)
+			nestedRan := false
+
+			err := runWithTimeout(t, func() error {
+				return db.RunReadwriteTransaction(ctx, func(ctx context.Context, _ dal.ReadwriteTransaction) error {
+					return db.RunReadonlyTransaction(ctx, func(context.Context, dal.ReadTransaction) error {
+						nestedRan = true
+						return nil
+					})
+				})
+			})
+
+			require.ErrorIs(t, err, ErrNestedTransaction)
+			require.False(t, nestedRan)
+		})
+	}
+}
+
+// TestNestedTransactionInReadonlyTransaction_Rejected completes the symmetry:
+// a read-only OUTER transaction also guards against a nested transaction of
+// either kind, matching the fact that Firestore's transactionInProgressKey
+// check does not care whether the OUTER transaction was read-only either.
+func TestNestedTransactionInReadonlyTransaction_Rejected(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase()
+
+	t.Run("read-write nested in read-only", func(t *testing.T) {
+		nestedRan := false
+		err := runWithTimeout(t, func() error {
+			return db.RunReadonlyTransaction(ctx, func(ctx context.Context, _ dal.ReadTransaction) error {
+				return db.RunReadwriteTransaction(ctx, func(context.Context, dal.ReadwriteTransaction) error {
+					nestedRan = true
+					return nil
+				})
+			})
+		})
+		require.ErrorIs(t, err, ErrNestedTransaction)
+		require.False(t, nestedRan)
+	})
+
+	t.Run("read-only nested in read-only", func(t *testing.T) {
+		nestedRan := false
+		err := runWithTimeout(t, func() error {
+			return db.RunReadonlyTransaction(ctx, func(ctx context.Context, _ dal.ReadTransaction) error {
+				return db.RunReadonlyTransaction(ctx, func(context.Context, dal.ReadTransaction) error {
+					nestedRan = true
+					return nil
+				})
+			})
+		})
+		require.ErrorIs(t, err, ErrNestedTransaction)
+		require.False(t, nestedRan)
+	})
+}
+
+// TestNestedReadwriteTransaction_OuterTreatsAsFatal_DiscardsWrites covers the
+// brief's first outer-transaction-unaffected case: a callback that propagates
+// the nested-transaction error aborts the outer transaction exactly like any
+// other callback error, discarding its own writes.
+func TestNestedReadwriteTransaction_OuterTreatsAsFatal_DiscardsWrites(t *testing.T) {
+	for _, mode := range bothTransactionModes {
+		t.Run(mode.name, func(t *testing.T) {
+			ctx := context.Background()
+			db := newDatabase(mode.opts...)
+
+			err := runWithTimeout(t, func() error {
+				return db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+					if err := tx.Set(ctx, thingRecord("t1", 1)); err != nil {
+						return err
+					}
+					// Treat the nested attempt as fatal: propagate it.
+					return db.RunReadwriteTransaction(ctx, func(context.Context, dal.ReadwriteTransaction) error {
+						return nil
+					})
+				})
+			})
+
+			require.ErrorIs(t, err, ErrNestedTransaction)
+			exists, existsErr := db.Exists(ctx, thingKey("t1"))
+			require.NoError(t, existsErr)
+			require.False(t, exists, "outer transaction's write must be discarded when its callback treats the nested-transaction error as fatal")
+		})
+	}
+}
+
+// TestNestedReadwriteTransaction_OuterSwallows_StillCommits covers the
+// brief's second outer-transaction-unaffected case: this is NOT poisoning.
+// ErrNestedTransaction is returned directly by the nested call, before any
+// transaction state for that nested attempt is created — unlike
+// ErrReadAfterWriteInTransaction, nothing records the rejection on the outer
+// transaction's own state (compare transactionState.readAfterWriteRejected).
+// This matches the real Firestore client: errNestedTransaction is returned by
+// Client.RunTransaction itself, with no effect on the outer *Transaction's
+// fields, so a callback that ignores it and returns nil commits normally.
+func TestNestedReadwriteTransaction_OuterSwallows_StillCommits(t *testing.T) {
+	for _, mode := range bothTransactionModes {
+		t.Run(mode.name, func(t *testing.T) {
+			ctx := context.Background()
+			db := newDatabase(mode.opts...)
+
+			err := runWithTimeout(t, func() error {
+				return db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+					if err := tx.Set(ctx, thingRecord("t1", 1)); err != nil {
+						return err
+					}
+					nestedErr := db.RunReadwriteTransaction(ctx, func(context.Context, dal.ReadwriteTransaction) error {
+						return nil
+					})
+					if !errors.Is(nestedErr, ErrNestedTransaction) {
+						t.Fatalf("expected ErrNestedTransaction from the nested call, got %v", nestedErr)
+					}
+					// Swallow it and keep going: per the doc comment above, this must
+					// not poison the outer transaction's eventual commit.
+					return nil
+				})
+			})
+
+			require.NoError(t, err, "the outer transaction must still commit: a swallowed ErrNestedTransaction does not poison it")
+			exists, existsErr := db.Exists(ctx, thingKey("t1"))
+			require.NoError(t, existsErr)
+			require.True(t, exists, "outer transaction's own work must still commit when the callback swallows the nested-transaction error")
+		})
+	}
+}
+
+// TestReadwriteTransaction_GetNonTransactionalContextEscapesGuard covers the
+// sanctioned escape ErrNestedTransaction's doc comment describes:
+// dal.GetNonTransactionalContext(ctx) returns a context from before dalgo
+// wrapped it with the transaction, so starting a new transaction with that
+// context is not "nested" as far as this guard can see.
+//
+// This only demonstrates the guard, not a deadlock-free general escape: it
+// runs against a WithOptimisticConcurrency database, because the default
+// locked mode's runLockedReadwriteTransaction holds db.mu for the whole
+// outer callback regardless of what the inner call's ctx carries, so a
+// second RunReadwriteTransaction call on the same *database while the outer
+// one is still running would deadlock on that pre-existing, unrelated lock —
+// see the last paragraph of ErrNestedTransaction's doc comment.
+func TestReadwriteTransaction_GetNonTransactionalContextEscapesGuard(t *testing.T) {
+	db := newDatabase(WithOptimisticConcurrency())
+	// A caller (or an upstream decorator such as access.NewDB) wraps the
+	// context with dal.NewContextWithTransaction before handing it to this
+	// backend; the transaction value itself is irrelevant to this guard, only
+	// the context chain it establishes is, so nil is fine here (dal's own
+	// tests use the same nil transaction for this purpose).
+	ctx := dal.NewContextWithTransaction(context.Background(), nil)
+
+	independentRan := false
+	err := runWithTimeout(t, func() error {
+		return db.RunReadwriteTransaction(ctx, func(ctx context.Context, _ dal.ReadwriteTransaction) error {
+			independentCtx := dal.GetNonTransactionalContext(ctx)
+			return db.RunReadwriteTransaction(independentCtx, func(context.Context, dal.ReadwriteTransaction) error {
+				independentRan = true
+				return nil
+			})
+		})
+	})
+
+	require.NoError(t, err, "dal.GetNonTransactionalContext(ctx) must escape the nested-transaction guard: it is dal core's sanctioned way to start an independent transaction from inside a callback")
+	require.True(t, independentRan, "the independent transaction started via the escape hatch must actually run")
+}

--- a/adapters/dalgo2memory/optimistic.go
+++ b/adapters/dalgo2memory/optimistic.go
@@ -271,7 +271,13 @@ func (db *database) runOptimisticReadwriteTransaction(ctx context.Context, f dal
 		optimistic:         tx,
 	}
 	s := session{db: db, txState: txState}
-	if err := f(ctx, s); err != nil {
+	// Stamp transactionInProgressKey on the ctx handed to f — not the ctx this
+	// function received, which RunReadwriteTransaction already checked for that
+	// key before dispatching here — so a nested RunReadonlyTransaction or
+	// RunReadwriteTransaction call made from inside this callback is rejected by
+	// ErrNestedTransaction instead of silently running as an independent,
+	// concurrently-committing transaction (see that error's doc comment).
+	if err := f(context.WithValue(ctx, transactionInProgressKey{}, true), s); err != nil {
 		return err
 	}
 	if txState.readAfterWriteRejected {
@@ -328,7 +334,13 @@ func (db *database) runLockedReadwriteTransaction(ctx context.Context, f dal.RWT
 		optimistic:         tx,
 	}
 	s := session{db: db, txState: txState}
-	if err := f(ctx, s); err != nil {
+	// See the identical comment in runOptimisticReadwriteTransaction: this
+	// stamps the ctx handed to f, not the ctx RunReadwriteTransaction already
+	// checked, so a nested transaction call from inside this callback is
+	// rejected by ErrNestedTransaction instead of deadlocking on db.mu, which
+	// this function holds for the callback's entire duration (sync.RWMutex is
+	// not reentrant).
+	if err := f(context.WithValue(ctx, transactionInProgressKey{}, true), s); err != nil {
 		return err // buffered writes are discarded: this IS the rollback
 	}
 	if txState.readAfterWriteRejected {


### PR DESCRIPTION
## Summary

Real Firestore's Go client (`cloud.google.com/go/firestore`, `transaction.go`) refuses a transaction started from inside another transaction's callback: `Client.RunTransaction` checks a `transactionInProgressKey` context value **before** it even looks at whether either side is read-only:

```go
if ctx.Value(transactionInProgressKey{}) != nil {
    return errNestedTransaction
}
```

Since `RunReadonlyTransaction` and `RunReadwriteTransaction` are both backed by the same `RunTransaction` call (`ReadOnly()` is just an option), this rejects all four nesting combinations identically — not only read-write-in-read-write.

Before this PR, `dalgo2memory` got both directions wrong for exactly the read-write-in-read-write case:
- the **default** whole-database-lock `RunReadwriteTransaction` holds `db.mu` for its callback's entire duration, so a nested `RunReadwriteTransaction` call **deadlocks** trying to re-acquire it (`sync.RWMutex` is not reentrant);
- the opt-in `WithOptimisticConcurrency` path holds no such lock, so the same nested call would **silently succeed** as an independent, concurrently-committing transaction — legalizing exactly the pattern real Firestore rejects.

A later PR in this series flips the default to the optimistic machinery, which would have made the silent-success behavior the default without this guard landing first.

## What changed

- `adapters/dalgo2memory/database.go`: an unexported `transactionInProgressKey{}` context-key type (the same idiom Firestore's own client uses) and an exported `ErrNestedTransaction` sentinel, whose doc comment records the Firestore-client evidence above, why a rejected nesting does not poison the outer transaction, and `dal.GetNonTransactionalContext` as the sanctioned escape for intentionally starting an independent transaction. `RunReadonlyTransaction` and `RunReadwriteTransaction` both check the marker on entry and both stamp it onto the context handed to their callback.
- `adapters/dalgo2memory/optimistic.go`: `runLockedReadwriteTransaction` and `runOptimisticReadwriteTransaction` — the two `RunReadwriteTransaction` backends — stamp the marker on the ctx passed to `f`.
- `adapters/dalgo2memory/nested_transaction_test.go` (new): coverage for all four nesting combinations, the two outer-transaction-unaffected shapes (fatal-propagation discards writes; swallowing does not poison the commit), and the `dal.GetNonTransactionalContext` escape hatch.

### ro-in-rw resolution

The brief asked to check the real Firestore client to decide whether `RunReadonlyTransaction` nested inside a running read-write transaction should also be guarded. Per the source above, Firestore's check is symmetric across all four combinations — so this PR guards `RunReadonlyTransaction` the same way, not just `RunReadwriteTransaction`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` (repo-wide, incl. pre-push hook)
- [x] `go test ./adapters/dalgo2memory/... -coverprofile=...` → **100.0% of statements**
- [x] Nested rw-in-rw rejected promptly (no deadlock), both modes
- [x] ro-in-rw, rw-in-ro, ro-in-ro rejected too
- [x] Outer transaction discards writes when it treats the nested error as fatal
- [x] Outer transaction still commits when it swallows the nested error (not poisoning)
- [x] `dal.GetNonTransactionalContext(ctx)` escapes the guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jHJHbnHddXPJe72gzyhsx