### PR TITLE
fix(dal): skip nil options in NewTransactionOptions and NewInsertOptions

### DIFF
--- a/dal/nil_options_test.go
+++ b/dal/nil_options_test.go
@@ -1,0 +1,34 @@
+package dal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewTransactionOptions_SkipsNil is the regression test for a panic found
+// by a fleet sweep: callers pass a literal nil (or an unset option variable)
+// among the variadic options — RunReadwriteTransaction(ctx, f, nil) exists at
+// several call sites in the wild — and the constructor invoked it. The
+// constructor guards every adapter at once, including dalgo2firestore, which
+// reads these options in production.
+func TestNewTransactionOptions_SkipsNil(t *testing.T) {
+	require.NotPanics(t, func() {
+		o := NewTransactionOptions(nil)
+		assert.NotNil(t, o)
+	})
+	// Real options interleaved with nils still apply.
+	o := NewTransactionOptions(nil, TxWithAttempts(3), nil)
+	assert.Equal(t, 3, o.Attempts())
+}
+
+// TestNewInsertOptions_SkipsNil applies the same guard, and reason, to the
+// insert-option constructor.
+func TestNewInsertOptions_SkipsNil(t *testing.T) {
+	require.NotPanics(t, func() {
+		_ = NewInsertOptions(nil)
+	})
+	o := NewInsertOptions(nil, WithRandomStringKey(16, 5), nil)
+	assert.NotNil(t, o.IDGenerator())
+}

--- a/dal/transaction.go
+++ b/dal/transaction.go
@@ -204,7 +204,16 @@ func (v txOptions) Password() string {
 func NewTransactionOptions(opts ...TransactionOption) TransactionOptions {
 	options := txOptions{}
 	for _, opt := range opts {
-		opt(&options)
+		// A nil option is skipped rather than invoked: callers commonly pass a
+		// literal nil or an unset option variable through a variadic chain
+		// (RunReadwriteTransaction(ctx, f, nil) exists in the wild), and
+		// invoking it panics. Adapters apply the same guard to their own
+		// options (see dalgo2memory's newDatabase); the constructor is the one
+		// place that protects every adapter at once - including
+		// dalgo2firestore, which reads these options in production.
+		if opt != nil {
+			opt(&options)
+		}
 	}
 	return &options
 }

--- a/dal/tx_inserter.go
+++ b/dal/tx_inserter.go
@@ -51,7 +51,11 @@ var _ InsertOptions = (*insertOptions)(nil)
 func NewInsertOptions(opts ...InsertOption) InsertOptions {
 	var options insertOptions
 	for _, o := range opts {
-		o(&options)
+		// Skip nil options rather than panic - same guard, and reason, as
+		// NewTransactionOptions.
+		if o != nil {
+			o(&options)
+		}
 	}
 	return options
 }


### PR DESCRIPTION
Found by the fleet sweep pre-validating the contention-default flip (#127-to-be): four call sites across sneat-core-modules, sneat-go, and debtus pass a literal `nil` among variadic transaction options — `RunReadwriteTransaction(ctx, f, nil)`. Historically harmless in tests because `dalgo2memory` never read its options; the flip branch reads them via `NewTransactionOptions`, which invoked the nil function value and panicked, crashing 5 debtus packages deterministically.

**The exposure is not test-only**: `dalgo2firestore` reads these options in production today (mapping `Attempts()` → `firestore.MaxAttempts`), so those call sites are latent live panics against real Firestore. Guarding the constructors fixes every adapter and every call site at once — the same guard `dalgo2memory.newDatabase` already applies to its own options. `NewInsertOptions` gets identical treatment.

Regression tests cover nil-only, and nils interleaved with real options still applying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jHJHbnHddXPJe72gzyhsx