### PR TITLE
feat(dalgo2memory): bounded auto-retry of transaction conflicts in optimistic mode

### DIFF
--- a/adapters/dalgo2memory/database.go
+++ b/adapters/dalgo2memory/database.go
@@ -207,12 +207,18 @@ func (db *database) RunReadonlyTransaction(ctx context.Context, f dal.ROTxWorker
 	return f(context.WithValue(ctx, transactionInProgressKey{}, true), session{db: db})
 }
 
-func (db *database) RunReadwriteTransaction(ctx context.Context, f dal.RWTxWorker, _ ...dal.TransactionOption) error {
+func (db *database) RunReadwriteTransaction(ctx context.Context, f dal.RWTxWorker, options ...dal.TransactionOption) error {
 	if ctx.Value(transactionInProgressKey{}) != nil {
 		return ErrNestedTransaction
 	}
 	if db.optimisticConcurrency {
-		return db.runOptimisticReadwriteTransaction(ctx, f)
+		// Attempts() is the only option this backend honors here: bounded
+		// auto-retry of ErrTransactionConflict, matching real Firestore's
+		// RunTransaction (see runOptimisticReadwriteTransaction's doc
+		// comment). It is meaningless for the locked mode below, which never
+		// produces that error in the first place.
+		attempts := dal.NewTransactionOptions(options...).Attempts()
+		return db.runOptimisticReadwriteTransaction(ctx, f, attempts)
 	}
 	return db.runLockedReadwriteTransaction(ctx, f)
 }

--- a/adapters/dalgo2memory/optimistic.go
+++ b/adapters/dalgo2memory/optimistic.go
@@ -5,11 +5,29 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"runtime"
 
 	"github.com/dal-go/dalgo/dal"
 	"github.com/dal-go/record"
 	"github.com/dal-go/record/update"
 )
+
+// defaultTransactionMaxAttempts is how many times an optimistic-mode
+// read-write transaction retries the whole callback after
+// ErrTransactionConflict when the caller does not request a specific count
+// via dal.TxWithAttempts. It matches
+// cloud.google.com/go/firestore.DefaultTransactionMaxAttempts (see that
+// module's transaction.go): the real Firestore Go client's RunTransaction
+// retries the whole callback on an ABORTED status up to that many times, so
+// production code running against real Firestore essentially never observes
+// a first-attempt abort. dalgo2firestore.RunReadwriteTransaction passes
+// dal.TransactionOptions.Attempts() straight through to firestore.MaxAttempts
+// when it is set (see dalgo2firestore/transaction.go's
+// createFirestoreTransactionOptions), and otherwise leaves the SDK's own
+// default in force — this constant is dalgo2memory's copy of that same
+// default, so a database created with WithOptimisticConcurrency fails tests
+// in ways production code never does if it surfaces a conflict un-retried.
+const defaultTransactionMaxAttempts = 5
 
 // ErrTransactionConflict is returned by RunReadwriteTransaction, for a
 // database created with WithOptimisticConcurrency, when another transaction
@@ -298,14 +316,89 @@ func conflictKey(collection, id string) string {
 }
 
 // runOptimisticReadwriteTransaction is RunReadwriteTransaction's
-// WithOptimisticConcurrency path — see optimisticState's doc comment for the
-// design. It never holds db.mu for the callback's duration, only briefly, once
-// per read/write operation, and once more (also briefly) for the final
-// commit, so unrelated transactions' callbacks run fully concurrently: a
-// transaction can even pause indefinitely between operations (as a test
-// driving a specific interleaving does) without blocking anyone else, since
-// it is not holding any lock while paused.
-func (db *database) runOptimisticReadwriteTransaction(ctx context.Context, f dal.RWTxWorker) error {
+// WithOptimisticConcurrency path: it retries the ENTIRE callback, up to
+// attempts times, whenever an attempt fails with ErrTransactionConflict —
+// matching the real Firestore Go client, whose RunTransaction retries the
+// whole callback on an ABORTED status up to DefaultTransactionMaxAttempts
+// (see defaultTransactionMaxAttempts's doc comment for the exact mapping).
+// Every attempt runs through runOptimisticReadwriteTransactionOnce with a
+// completely FRESH optimisticState — fresh reads, fresh pending writes, a
+// fresh snapshot pin — exactly as a real Firestore retry gets a fresh
+// server-side transaction.
+//
+// Because of that, THE CALLBACK MUST BE SAFE TO RUN MORE THAN ONCE: dalgo
+// core's own RWTxWorker doc and the real Firestore client both impose the
+// same requirement ("f may be called more than once, f should usually be
+// idempotent", cloud.google.com/go/firestore's transaction.go), and it is not
+// new here — WithOptimisticConcurrency already re-runs nothing itself, but a
+// caller-supplied callback that mutates state it captured from outside tx
+// (an in-memory counter, an external side effect) will observe a retry's
+// repeat invocation in both systems identically. A callback that is not
+// idempotent needs dal.TxWithAttempts(1) to disable retrying altogether.
+//
+// A conflict is retried whether it was detected by the callback itself (a
+// snapshot-abort read via observeAtSnapshot/observeCollectionAtSnapshot, or
+// the poisoned-commit refusal after a swallowed read error) or only later, at
+// commit's own baseline validation: both cases are ErrTransactionConflict,
+// and both mean the same thing — this attempt's view was invalidated by
+// someone else's commit before it finished, so a fresh attempt might not be.
+//
+// ErrReadAfterWriteInTransaction is deliberately NEVER retried, even though
+// runOptimisticReadwriteTransactionOnce can return it wrapped in the same way
+// commit wraps a conflict: it signals a code bug in the callback (a read that
+// follows the callback's own write, which this adapter's ordering rule
+// rejects), not contention with another transaction, and running the exact
+// same buggy callback again cannot fix that. The real Firestore client draws
+// the identical line: it detects the equivalent violation client-side and
+// sets err to errReadAfterWrite BEFORE the retry loop's isAborted(err) check,
+// so that error is never classified as retryable there either (see
+// cloud.google.com/go/firestore's transaction.go, RunTransaction). Checking
+// only IsTransactionConflict below is what implements this: neither
+// ErrReadAfterWriteInTransaction nor any ordinary callback error (a
+// not-found, a validation failure, ErrNestedTransaction, ...) ever wraps
+// ErrTransactionConflict, so none of them are retried.
+//
+// attempts is dal.TransactionOptions.Attempts() from the options
+// RunReadwriteTransaction's caller passed in. Zero or negative — unset, or an
+// odd caller-supplied value — is treated as defaultTransactionMaxAttempts,
+// the same default the real client applies when Attempts() is left at zero
+// (dalgo2firestore's createFirestoreTransactionOptions only calls
+// firestore.MaxAttempts when attempts > 0, otherwise leaving the SDK's own
+// DefaultTransactionMaxAttempts in force).
+//
+// There is no backoff between attempts beyond a runtime.Gosched(): the real
+// client backs off with gax.Backoff (transaction.go) to avoid hammering a
+// remote server while real contention clears, but this is an in-memory
+// adapter with no I/O latency, network contention, or rate limit to wait
+// out — the only thing worth yielding for is giving another goroutine racing
+// this one on the same *database a chance to finish its own commit.
+func (db *database) runOptimisticReadwriteTransaction(ctx context.Context, f dal.RWTxWorker, attempts int) error {
+	if attempts <= 0 {
+		attempts = defaultTransactionMaxAttempts
+	}
+	var err error
+	for attempt := 0; attempt < attempts; attempt++ {
+		if attempt > 0 {
+			runtime.Gosched()
+		}
+		err = db.runOptimisticReadwriteTransactionOnce(ctx, f)
+		if err == nil || !IsTransactionConflict(err) {
+			return err
+		}
+	}
+	return err
+}
+
+// runOptimisticReadwriteTransactionOnce is a single attempt of an
+// optimistic-mode read-write transaction — see optimisticState's doc comment
+// for the design, and runOptimisticReadwriteTransaction's doc comment for how
+// attempts are retried around this. It never holds db.mu for the callback's
+// duration, only briefly, once per read/write operation, and once more (also
+// briefly) for the final commit, so unrelated transactions' callbacks run
+// fully concurrently: a transaction can even pause indefinitely between
+// operations (as a test driving a specific interleaving does) without
+// blocking anyone else, since it is not holding any lock while paused.
+func (db *database) runOptimisticReadwriteTransactionOnce(ctx context.Context, f dal.RWTxWorker) error {
 	tx := &optimisticState{
 		db:               db,
 		reads:            make(map[string]uint64),
@@ -340,7 +433,13 @@ func (db *database) runOptimisticReadwriteTransaction(ctx context.Context, f dal
 // runLockedReadwriteTransaction is RunReadwriteTransaction's default path: it
 // holds db.mu for the callback's entire duration, so read-write transactions
 // are fully serialized and cannot contend (see WithOptimisticConcurrency for
-// the mode where they can).
+// the mode where they can). It never retries, and RunReadwriteTransaction
+// does not even pass it dal.TransactionOptions.Attempts(): validateVersions
+// stays false below, so db.versions and db.collectionSeq are never consulted
+// or grown for this mode's own transactions, and ErrTransactionConflict can
+// only ever originate from validateVersions' checks — a locked-mode
+// transaction's callback and commit therefore never produce it, and there is
+// nothing for a retry loop to catch here.
 //
 // Writes are nonetheless buffered through the same optimisticState machinery
 // rather than applied to the storage engines as they are made, because that is

--- a/adapters/dalgo2memory/optimistic_test.go
+++ b/adapters/dalgo2memory/optimistic_test.go
@@ -107,6 +107,14 @@ type slugThing struct {
 // TestOptimisticConcurrencyReadWriteConflict's doc comment for why ordinary
 // channels are enough to force this deterministically, with no dedicated
 // test hook needed.
+//
+// dal.TxWithAttempts(1) disables the default auto-retry: without it, the
+// loser's transaction would be re-run after its first-attempt conflict. Its
+// retry's fresh Get would find the slug already claimed (the winner has since
+// committed), so it would return the "test setup" error below instead of
+// ever reaching bothRead/proceed again — turning the single conflict this
+// test looks for into an unrelated setup failure, not the ErrTransactionConflict
+// the assertions below require.
 func TestOptimisticConcurrencyGetThenInsertSameKeyExactlyOneWins(t *testing.T) {
 	ctx := context.Background()
 	db := newDatabase(WithOptimisticConcurrency())
@@ -129,7 +137,7 @@ func TestOptimisticConcurrencyGetThenInsertSameKeyExactlyOneWins(t *testing.T) {
 			bothRead <- struct{}{}
 			<-proceed
 			return tx.Insert(ctx, dalrecord.NewRecordWithData(key, &slugThing{Owner: owner}))
-		})
+		}, dal.TxWithAttempts(1))
 	}
 
 	go claim("alice")
@@ -183,6 +191,11 @@ func TestOptimisticConcurrencyGetThenInsertSameKeyExactlyOneWins(t *testing.T) {
 // resumption, which is all the determinism this test needs; a bespoke
 // test-only hook would buy nothing beyond what the callback itself already
 // provides as a synchronization point.
+//
+// A's transaction passes dal.TxWithAttempts(1): its callback closes
+// aReached, and the default auto-retry would re-run that same callback after
+// the first-attempt conflict this test is looking for, panicking on
+// aReached's second close.
 func TestOptimisticConcurrencyReadWriteConflict(t *testing.T) {
 	ctx := context.Background()
 	db := newDatabase(WithOptimisticConcurrency())
@@ -202,7 +215,7 @@ func TestOptimisticConcurrencyReadWriteConflict(t *testing.T) {
 			close(aReached)
 			<-releaseA
 			return tx.Set(ctx, dalrecord.NewRecordWithData(key, &thing{Name: "from-a", Count: got.Count + 1}))
-		})
+		}, dal.TxWithAttempts(1))
 	}()
 
 	<-aReached // A has read K; it is now paused, holding no lock

--- a/adapters/dalgo2memory/retry_test.go
+++ b/adapters/dalgo2memory/retry_test.go
@@ -1,0 +1,180 @@
+package dalgo2memory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/record"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the bounded auto-retry runOptimisticReadwriteTransaction
+// applies to ErrTransactionConflict, matching the real Firestore Go client's
+// RunTransaction (see that function's doc comment for the exact mapping to
+// cloud.google.com/go/firestore.DefaultTransactionMaxAttempts and to
+// dalgo2firestore's own Attempts()->MaxAttempts wiring). As in
+// snapshot_test.go and txquery_test.go, external commits are simulated with
+// top-level (non-transactional) writes on the same database, each its own
+// single-key commit that cannot deadlock against the transaction under test.
+
+// TestOptimisticConcurrencyRetry_ConflictThenSucceeds is the headline
+// required case: the callback's first attempt is invalidated by a
+// concurrent-looking external commit, and its second attempt — driven only
+// on the first attempt via the callbackRuns counter, so it is deterministic
+// rather than a race — reads the winning value fresh and commits cleanly.
+func TestOptimisticConcurrencyRetry_ConflictThenSucceeds(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+
+	var callbackRuns int
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		callbackRuns++
+		n, err := readThingN(ctx, tx, "A")
+		if err != nil {
+			return err
+		}
+		if callbackRuns == 1 {
+			// Only on the first attempt: an external commit lands between
+			// this attempt's read and its own commit, invalidating it. A
+			// second attempt must not repeat this — it should read the
+			// winning value (99) fresh and succeed.
+			require.NoError(t, db.Set(ctx, thingRecord("A", 99)))
+		}
+		return tx.Set(ctx, thingRecord("A", int(n)+1))
+	})
+
+	require.NoError(t, err, "the second attempt must succeed once nothing external races it")
+	require.Equal(t, 2, callbackRuns, "the callback must run exactly twice: attempt 1 conflicts, attempt 2 succeeds")
+
+	var got map[string]any
+	require.NoError(t, db.Get(ctx, record.NewRecordWithData(thingKey("A"), &got)))
+	assert.EqualValues(t, 100, got["n"], "attempt 2 must have read the winning external value (99) and added 1 to it")
+}
+
+// TestOptimisticConcurrencyRetry_PersistentConflictExhaustsDefaultAttempts
+// checks the other side of the bound: a conflict that recurs on every single
+// attempt (the external commit here races EVERY attempt's read, not just the
+// first) must not retry forever — it exhausts defaultTransactionMaxAttempts
+// and returns a final error that still satisfies IsTransactionConflict, so a
+// caller that gives up can still tell why.
+func TestOptimisticConcurrencyRetry_PersistentConflictExhaustsDefaultAttempts(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+
+	var callbackRuns int
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		callbackRuns++
+		if _, err := readThingN(ctx, tx, "A"); err != nil {
+			return err
+		}
+		// Unlike the test above, this external commit runs on EVERY
+		// attempt, after that attempt's own read: no attempt can ever
+		// succeed.
+		require.NoError(t, db.Set(ctx, thingRecord("A", callbackRuns+100)))
+		return nil
+	})
+
+	require.Equal(t, defaultTransactionMaxAttempts, callbackRuns,
+		"the callback must run exactly once per attempt, up to the default budget, no more")
+	require.Error(t, err)
+	assert.True(t, IsTransactionConflict(err), "the exhausted retry must still report a classifiable conflict: %v", err)
+}
+
+// TestOptimisticConcurrencyRetry_TxWithAttempts1DisablesRetry checks that
+// dal.TxWithAttempts(1) really means exactly one attempt: a conflict that
+// would otherwise be retried under the default budget is instead returned
+// immediately, after exactly one callback run.
+func TestOptimisticConcurrencyRetry_TxWithAttempts1DisablesRetry(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+
+	var callbackRuns int
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		callbackRuns++
+		if _, err := readThingN(ctx, tx, "A"); err != nil {
+			return err
+		}
+		require.NoError(t, db.Set(ctx, thingRecord("A", 2)))
+		return nil
+	}, dal.TxWithAttempts(1))
+
+	require.Equal(t, 1, callbackRuns, "TxWithAttempts(1) must disable retrying entirely")
+	require.Error(t, err)
+	assert.True(t, IsTransactionConflict(err))
+}
+
+// TestOptimisticConcurrencyRetry_TxWithAttemptsHonorsExplicitCount checks
+// that an explicit attempt count other than 1 or the default is honored
+// exactly: a persistent conflict run under dal.TxWithAttempts(3) exhausts
+// precisely 3 attempts, neither more (the default) nor fewer (1).
+func TestOptimisticConcurrencyRetry_TxWithAttemptsHonorsExplicitCount(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency())
+	require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+
+	var callbackRuns int
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		callbackRuns++
+		if _, err := readThingN(ctx, tx, "A"); err != nil {
+			return err
+		}
+		require.NoError(t, db.Set(ctx, thingRecord("A", callbackRuns+100)))
+		return nil
+	}, dal.TxWithAttempts(3))
+
+	require.Equal(t, 3, callbackRuns, "TxWithAttempts(3) must run exactly 3 attempts, not the default 5 or a single attempt")
+	require.Error(t, err)
+	assert.True(t, IsTransactionConflict(err))
+}
+
+// TestOptimisticConcurrencyRetry_ReadAfterWriteNotRetried is the required
+// negative case for the retryable/non-retryable line: ErrReadAfterWriteInTransaction
+// signals a code bug in the callback (a read that follows the callback's own
+// write), not contention with another transaction, so it must never be
+// retried — the callback runs exactly once even though the default budget
+// would allow up to 5.
+func TestOptimisticConcurrencyRetry_ReadAfterWriteNotRetried(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase(WithOptimisticConcurrency()) // noReadsAfterWritesInTransaction defaults to true
+
+	var callbackRuns int
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		callbackRuns++
+		if err := tx.Set(ctx, thingRecord("t1", 1)); err != nil {
+			return err
+		}
+		_, existsErr := tx.Exists(ctx, thingKey("t1"))
+		return existsErr
+	})
+
+	require.ErrorIs(t, err, ErrReadAfterWriteInTransaction)
+	require.Equal(t, 1, callbackRuns, "a read-after-write ordering bug must not be retried, even under the default attempt budget")
+}
+
+// TestLockedModeIgnoresAttemptsOptionSilently is the required negative case
+// for the OTHER transaction mode: a database created WITHOUT
+// WithOptimisticConcurrency never produces ErrTransactionConflict (its
+// versions/collectionSeq tables stay empty — see
+// runLockedReadwriteTransaction's doc comment), so RunReadwriteTransaction's
+// default (locked) path must behave exactly as it did before this feature
+// existed, regardless of what dal.TransactionOptions.Attempts() the caller
+// asks for: an ordinary callback error is returned immediately, with the
+// callback having run exactly once.
+func TestLockedModeIgnoresAttemptsOptionSilently(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase() // default locked mode: no WithOptimisticConcurrency
+
+	var callbackRuns int
+	err := db.RunReadwriteTransaction(ctx, func(context.Context, dal.ReadwriteTransaction) error {
+		callbackRuns++
+		return errBoom
+	}, dal.TxWithAttempts(5))
+
+	require.ErrorIs(t, err, errBoom)
+	require.Equal(t, 1, callbackRuns, "the locked mode must not retry regardless of the requested attempt count")
+}

--- a/adapters/dalgo2memory/snapshot_test.go
+++ b/adapters/dalgo2memory/snapshot_test.go
@@ -39,6 +39,12 @@ func readThingN(ctx context.Context, tx dal.ReadTransaction, id string) (float64
 // B's new value, which would fracture the view (A=1 and B=2 never coexisted).
 // A read of an UNCHANGED key between the two stays fine: the live store is
 // still the snapshot for everything the external commit did not touch.
+//
+// dal.TxWithAttempts(1) disables the default auto-retry: the callback's
+// external commits and require.EqualValues assertions run again on every
+// retry attempt, and a is 2 (not 1) once a retry's own first read observes
+// the previous attempt's external Set — asserting a single attempt's
+// observation is the entire point of this test.
 func TestSnapshotReads_FracturedViewAbortsAtRead(t *testing.T) {
 	ctx := context.Background()
 	db := newDatabase(WithOptimisticConcurrency())
@@ -62,7 +68,7 @@ func TestSnapshotReads_FracturedViewAbortsAtRead(t *testing.T) {
 
 		_, readErr = readThingN(ctx, tx, "B")
 		return readErr
-	})
+	}, dal.TxWithAttempts(1))
 
 	require.Error(t, readErr, "reading B after A's snapshot was overwritten must fail at the read")
 	assert.True(t, IsTransactionConflict(readErr), "the read error must be retryable: %v", readErr)
@@ -75,6 +81,11 @@ func TestSnapshotReads_FracturedViewAbortsAtRead(t *testing.T) {
 // Firestore client, which fails the commit of a transaction whose read came
 // back ABORTED regardless of what the callback returned. A later read in the
 // same transaction (of any key) also keeps failing: the transaction is dead.
+//
+// dal.TxWithAttempts(1) disables the default auto-retry, which the callback
+// swallowing its own conflict would otherwise trigger: a retry's fresh
+// attempt is not guaranteed to reproduce the same poisoned-read/poisoned-write
+// sequence this test asserts about a single attempt.
 func TestSnapshotReads_SwallowedConflictPoisonsCommit(t *testing.T) {
 	ctx := context.Background()
 	db := newDatabase(WithOptimisticConcurrency())
@@ -101,7 +112,7 @@ func TestSnapshotReads_SwallowedConflictPoisonsCommit(t *testing.T) {
 			return err
 		}
 		return nil
-	})
+	}, dal.TxWithAttempts(1))
 
 	require.Error(t, err, "a transaction that observed a snapshot conflict must not commit")
 	assert.True(t, IsTransactionConflict(err))
@@ -118,6 +129,11 @@ func TestSnapshotReads_SwallowedConflictPoisonsCommit(t *testing.T) {
 // Firestore's fixed read time — trading a spurious abort (absorbed by the
 // caller's retry) for an O(1) check and semantics that need one sentence to
 // state.
+//
+// dal.TxWithAttempts(1) disables the default auto-retry: the callback's own
+// external commit of B always lands after each attempt's snapshot is pinned,
+// so a retry would just reproduce the same abort every time — this test is
+// about that single-attempt behavior, not about how many times it repeats.
 func TestSnapshotReads_UnrelatedNewerKeyAlsoAborts(t *testing.T) {
 	ctx := context.Background()
 	db := newDatabase(WithOptimisticConcurrency())
@@ -131,7 +147,7 @@ func TestSnapshotReads_UnrelatedNewerKeyAlsoAborts(t *testing.T) {
 		require.NoError(t, db.Set(ctx, thingRecord("B", 2)))
 		_, readErr := readThingN(ctx, tx, "B")
 		return readErr
-	})
+	}, dal.TxWithAttempts(1))
 	assert.True(t, IsTransactionConflict(err))
 }
 
@@ -164,6 +180,11 @@ func TestSnapshotReads_BlindWriteToNewerKeyCommits(t *testing.T) {
 // above must not weaken write-write conflict detection. A key this
 // transaction blind-wrote and another transaction then committed over is
 // still caught at commit by the baseline validation.
+//
+// dal.TxWithAttempts(1) disables the default auto-retry: the callback's
+// external commit always lands after the blind write it races, in every
+// attempt, so this is a single-attempt observation, not a claim about what
+// happens after N retries.
 func TestSnapshotReads_WriteWriteRaceStillConflicts(t *testing.T) {
 	ctx := context.Background()
 	db := newDatabase(WithOptimisticConcurrency())
@@ -175,7 +196,7 @@ func TestSnapshotReads_WriteWriteRaceStillConflicts(t *testing.T) {
 		}
 		require.NoError(t, db.Set(ctx, thingRecord("A", 2))) // external commit wins the race
 		return nil
-	})
+	}, dal.TxWithAttempts(1))
 	assert.True(t, IsTransactionConflict(err),
 		"an external commit between a blind write and its commit must still conflict")
 }
@@ -206,6 +227,12 @@ func TestSnapshotReads_PinsAtFirstReadNotAtStart(t *testing.T) {
 // it after an external commit returns the SNAPSHOT value (the cached entry),
 // never the newer one — and the transaction then fails at commit via baseline
 // validation rather than ever showing the torn value.
+//
+// dal.TxWithAttempts(1) disables the default auto-retry: without it, a
+// retry's first read would pin its NEW snapshot after the previous attempt's
+// external Set already landed, so the re-read's assert.EqualValues(t, 1, a)
+// below would see 2 instead — failing an assertion this test's whole point is
+// to make about a single attempt's snapshot.
 func TestSnapshotReads_RereadStaysOnSnapshot(t *testing.T) {
 	ctx := context.Background()
 	db := newDatabase(WithOptimisticConcurrency())
@@ -222,7 +249,7 @@ func TestSnapshotReads_RereadStaysOnSnapshot(t *testing.T) {
 		}
 		assert.EqualValues(t, 1, a, "a re-read must stay on the transaction's snapshot")
 		return nil
-	})
+	}, dal.TxWithAttempts(1))
 	assert.True(t, IsTransactionConflict(err),
 		"the transaction read a key another commit overwrote, so its commit must conflict")
 }

--- a/adapters/dalgo2memory/txquery_test.go
+++ b/adapters/dalgo2memory/txquery_test.go
@@ -63,6 +63,12 @@ func TestTxQuery_WorksAndCommits(t *testing.T) {
 // commit INSERTS a new record there. No key in the per-key read set names the
 // new record — it did not exist — yet the query's result is now stale, so the
 // commit must conflict.
+//
+// dal.TxWithAttempts(1) disables the default auto-retry: the callback's
+// external Set of the phantom record always lands after each attempt's own
+// query, so a retry would just repeat the same conflict every time — this
+// test is about that single-attempt behavior, not about how many times it
+// repeats.
 func TestTxQuery_PhantomInsertConflictsAtCommit(t *testing.T) {
 	ctx := context.Background()
 	db := newDatabase(WithOptimisticConcurrency())
@@ -75,7 +81,7 @@ func TestTxQuery_PhantomInsertConflictsAtCommit(t *testing.T) {
 		// The phantom: a record the query could not have named as a key.
 		require.NoError(t, db.Set(ctx, thingRecord("B", 1)))
 		return nil
-	})
+	}, dal.TxWithAttempts(1))
 	assert.True(t, IsTransactionConflict(err),
 		"an insert into a queried collection must conflict the querying transaction: %v", err)
 }
@@ -105,6 +111,12 @@ func TestTxQuery_UnrelatedCollectionWriteDoesNotConflict(t *testing.T) {
 // transaction already observed, so the query itself aborts — and a second
 // query attempt hits the poisoned fast-path, and the swallowed conflict still
 // refuses the commit.
+//
+// dal.TxWithAttempts(1) disables the default auto-retry: the callback's
+// external Set into "things" always lands after each attempt's own snapshot
+// pin, so a retry would just repeat the same abort sequence every time — this
+// test is about that single-attempt behavior, not about how many times it
+// repeats.
 func TestTxQuery_QueryAfterSnapshotFractureAborts(t *testing.T) {
 	ctx := context.Background()
 	db := newDatabase(WithOptimisticConcurrency())
@@ -127,13 +139,19 @@ func TestTxQuery_QueryAfterSnapshotFractureAborts(t *testing.T) {
 		_, again := queryThingIDs(ctx, tx)
 		require.True(t, IsTransactionConflict(again), "the poisoned transaction fails every later query too")
 		return nil // swallow, as buggy caller code might
-	})
+	}, dal.TxWithAttempts(1))
 	assert.True(t, IsTransactionConflict(err), "the swallowed query conflict must still refuse the commit")
 }
 
 // TestTxQuery_QueryPinsSnapshot: a query can be the transaction's FIRST
 // observation, pinning the snapshot exactly as a point read would — proven by
 // the point read AFTER a later external commit aborting.
+//
+// dal.TxWithAttempts(1) disables the default auto-retry: the callback's
+// external Set of A always lands after each attempt's own query pins the
+// snapshot, so a retry would just repeat the same abort every time — this
+// test is about that single-attempt behavior, not about how many times it
+// repeats.
 func TestTxQuery_QueryPinsSnapshot(t *testing.T) {
 	ctx := context.Background()
 	db := newDatabase(WithOptimisticConcurrency())
@@ -150,7 +168,7 @@ func TestTxQuery_QueryPinsSnapshot(t *testing.T) {
 		require.True(t, IsTransactionConflict(readErr),
 			"a point read of a key committed after the query's snapshot must abort: %v", readErr)
 		return readErr
-	})
+	}, dal.TxWithAttempts(1))
 	assert.True(t, IsTransactionConflict(err))
 }
 


### PR DESCRIPTION
## Summary

PR 4 of the approved 6-PR plan: bounded auto-retry of transaction conflicts in `dalgo2memory`'s optimistic-concurrency mode, matching the real Firestore Go client.

- `cloud.google.com/go/firestore@v1.25.0`'s `transaction.go` defines `DefaultTransactionMaxAttempts = 5` and retries the whole callback on ABORTED (`for i := 0; i < t.maxAttempts; i++`), so production code essentially never observes a first-attempt abort.
- `dalgo2firestore/transaction.go`'s `createFirestoreTransactionOptions` maps `dal.TransactionOptions.Attempts()` straight to `firestore.MaxAttempts` when set, otherwise leaving the SDK's own default in force.
- `dalgo2memory`'s `RunReadwriteTransaction` previously discarded its `options ...dal.TransactionOption` parameter entirely and surfaced `ErrTransactionConflict` un-retried — a faithfulness gap that makes tests against this adapter fail in ways they never would against real Firestore.

## Changes

- `RunReadwriteTransaction` now threads `options` through: for a `WithOptimisticConcurrency` database it computes `dal.NewTransactionOptions(options...).Attempts()` and passes it to the (renamed) retry wrapper. The locked mode is untouched — it never calls `dal.NewTransactionOptions` and ignores `Attempts()` silently, because its `versions`/`collectionSeq` tables stay empty and it can never produce `ErrTransactionConflict` to retry.
- `runOptimisticReadwriteTransaction` is now the retry loop: default 5 attempts (zero/negative treated as default), retries only when `IsTransactionConflict(err)`, `runtime.Gosched()` between attempts (no real backoff — nothing to wait out in-memory). The prior single-attempt body is renamed `runOptimisticReadwriteTransactionOnce` and gets a completely fresh `optimisticState` per attempt.
- `ErrReadAfterWriteInTransaction` is deliberately never retried — verified against the real client's `RunTransaction`, which sets `err = errReadAfterWrite` *before* its `isAborted(err)` check, so that violation is never treated as retryable there either. It's a callback bug, not contention.
- Doc comments at the retry loop spell out the re-run-safety requirement dalgo core's `RWTxWorker` and the real Firestore client both already impose on callbacks.

## Existing tests updated (single-attempt semantics preserved with `dal.TxWithAttempts(1)`)

Audited every file using `WithOptimisticConcurrency` (`atomicity_test.go`, `nested_transaction_test.go`, `optimistic_test.go`, `snapshot_test.go`, `txquery_test.go`). Only tests whose callback produces `ErrTransactionConflict` and depends on running exactly once needed the change — `atomicity_test.go` and `nested_transaction_test.go` never produce that error (ordinary callback errors, `ErrReadAfterWriteInTransaction`, `ErrNestedTransaction`) so they're untouched.

- `optimistic_test.go`: `TestOptimisticConcurrencyGetThenInsertSameKeyExactlyOneWins` (retry's fresh Get would find the slug already claimed, turning the assertion into an unrelated "test setup" error) and `TestOptimisticConcurrencyReadWriteConflict` (retry would panic closing an already-closed channel).
- `snapshot_test.go`: the 5 of 7 tests that observe a conflict (`FracturedViewAbortsAtRead`, `SwallowedConflictPoisonsCommit`, `UnrelatedNewerKeyAlsoAborts`, `WriteWriteRaceStillConflicts`, `RereadStaysOnSnapshot`) — several have `require`/`assert` on values that differ on a retry's fresh snapshot (e.g. `RereadStaysOnSnapshot` would see `a=2` instead of the asserted `1`). The 2 non-conflict tests (`BlindWriteToNewerKeyCommits`, `PinsAtFirstReadNotAtStart`) are untouched — they never retry.
- `txquery_test.go`: the 3 of 7 tests that observe a conflict (`PhantomInsertConflictsAtCommit`, `QueryAfterSnapshotFractureAborts`, `QueryPinsSnapshot`) for the same reason (their external commits re-run every attempt, so the assertions become non-deterministic or just wasteful without pinning to one attempt).

Every touched assertion is unchanged in substance — only `dal.TxWithAttempts(1)` was added to the `RunReadwriteTransaction` call.

## New tests (`retry_test.go`)

- `TestOptimisticConcurrencyRetry_ConflictThenSucceeds` — conflict on attempt 1 (driven deterministically via a counter, not a race), succeeds on attempt 2, callback runs exactly twice, final stored value correct.
- `TestOptimisticConcurrencyRetry_PersistentConflictExhaustsDefaultAttempts` — exhausts the default 5 attempts, callback run count asserted, final error still satisfies `IsTransactionConflict`.
- `TestOptimisticConcurrencyRetry_TxWithAttempts1DisablesRetry` — exactly 1 attempt.
- `TestOptimisticConcurrencyRetry_TxWithAttemptsHonorsExplicitCount` — exactly 3 attempts.
- `TestOptimisticConcurrencyRetry_ReadAfterWriteNotRetried` — callback runs exactly once.
- `TestLockedModeIgnoresAttemptsOptionSilently` — locked mode ignores `Attempts()`, callback runs exactly once.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` (whole module, all packages green)
- [x] `go test ./adapters/dalgo2memory/... -coverprofile=... -covermode=set` → **100.0% of statements**
- [x] `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jHJHbnHddXPJe72gzyhsx