### PR TITLE
build: declare go 1.26.0 with toolchain go1.27.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/dal-go/dalgo
 
-go 1.27.0
+go 1.26.0
+
+toolchain go1.27.0
 
 require github.com/dal-go/record v0.1.3
 


### PR DESCRIPTION
Founder convention: declare `go 1.26.0` and set `toolchain go1.27.0`, rather than ratcheting the `go` directive itself.

## Why this matters beyond style

dalgo does not need 1.27. The highest `go` directive among its dependencies is **1.24.0** (dal-go/record, RoaringBitmap/roaring), and the full suite builds, vets and passes under a Go 1.26 toolchain — verified: 19 of 19 packages ok with `GOTOOLCHAIN=go1.26.0`. The 1.27.0 directive was stamped incidentally by a `go get` run on a 1.27 toolchain.

Because Go requires every consumer to declare at least its dependencies `go` directive, that incidental value ratcheted the whole fleet:

- consumers could not hold `go 1.26.0` — `go mod tidy` rewrote it straight back to 1.27.0;
- CI pinned to a Go 1.26 toolchain failed with `github.com/dal-go/dalgo@v0.74.0 requires go >= 1.27.0 (running go 1.26.0; GOTOOLCHAIN=local)`;
- CodeQL "default setup", which runs the runner preinstalled toolchain with `GOTOOLCHAIN=local` and cannot be configured from repo code, could not build dalgo consumers at all.

## Verification

- `go mod tidy` leaves `go 1.26.0` + `toolchain go1.27.0` in place (no rewrite back).
- `GOTOOLCHAIN=go1.26.0`: `go build ./...`, `go vet ./...` clean; `go test -count=1 ./...` 19 packages ok.
- dtql schema freshness check clean (`git diff --exit-code dtql/schema`).

Not a breaking change: lowering a minimum `go` directive widens the set of toolchains that can build the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jHJHbnHddXPJe72gzyhsx