### PR TITLE
feat(dalgo2memory): contention is the default — a plain NewDB() is the Firestore profile

### DIFF
--- a/adapters/dalgo2memory/atomicity_test.go
+++ b/adapters/dalgo2memory/atomicity_test.go
@@ -37,7 +37,8 @@ func TestTransactionRollback_DiscardsWrites(t *testing.T) {
 		name string
 		opts []Option
 	}{
-		{"default locked mode", nil},
+		{"default (contending) mode", nil},
+		{"single-writer mode", []Option{WithSingleWriterTransactions()}},
 		{"WithOptimisticConcurrency", []Option{WithOptimisticConcurrency()}},
 	} {
 		t.Run(mode.name, func(t *testing.T) {
@@ -73,7 +74,8 @@ func TestTransactionRollback_DiscardsDeletes(t *testing.T) {
 		name string
 		opts []Option
 	}{
-		{"default locked mode", nil},
+		{"default (contending) mode", nil},
+		{"single-writer mode", []Option{WithSingleWriterTransactions()}},
 		{"WithOptimisticConcurrency", []Option{WithOptimisticConcurrency()}},
 	} {
 		t.Run(mode.name, func(t *testing.T) {
@@ -105,7 +107,8 @@ func TestTransactionCommit_AppliesAllWrites(t *testing.T) {
 		name string
 		opts []Option
 	}{
-		{"default locked mode", nil},
+		{"default (contending) mode", nil},
+		{"single-writer mode", []Option{WithSingleWriterTransactions()}},
 		{"WithOptimisticConcurrency", []Option{WithOptimisticConcurrency()}},
 	} {
 		t.Run(mode.name, func(t *testing.T) {
@@ -323,7 +326,8 @@ func TestReadAfterWriteRejection_PoisonsCommitEvenIfSwallowed(t *testing.T) {
 		name string
 		opts []Option
 	}{
-		{"default locked mode", nil},
+		{"default (contending) mode", nil},
+		{"single-writer mode", []Option{WithSingleWriterTransactions()}},
 		{"WithOptimisticConcurrency", []Option{WithOptimisticConcurrency()}},
 	} {
 		t.Run(mode.name, func(t *testing.T) {

--- a/adapters/dalgo2memory/database.go
+++ b/adapters/dalgo2memory/database.go
@@ -35,9 +35,19 @@ func newDatabase(options ...Option) *database {
 		// Firestore's real ordering rule. See
 		// WithInterleavedReadsAndWritesInTransaction for the opt-out.
 		noReadsAfterWritesInTransaction: true,
-		schemaRefBreaking:               true,
-		versions:                        make(map[string]uint64),
-		collectionSeq:                   make(map[string]uint64),
+		// optimisticConcurrency defaults to true: a plain NewDB() runs
+		// read-write transactions on the optimistic machinery — genuine
+		// contention, snapshot reads, and bounded auto-retry of conflicts —
+		// completing the Firestore-faithful default profile. Real Firestore
+		// transactions really do contend, so a concurrency test passing
+		// against a serialized double proves nothing about production; that
+		// gap is why this defaults on. See WithSingleWriterTransactions for
+		// the intent-named opt-out that restores the whole-database-lock
+		// single-writer mode.
+		optimisticConcurrency: true,
+		schemaRefBreaking:     true,
+		versions:              make(map[string]uint64),
+		collectionSeq:         make(map[string]uint64),
 	}
 	for _, option := range options {
 		if option != nil {
@@ -72,11 +82,12 @@ type database struct {
 	// unless WithoutSchemaRefBreaking was used). NewDB initializes it to true.
 	schemaRefBreaking bool
 
-	// optimisticConcurrency selects the opt-in optimistic-concurrency
-	// read-write transaction mode (see WithOptimisticConcurrency) in place of
-	// the default whole-database lock RunReadwriteTransaction otherwise holds
-	// for a transaction's entire duration. Default false: nothing below
-	// changes behavior until it is set.
+	// optimisticConcurrency selects the optimistic-concurrency read-write
+	// transaction mode — genuine contention, snapshot reads, auto-retry.
+	// Default TRUE (see newDatabase): a plain NewDB() is the Firestore
+	// profile. WithSingleWriterTransactions sets it false, restoring the
+	// whole-database lock RunReadwriteTransaction otherwise holds for a
+	// transaction's entire duration.
 	optimisticConcurrency bool
 	// versions is the commit-version table optimistic-mode transactions
 	// validate their reads against at commit (see optimisticState.commit): it

--- a/adapters/dalgo2memory/flip_test.go
+++ b/adapters/dalgo2memory/flip_test.go
@@ -2,6 +2,7 @@ package dalgo2memory
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/dal-go/dalgo/dal"
@@ -87,4 +88,68 @@ func TestDefault_AtomicityUnchanged(t *testing.T) {
 	exists, existsErr := db.Exists(ctx, thingKey("X"))
 	require.NoError(t, existsErr)
 	assert.False(t, exists, "a failed transaction's writes must be discarded on the bare default")
+}
+
+// TestDefault_HotKeyContentionAllComplete pins the escalation progress
+// guarantee: N workers doing read-modify-write on ONE hot key must ALL
+// eventually complete under the bare default, the way real Firestore's
+// server-side lock queue lets contended writers finish rather than abort
+// each other forever. Before final-attempt escalation this shape could
+// exhaust the optimistic attempt budget and surface a raw conflict that
+// production never sees (measured in a fleet sweep: 8 workers on one
+// counter document).
+func TestDefault_HotKeyContentionAllComplete(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase()
+	require.NoError(t, db.Set(ctx, thingRecord("counter", 0)))
+
+	const workers = 12
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+				var data map[string]any
+				rec := record.NewRecordWithData(thingKey("counter"), &data)
+				if err := tx.Get(ctx, rec); err != nil {
+					return err
+				}
+				n, _ := data["n"].(float64)
+				return tx.Set(ctx, record.NewRecordWithData(thingKey("counter"), map[string]any{"n": n + 1}))
+			})
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err, "every contended transaction must eventually complete, as against real Firestore")
+	}
+
+	var final map[string]any
+	require.NoError(t, db.Get(ctx, record.NewRecordWithData(thingKey("counter"), &final)))
+	assert.EqualValues(t, workers, final["n"],
+		"every increment must be applied exactly once: no lost updates, no double-commits")
+}
+
+// TestTxWithAttempts1_NeverEscalates pins the other half of the escalation
+// contract: a single-attempt transaction is one PURE optimistic shot, so a
+// conflict still surfaces — this is what keeps every conflict-observation
+// test in this package meaningful.
+func TestTxWithAttempts1_NeverEscalates(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase()
+	require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		var data map[string]any
+		if err := tx.Get(ctx, record.NewRecordWithData(thingKey("A"), &data)); err != nil {
+			return err
+		}
+		require.NoError(t, db.Set(ctx, thingRecord("A", 2))) // external commit
+		return tx.Set(ctx, thingRecord("A", 3))
+	}, dal.TxWithAttempts(1))
+	assert.True(t, IsTransactionConflict(err),
+		"a one-attempt transaction must surface the conflict, never escalate past it")
 }

--- a/adapters/dalgo2memory/flip_test.go
+++ b/adapters/dalgo2memory/flip_test.go
@@ -1,0 +1,90 @@
+package dalgo2memory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/record"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the FLIP itself: a plain NewDB() — no options — now behaves
+// as the Firestore profile end to end. Every capability asserted here is
+// already proven in depth elsewhere (snapshot_test.go, txquery_test.go,
+// retry_test.go) against WithOptimisticConcurrency, which is now an affirming
+// no-op; what THESE tests prove is that the bare default gets the same
+// behavior, so no consumer has to pass an option to test against something
+// Firestore-shaped.
+
+// TestDefault_SnapshotReadsAndRetry: on a bare newDatabase(), a fractured
+// read aborts the attempt AND the default auto-retry re-runs the callback to
+// success — the two halves of the profile working together with no options.
+func TestDefault_SnapshotReadsAndRetry(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase() // no options: the whole point
+	require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+	require.NoError(t, db.Set(ctx, thingRecord("B", 1)))
+
+	attempts := 0
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		attempts++
+		var a map[string]any
+		if err := tx.Get(ctx, record.NewRecordWithData(thingKey("A"), &a)); err != nil {
+			return err
+		}
+		if attempts == 1 {
+			// Fracture the first attempt's snapshot with external commits.
+			require.NoError(t, db.Set(ctx, thingRecord("A", 2)))
+			require.NoError(t, db.Set(ctx, thingRecord("B", 2)))
+		}
+		var b map[string]any
+		if err := tx.Get(ctx, record.NewRecordWithData(thingKey("B"), &b)); err != nil {
+			return err
+		}
+		assert.Equal(t, a["n"], b["n"], "the callback must never observe a fractured view")
+		return nil
+	})
+	require.NoError(t, err, "the default must auto-retry the aborted first attempt")
+	assert.Equal(t, 2, attempts, "attempt 1 aborts on the fractured read; attempt 2 succeeds")
+}
+
+// TestDefault_TransactionalQueryWithPhantomProtection: a bare newDatabase()
+// supports queries inside read-write transactions AND conflicts on a phantom
+// insert — with retry disabled to observe the conflict itself.
+func TestDefault_TransactionalQueryWithPhantomProtection(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase()
+	require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		n, err := queryThingIDs(ctx, tx)
+		if err != nil {
+			return err
+		}
+		assert.Equal(t, 1, n)
+		require.NoError(t, db.Set(ctx, thingRecord("B", 1))) // the phantom
+		return nil
+	}, dal.TxWithAttempts(1))
+	assert.True(t, IsTransactionConflict(err),
+		"a phantom insert into a queried collection must conflict on the bare default: %v", err)
+}
+
+// TestDefault_AtomicityUnchanged: the flip must not disturb what #121
+// established — a failed callback discards its writes on the bare default.
+func TestDefault_AtomicityUnchanged(t *testing.T) {
+	ctx := context.Background()
+	db := newDatabase()
+
+	err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		if err := tx.Set(ctx, thingRecord("X", 1)); err != nil {
+			return err
+		}
+		return errBoom
+	})
+	require.ErrorIs(t, err, errBoom)
+	exists, existsErr := db.Exists(ctx, thingKey("X"))
+	require.NoError(t, existsErr)
+	assert.False(t, exists, "a failed transaction's writes must be discarded on the bare default")
+}

--- a/adapters/dalgo2memory/nested_transaction_test.go
+++ b/adapters/dalgo2memory/nested_transaction_test.go
@@ -19,7 +19,8 @@ var bothTransactionModes = []struct {
 	name string
 	opts []Option
 }{
-	{"default locked mode", nil},
+	{"default (contending) mode", nil},
+	{"single-writer mode", []Option{WithSingleWriterTransactions()}},
 	{"WithOptimisticConcurrency", []Option{WithOptimisticConcurrency()}},
 }
 

--- a/adapters/dalgo2memory/optimistic.go
+++ b/adapters/dalgo2memory/optimistic.go
@@ -381,12 +381,69 @@ func (db *database) runOptimisticReadwriteTransaction(ctx context.Context, f dal
 		if attempt > 0 {
 			runtime.Gosched()
 		}
+		if attempt == attempts-1 && attempts > 1 {
+			// FINAL-ATTEMPT ESCALATION: a transaction that lost every
+			// optimistic attempt runs its last one holding db.mu for the
+			// callback's entire duration, which cannot conflict - nothing can
+			// interleave. This is the progress guarantee real Firestore gives
+			// through server-side locking: contended writers there QUEUE on
+			// document locks and eventually all complete, they do not abort
+			// each other forever. Pure OCC without a queue can starve a
+			// transaction on a hot key indefinitely (measured: 8 workers
+			// incrementing one document exhausted 5 optimistic attempts and
+			// surfaced a raw conflict production would never see); escalation
+			// bounds that at "worst case degrades to the single-writer mode
+			// for one attempt", exactly the semantics of waiting on the lock.
+			//
+			// TxWithAttempts(1) deliberately never escalates - it means "one
+			// optimistic shot", which is what conflict-observation tests use.
+			return db.runEscalatedReadwriteTransaction(ctx, f)
+		}
 		err = db.runOptimisticReadwriteTransactionOnce(ctx, f)
 		if err == nil || !IsTransactionConflict(err) {
 			return err
 		}
 	}
 	return err
+}
+
+// runEscalatedReadwriteTransaction is the final-attempt form of an
+// optimistic-mode transaction (see the escalation comment in
+// runOptimisticReadwriteTransaction): it holds db.mu for the callback's whole
+// duration like the single-writer mode does, but keeps validateVersions true
+// so its commit STAMPS db.versions and db.collectionSeq - concurrent
+// optimistic transactions must see this commit as a conflicting write exactly
+// like any other. Validation itself passes trivially: holding the lock means
+// no other commit can interleave between this transaction's reads and its
+// commit. The snapshot machinery is likewise inert here for the same reason -
+// commitSeq cannot advance mid-transaction.
+func (db *database) runEscalatedReadwriteTransaction(ctx context.Context, f dal.RWTxWorker) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	tx := &optimisticState{
+		db:               db,
+		reads:            make(map[string]uint64),
+		pending:          make(map[string]*pendingEntry),
+		ownerHoldsLock:   true,
+		validateVersions: true,
+	}
+	txState := &transactionState{
+		noReadsAfterWrites: db.noReadsAfterWritesInTransaction,
+		optimistic:         tx,
+	}
+	s := session{db: db, txState: txState}
+	// Nested-transaction stamping: see the identical comment in
+	// runLockedReadwriteTransaction - a nested call must be rejected, not
+	// deadlock on the db.mu this function holds.
+	if err := f(context.WithValue(ctx, transactionInProgressKey{}, true), s); err != nil {
+		return err // buffered writes are discarded: this IS the rollback
+	}
+	if txState.readAfterWriteRejected {
+		// Same poisoning as both other runners: a swallowed ordering
+		// rejection must not commit.
+		return fmt.Errorf("%w: commit refused because a read-after-write was rejected earlier in this transaction", ErrReadAfterWriteInTransaction)
+	}
+	return tx.commit()
 }
 
 // runOptimisticReadwriteTransactionOnce is a single attempt of an

--- a/adapters/dalgo2memory/optimistic_test.go
+++ b/adapters/dalgo2memory/optimistic_test.go
@@ -14,12 +14,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestOptimisticConcurrencyOption checks WithOptimisticConcurrency's own
-// bookkeeping: off by default, on when requested. Everything else in this
-// file exercises the behavior that flag switches on.
-func TestOptimisticConcurrencyOption(t *testing.T) {
-	require.False(t, newDatabase().optimisticConcurrency)
+// TestTransactionModeOptions checks the mode options' bookkeeping around the
+// contention-by-default flip: a plain NewDB() runs optimistic (the Firestore
+// profile), WithSingleWriterTransactions restores the whole-database lock,
+// the deprecated WithOptimisticConcurrency and the profile-naming
+// WithFirestoreProfile both affirm the default, and — because options apply
+// in order — the last one wins in either direction. Everything else in this
+// file exercises the behavior the flag switches between.
+func TestTransactionModeOptions(t *testing.T) {
+	require.True(t, newDatabase().optimisticConcurrency, "contention is the default")
+	require.False(t, newDatabase(WithSingleWriterTransactions()).optimisticConcurrency)
 	require.True(t, newDatabase(WithOptimisticConcurrency()).optimisticConcurrency)
+	require.True(t, newDatabase(WithFirestoreProfile()).optimisticConcurrency)
+	require.True(t, newDatabase(WithFirestoreProfile()).noReadsAfterWritesInTransaction)
+	require.True(t,
+		newDatabase(WithSingleWriterTransactions(), WithFirestoreProfile()).optimisticConcurrency,
+		"options apply in order: the profile re-asserts contention")
+	require.False(t,
+		newDatabase(WithOptimisticConcurrency(), WithSingleWriterTransactions()).optimisticConcurrency,
+		"options apply in order: the single-writer opt-out wins when last")
 }
 
 // TestIsTransactionConflict is the direct unit test for the predicate the
@@ -33,18 +46,18 @@ func TestIsTransactionConflict(t *testing.T) {
 	require.True(t, IsTransactionConflict(fmt.Errorf("wrapped: %w", ErrTransactionConflict)))
 }
 
-// TestDefaultTransactionsRemainSerialized is the regression guard for the
-// behavior this whole feature must not touch: without
-// WithOptimisticConcurrency, RunReadwriteTransaction still takes a
-// whole-database lock for a transaction's entire duration, so a second
-// read-write transaction cannot even START running until the first one's
-// callback returns. This is exactly what makes a "two concurrent claims,
-// exactly one wins" test meaningless against the default mode (see
-// WithOptimisticConcurrency's doc comment) — proving it still holds is what
-// justifies every other test in this file bothering to exist.
-func TestDefaultTransactionsRemainSerialized(t *testing.T) {
+// TestSingleWriterTransactionsSerialize is the regression guard for the
+// intent-named opt-out: under WithSingleWriterTransactions,
+// RunReadwriteTransaction takes a whole-database lock for a transaction's
+// entire duration, so a second read-write transaction cannot even START
+// running until the first one's callback returns. This was NewDB's default
+// before contention was (the flip that made a plain NewDB() the Firestore
+// profile); the mode survives as an explicit choice for backends that
+// genuinely serialize writers and for step-choreographed tests, and this
+// test is what proves the choice still delivers exactly that.
+func TestSingleWriterTransactionsSerialize(t *testing.T) {
 	ctx := context.Background()
-	db := newDatabase() // no WithOptimisticConcurrency: the pre-existing default
+	db := newDatabase(WithSingleWriterTransactions())
 
 	firstEntered := make(chan struct{})
 	release := make(chan struct{})

--- a/adapters/dalgo2memory/retry_test.go
+++ b/adapters/dalgo2memory/retry_test.go
@@ -54,13 +54,20 @@ func TestOptimisticConcurrencyRetry_ConflictThenSucceeds(t *testing.T) {
 	assert.EqualValues(t, 100, got["n"], "attempt 2 must have read the winning external value (99) and added 1 to it")
 }
 
-// TestOptimisticConcurrencyRetry_PersistentConflictExhaustsDefaultAttempts
-// checks the other side of the bound: a conflict that recurs on every single
-// attempt (the external commit here races EVERY attempt's read, not just the
-// first) must not retry forever — it exhausts defaultTransactionMaxAttempts
-// and returns a final error that still satisfies IsTransactionConflict, so a
-// caller that gives up can still tell why.
-func TestOptimisticConcurrencyRetry_PersistentConflictExhaustsDefaultAttempts(t *testing.T) {
+// TestOptimisticConcurrencyRetry_PersistentConflictEscalatesAndCompletes
+// checks the other side of the bound, whose contract changed when
+// final-attempt escalation landed: a conflict recurring on every optimistic
+// attempt no longer exhausts into a raw error — the LAST attempt runs under
+// the whole-database lock and cannot conflict, so the transaction completes,
+// matching real Firestore's lock queue where contended writers finish rather
+// than abort each other forever. The callback runs exactly once per attempt.
+//
+// The external fracture-commit is guarded to the optimistic attempts only:
+// on the escalated attempt this callback must not perform a top-level write
+// on the same database, since the escalated attempt holds db.mu for the
+// callback's whole duration — the identical (and pre-existing) hazard of the
+// single-writer mode, documented at runEscalatedReadwriteTransaction.
+func TestOptimisticConcurrencyRetry_PersistentConflictEscalatesAndCompletes(t *testing.T) {
 	ctx := context.Background()
 	db := newDatabase(WithOptimisticConcurrency())
 	require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
@@ -71,17 +78,22 @@ func TestOptimisticConcurrencyRetry_PersistentConflictExhaustsDefaultAttempts(t 
 		if _, err := readThingN(ctx, tx, "A"); err != nil {
 			return err
 		}
-		// Unlike the test above, this external commit runs on EVERY
-		// attempt, after that attempt's own read: no attempt can ever
-		// succeed.
-		require.NoError(t, db.Set(ctx, thingRecord("A", callbackRuns+100)))
-		return nil
+		if callbackRuns < defaultTransactionMaxAttempts {
+			// Fracture every OPTIMISTIC attempt's snapshot after its read: no
+			// optimistic attempt can ever commit.
+			require.NoError(t, db.Set(ctx, thingRecord("A", callbackRuns+100)))
+		}
+		return tx.Set(ctx, thingRecord("A", 999))
 	})
 
+	require.NoError(t, err,
+		"the escalated final attempt cannot conflict, so a persistently contended transaction completes")
 	require.Equal(t, defaultTransactionMaxAttempts, callbackRuns,
-		"the callback must run exactly once per attempt, up to the default budget, no more")
-	require.Error(t, err)
-	assert.True(t, IsTransactionConflict(err), "the exhausted retry must still report a classifiable conflict: %v", err)
+		"the callback must run exactly once per attempt: every optimistic attempt, then the escalated one")
+
+	var got map[string]any
+	require.NoError(t, db.Get(ctx, record.NewRecordWithData(thingKey("A"), &got)))
+	assert.EqualValues(t, 999, got["n"], "the escalated attempt's write must be the one that landed")
 }
 
 // TestOptimisticConcurrencyRetry_TxWithAttempts1DisablesRetry checks that
@@ -123,13 +135,18 @@ func TestOptimisticConcurrencyRetry_TxWithAttemptsHonorsExplicitCount(t *testing
 		if _, err := readThingN(ctx, tx, "A"); err != nil {
 			return err
 		}
-		require.NoError(t, db.Set(ctx, thingRecord("A", callbackRuns+100)))
+		if callbackRuns < 3 {
+			// Fracture only the optimistic attempts (1 and 2); the escalated
+			// third attempt holds db.mu, where a top-level write would
+			// deadlock — see runEscalatedReadwriteTransaction.
+			require.NoError(t, db.Set(ctx, thingRecord("A", callbackRuns+100)))
+		}
 		return nil
 	}, dal.TxWithAttempts(3))
 
-	require.Equal(t, 3, callbackRuns, "TxWithAttempts(3) must run exactly 3 attempts, not the default 5 or a single attempt")
-	require.Error(t, err)
-	assert.True(t, IsTransactionConflict(err))
+	require.Equal(t, 3, callbackRuns,
+		"TxWithAttempts(3) must run exactly 3 attempts: 2 optimistic, then the escalated final one — not the default 5, not a single attempt")
+	require.NoError(t, err, "the escalated final attempt completes the transaction")
 }
 
 // TestOptimisticConcurrencyRetry_ReadAfterWriteNotRetried is the required
@@ -177,4 +194,70 @@ func TestLockedModeIgnoresAttemptsOptionSilently(t *testing.T) {
 
 	require.ErrorIs(t, err, errBoom)
 	require.Equal(t, 1, callbackRuns, "the locked mode must not retry regardless of the requested attempt count")
+}
+
+// TestEscalatedAttempt_FailureModes covers the escalated final attempt's two
+// non-commit exits, which are otherwise shadowed by escalation's cannot-
+// conflict guarantee: a callback error still rolls the attempt back, and a
+// swallowed read-after-write rejection still poisons the commit — the same
+// contracts the optimistic and single-writer runners honor.
+func TestEscalatedAttempt_FailureModes(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("callback error discards writes", func(t *testing.T) {
+		db := newDatabase(WithOptimisticConcurrency())
+		require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+		var runs int
+		err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+			runs++
+			if _, err := readThingN(ctx, tx, "A"); err != nil {
+				return err
+			}
+			if runs == 1 {
+				require.NoError(t, db.Set(ctx, thingRecord("A", 2))) // fracture attempt 1
+			}
+			if err := tx.Set(ctx, thingRecord("C", 1)); err != nil {
+				return err
+			}
+			if runs == 2 {
+				return errBoom // fail the ESCALATED attempt itself
+			}
+			return nil
+		}, dal.TxWithAttempts(2))
+		require.ErrorIs(t, err, errBoom)
+		require.Equal(t, 2, runs)
+		exists, existsErr := db.Exists(ctx, thingKey("C"))
+		require.NoError(t, existsErr)
+		assert.False(t, exists, "the escalated attempt's writes must be discarded on callback error")
+	})
+
+	t.Run("swallowed read-after-write poisons the escalated commit", func(t *testing.T) {
+		db := newDatabase(WithOptimisticConcurrency())
+		require.NoError(t, db.Set(ctx, thingRecord("A", 1)))
+		var runs int
+		err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+			runs++
+			if _, err := readThingN(ctx, tx, "A"); err != nil {
+				return err
+			}
+			if runs == 1 {
+				require.NoError(t, db.Set(ctx, thingRecord("A", 2))) // fracture attempt 1
+			}
+			if err := tx.Set(ctx, thingRecord("C", 1)); err != nil {
+				return err
+			}
+			if runs == 2 {
+				_, rawErr := readThingN(ctx, tx, "A") // read after write: rejected
+				require.ErrorIs(t, rawErr, ErrReadAfterWriteInTransaction)
+				// Swallow it, as buggy caller code might.
+			}
+			return nil
+		}, dal.TxWithAttempts(2))
+		require.ErrorIs(t, err, ErrReadAfterWriteInTransaction,
+			"the escalated attempt must refuse to commit after a swallowed ordering rejection")
+		require.Equal(t, 2, runs, "a read-after-write rejection is a code bug, never retried")
+		exists, existsErr := db.Exists(ctx, thingKey("C"))
+		require.NoError(t, existsErr)
+		assert.False(t, exists)
+	})
 }

--- a/adapters/dalgo2memory/retry_test.go
+++ b/adapters/dalgo2memory/retry_test.go
@@ -167,7 +167,7 @@ func TestOptimisticConcurrencyRetry_ReadAfterWriteNotRetried(t *testing.T) {
 // callback having run exactly once.
 func TestLockedModeIgnoresAttemptsOptionSilently(t *testing.T) {
 	ctx := context.Background()
-	db := newDatabase() // default locked mode: no WithOptimisticConcurrency
+	db := newDatabase(WithSingleWriterTransactions()) // single-writer mode: conflicts cannot occur
 
 	var callbackRuns int
 	err := db.RunReadwriteTransaction(ctx, func(context.Context, dal.ReadwriteTransaction) error {

--- a/adapters/dalgo2memory/schema.go
+++ b/adapters/dalgo2memory/schema.go
@@ -52,24 +52,32 @@ func WithInterleavedReadsAndWritesInTransaction() Option {
 }
 
 // WithOptimisticConcurrency selects optimistic-concurrency read-write
-// transactions for this in-memory database instead of the default: without
-// it, RunReadwriteTransaction takes a whole-database lock for the callback's
-// entire duration, so read-write transactions are fully serialized and can
-// never actually contend with one another.
+// transactions for this in-memory database.
 //
-// That default is exactly right for most tests, but it makes one specific
-// class of test lie: a test that claims to prove a real concurrency
-// guarantee — "two concurrent claims of a unique slug, exactly one wins", or
-// "two concurrent bookings for the last remaining place, one is refused" —
-// passes trivially against the default lock, because the two transactions it
-// spawns can never actually run at the same time. It proves nothing about a
-// database, like Firestore, whose transactions really do contend. Production
-// code in this ecosystem relies on exactly this guarantee (see
-// sneat-co/bookius's facade4bookius/booking.go, which does a Get-then-Insert
-// inside RunReadwriteTransaction for slug uniqueness and for capacity), so a
-// test standing in for Firestore needs a mode where the contention is real.
+// Deprecated: this is now NewDB's default behavior, so calling this option is
+// redundant on a plain NewDB(). It still works — it re-asserts optimistic
+// concurrency, which only matters when combined with an earlier
+// WithSingleWriterTransactions() in the same option list, since options apply
+// in order and the last one wins. New code should omit it and rely on the
+// default (or name it via WithFirestoreProfile); existing callers
+// (sneat-co/chessraiders among them) are unaffected and may drop the call at
+// their own pace. This follows the exact deprecation precedent of
+// WithNoReadsAfterWritesInTransaction when strict ordering became the
+// default.
 //
-// With this option, transactions may run concurrently: each buffers the keys
+// The paragraphs below describe the machinery, which is now simply how a
+// plain NewDB() behaves. Before this was the default, a test that claimed to
+// prove a real concurrency guarantee — "two concurrent claims of a unique
+// slug, exactly one wins", or "two concurrent bookings for the last remaining
+// place, one is refused" — passed trivially against the old whole-database
+// lock, because the two transactions it spawned could never actually run at
+// the same time. It proved nothing about a database, like Firestore, whose
+// transactions really do contend. Production code in this ecosystem relies on
+// exactly this guarantee (see sneat-co/bookius's facade4bookius/booking.go,
+// which does a Get-then-Insert inside RunReadwriteTransaction for slug
+// uniqueness and for capacity), which is why contention is now the default.
+//
+// In this mode, transactions may run concurrently: each buffers the keys
 // it reads and the writes it makes locally, touching no shared storage until
 // it commits (when its callback returns nil). At that point it fails with
 // ErrTransactionConflict (test with IsTransactionConflict) if another
@@ -100,16 +108,59 @@ func WithInterleavedReadsAndWritesInTransaction() Option {
 // forcing every adapter to grow an equivalent option and test hook just to
 // stay in the suite would be scope the other adapters never asked for.
 //
-// The default remains the whole-database lock, so transactions still cannot
-// contend unless this option is passed. What the default no longer differs on
-// is ATOMICITY: both modes buffer a transaction's writes and apply them only
-// once its callback returns nil, so a failed transaction discards its writes
-// exactly as Firestore does (see runLockedReadwriteTransaction). Contention is
-// therefore the one remaining transactional difference between the two modes,
-// alongside queries — which the default mode supports inside a read-write
-// transaction and this mode does not.
+// Both modes buffer a transaction's writes and apply them only once its
+// callback returns nil, so a failed transaction discards its writes exactly
+// as Firestore does regardless of this choice (see
+// runLockedReadwriteTransaction).
 func WithOptimisticConcurrency() Option {
 	return func(db *database) {
+		db.optimisticConcurrency = true
+	}
+}
+
+// WithSingleWriterTransactions opts a database out of the default
+// contention-capable transaction machinery: RunReadwriteTransaction takes a
+// whole-database lock for the callback's entire duration, so read-write
+// transactions are fully serialized — a single writer at a time, the way
+// SQLite's database-level write lock behaves. This was NewDB's default before
+// contention was; atomicity is unaffected (writes are buffered and discarded
+// on a failed callback in both modes), and transaction options like
+// dal.TxWithAttempts are silently ignored, since a conflict can never occur.
+//
+// Use this when the in-memory database stands in for a backend that
+// genuinely serializes writers, or for a test that deliberately choreographs
+// step-by-step transaction ordering and needs transactions never to abort.
+// Do NOT reach for it just to make a failing concurrent test pass: if the
+// code under test also runs against Firestore, a test failing with
+// ErrTransactionConflict under the default is exercising real contention
+// that production sees too — silencing it here hides the signal, the same
+// trap WithInterleavedReadsAndWritesInTransaction's doc comment warns about
+// for ordering.
+func WithSingleWriterTransactions() Option {
+	return func(db *database) {
+		db.optimisticConcurrency = false
+	}
+}
+
+// WithFirestoreProfile names the backend a plain NewDB() emulates: Firestore.
+// It re-asserts the full Firestore-faithful transaction bundle — strict
+// read-before-write ordering, snapshot reads with genuine contention, atomic
+// buffered commits, and bounded auto-retry of conflicts — and is therefore an
+// affirming no-op on a plain NewDB(), useful in two ways: as documentation in
+// a test that wants to SAY what it emulates rather than rely on defaults, and
+// as a last-wins reset after earlier options in the same list.
+//
+// Profiles name real backends rather than exposing isolation levels as free
+// dials, because a test double configured into a combination no real backend
+// has emulates nothing — see this package's option naming throughout. A SQL
+// profile family (per-transaction isolation levels, read-your-writes,
+// interleaved ordering) is planned to join it once the interleaved mode
+// gains query overlay support; until then
+// WithInterleavedReadsAndWritesInTransaction and WithSingleWriterTransactions
+// are the SQL-flavoured building blocks.
+func WithFirestoreProfile() Option {
+	return func(db *database) {
+		db.noReadsAfterWritesInTransaction = true
 		db.optimisticConcurrency = true
 	}
 }


### PR DESCRIPTION
**PR 6 of 6 — THE FLIP.** A plain `NewDB()` now runs read-write transactions on the optimistic machinery: genuine contention, snapshot reads, transactional queries with phantom protection, atomic buffered commits, bounded auto-retry (5 attempts, matching the Firestore SDK), and **final-attempt lock escalation** so contended transactions always complete — the progress guarantee real Firestore provides through server-side lock queueing. Every capability landed separately (#121–#127); this PR changes which bundle the bare constructor selects.

## API (additive)
- `WithSingleWriterTransactions()` — intent-named opt-out restoring the whole-DB-lock single-writer mode (SQLite-style). Doc comment forbids using it to silence contention failures.
- `WithFirestoreProfile()` — names the backend the default emulates, per the founder decision on named backend profiles; affirming no-op / last-wins reset. SQL profile family follows with interleaved-mode query overlay.
- `WithOptimisticConcurrency()` — deprecated affirming no-op (precedent: `WithNoReadsAfterWritesInTransaction`).

## Fleet pre-validation (gates this merge)
78 consumer repos measured, each with a control run (dalgo v0.71.0) and a flip-branch run — only deltas count. Results so far (7 sweep agents; 67 measured at dispatch of consumer fixes, remainder in flight):

- **Zero deltas** in 64 of 67 measured repos.
- **Upstream fixes made from findings**: nil options panic → #127 (also a latent production panic via dalgo2firestore); OCC hot-key starvation → final-attempt escalation (this branch).
- **Three real production bugs exposed in consumers** (the flip doing its job — all fixes in flight before this merges): competios rate-limiter over-admission via retry-latched closure (27 admitted vs capacity 5 — identical behavior against real Firestore); chessraiders recovery-dispatch double-claim; commitius replay exactly-once under diagnosis.
- One retry-hostile exact-count assertion (sneat-core-modules) being made retry-tolerant.

**Do not merge until the sweep table and consumer-fix PRs above are complete — merge auto-tags and releases.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jHJHbnHddXPJe72gzyhsx