### PR TITLE
spec(access): declarative per-principal policies (row-level conditions, bindings, field patterns) + triggers idea

### DIFF
--- a/spec/features/access-policies/README.md
+++ b/spec/features/access-policies/README.md
@@ -17,6 +17,14 @@ Add portable, adapter-independent access policies to DALgo. A secured `dal.DB` e
 
 The product promise is: **define least privilege once and enforce it across every DALgo adapter.**
 
+## Contents
+
+| Child | Description |
+|---|---|
+| [row-level-conditions](row-level-conditions/README.md) | Optional `where`/`check` conditions on allow rules, expressed in the `dal.Condition` AST with runtime variables (`$currentUser`, named variables from context); post-read check for `Get`/`Exists`, AND-rewrite for `Query`, pre-/post-image checks for writes inside a transaction. |
+| [principal-bindings](principal-bindings/README.md) | Rule sets bound to `roles`/`groups`/`users`/`everyone`; principal on context; effective policy = union of the principal's bindings compiled as one policy, then intersected with database policies. |
+| [field-patterns](field-patterns/README.md) | `fields` allow-lists with `*` wildcards on rules: projection/redaction on reads, touched-field checks on writes (list `users` without `passwordHash`). |
+
 ## Problem
 
 DALgo currently provides a common API for records, queries, and transactions, but a component receiving a `dal.DB` or transaction receives all authority exposed by that handle. Applications with extensions, plug-ins, tenants, background jobs, analytics users, or support tooling must rely on convention to keep code inside an allowed subtree. A mistake can write a root collection, enumerate sensitive records, or query data outside the current tenant.

--- a/spec/features/access-policies/field-patterns/README.md
+++ b/spec/features/access-policies/field-patterns/README.md
@@ -1,0 +1,188 @@
+---
+format: https://specscore.md/feature-specification
+status: Draft
+---
+
+# Feature: Field patterns — wildcard field allow-lists on rules
+
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/field-patterns?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/field-patterns?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/field-patterns?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/field-patterns?op=request-change) |
+**Status:** Draft
+**Date:** 2026-09-02
+**Owner:** alex
+**Source Ideas:** row-level-access-conditions
+**Tracking:** [dal-go/dalgo#133](https://github.com/dal-go/dalgo/issues/133)
+
+## Summary
+
+Let an allow rule carry `fields`: an allow-list of field names and dotted
+paths with `*` wildcards (`name`, `address.*`, `public_*`). On reads the
+secured wrapper **projects** a query to the allowed fields and **redacts** point
+reads to them; on writes it requires that every field present (`Insert`,
+`Set`) or touched (`Update`) matches the list. Wildcards for collections are
+the parent feature's path patterns; this extends the same habit to fields.
+
+The canonical case: a caller may list `users` but never receive
+`passwordHash`.
+
+The product promise is: **say which fields once, and reads never return more
+than that, writes never change more than that, on any adapter.**
+
+## Problem
+
+A rule today grants an operation on a whole record. A support tool allowed to
+read `users` sees password hashes; a reporting tool allowed to query `orders`
+sees card tokens; an extension allowed to update a contact can rewrite its
+`ownerID`. Field exposure is decided in application code per endpoint — or not
+at all. Directus lets a permission name allowed fields (`*` or a list); Firestore
+rules can test the keys a write touches. DALgo has neither.
+
+## Design Principles
+
+- **Allow-list, wildcard, dotted.** `fields` names what is allowed; `*` matches
+  one segment; a trailing `.*` matches a subtree. No deny-list in the first
+  slice — the most-specific rule already narrows.
+- **Reads project, writes check.** Projection is pushed into the query where the
+  adapter supports column selection; point reads are redacted in the wrapper.
+- **Conditions may see what callers may not.** A `where`/`check` condition may
+  reference a field outside `fields`; it is evaluated by the wrapper or the
+  engine, never returned.
+- **Fail closed.** A write that mentions a disallowed field is denied whole; a
+  query that cannot be projected is denied rather than returned in full.
+
+## Behavior
+
+### REQ: field-pattern-vocabulary
+
+A rule MUST accept `fields` as a list of patterns. A pattern MUST be a dotted
+path whose segments are literal names or `*`; a trailing `.*` MUST match the
+whole subtree below the preceding path; a `*` inside a segment (`public_*`)
+MUST match a name prefix or suffix. Patterns MUST be validated at construction.
+A rule without `fields` MUST mean all fields, as today.
+
+#### AC-1: pattern-forms
+
+**Given** `fields: [name, address.*, public_*]`
+**When** the fields `name`, `address.city`, `public_bio`, `address`, `email` are tested
+**Then** the first three match and the last two do not.
+
+### REQ: read-projection
+
+For `Query` under a rule with `fields`, the wrapper MUST restrict the query's
+`Columns` to the intersection of the caller's selection (all fields when none
+is given) and the allowed patterns, before delegating; when the adapter cannot
+honour a projection the wrapper MUST redact returned records. For `Get`, the
+wrapper MUST redact the returned record to the allowed fields. Redaction MUST
+remove disallowed fields entirely rather than blanking them, so a caller cannot
+distinguish "absent" from "hidden".
+
+#### AC-1: query-projected
+
+**Given** a rule allowing `Query` on `/users` with `fields: [id, name]` and a recording adapter
+**When** the caller queries `users` selecting all columns
+**Then** the adapter observes a query selecting `id` and `name` only.
+
+#### AC-2: get-redacted
+
+**Given** the same rule
+**When** the caller gets `/users/u1`
+**Then** the returned data contains `id` and `name` and no other field.
+
+### REQ: write-field-check
+
+For `Insert` and `Set`, every field present in the data MUST match an allowed
+pattern; for `Update`, every field path the update touches MUST match; a
+violation MUST deny the whole write (and the whole batch for multi-record
+writes) before delegation. Condition slots (`where`, `check`) MAY reference
+disallowed fields.
+
+#### AC-1: update-outside-fields
+
+**Given** a rule allowing `Update` on `/contacts/*` with `fields: [name, phones.*]`
+**When** the caller updates `ownerID`
+**Then** the update is denied naming `ownerID`.
+
+#### AC-2: condition-may-read-hidden-field
+
+**Given** a rule with `fields: [name]` and `where: ownerID == $currentUser`
+**When** the caller gets their own record
+**Then** the read is allowed and the returned data contains `name` only.
+
+### REQ: precedence-and-composition
+
+`fields` MUST participate in precedence like any other rule attribute: the
+winning rule's list applies. Across policies in an intersection, the effective
+allowed set MUST be the intersection of every applicable rule's allowed fields.
+
+#### AC-1: intersection-across-policies
+
+**Given** a database policy allowing `fields: [id, name, email]` and a context policy allowing `fields: [name, phone]` on the same path
+**When** the caller reads a record
+**Then** only `name` is returned.
+
+## Acceptance Criteria
+
+### AC: pattern-forms (verifies REQ:field-pattern-vocabulary)
+
+**Given** `fields: [name, address.*, public_*]`
+**When** the fields `name`, `address.city`, `public_bio`, `address`, `email` are tested
+**Then** the first three match and the last two do not.
+
+### AC: query-projected (verifies REQ:read-projection)
+
+**Given** a rule allowing `Query` on `/users` with `fields: [id, name]` and a recording adapter
+**When** the caller queries `users` selecting all columns
+**Then** the adapter observes a query selecting `id` and `name` only.
+
+### AC: update-outside-fields (verifies REQ:write-field-check)
+
+**Given** a rule allowing `Update` on `/contacts/*` with `fields: [name, phones.*]`
+**When** the caller updates `ownerID`
+**Then** the update is denied naming `ownerID`.
+
+### AC: intersection-across-policies (verifies REQ:precedence-and-composition)
+
+**Given** a database policy allowing `fields: [id, name, email]` and a context policy allowing `fields: [name, phone]` on the same path
+**When** the caller reads a record
+**Then** only `name` is returned.
+
+## Architecture
+
+- `access.Rule` gains `Fields []FieldPattern`; compiled rules hold a matcher.
+- The secured query executor rewrites `Columns` using the existing
+  [column projection](../../query-column-projection/README.md) support; when an
+  adapter reports it cannot project, the wrapper redacts in the reader.
+- Point-read redaction operates on map data directly and on struct data through
+  the same field access the query model uses, producing a map when a struct
+  cannot be partially populated.
+- Write checks inspect record data (maps or structs via field access) and the
+  `update` operations' field paths.
+- Codecs extend the versioned document model with `fields`.
+
+No adapter is modified.
+
+## Error Handling and Failure Modes
+
+- Invalid pattern: constructor error; `Must…` panics.
+- Write touching a disallowed field: deny whole write/batch; explanation names the field.
+- Query cannot be projected and redaction is impossible for the reader kind: deny.
+- Empty intersection across policies: reads return records with no fields; writes are denied.
+
+## Testing Strategy
+
+- Pattern matcher table tests (literal, `*` segment, prefix/suffix, subtree).
+- Recording adapter tests proving projected queries and redacted reads.
+- Write tests for insert/set/update/multi with allowed and disallowed fields.
+- Intersection tests across database and context policies.
+- Codec round trips.
+- The parent feature's suite re-run with `fields` absent (no change).
+
+## Out of Scope
+
+- Field deny-lists (`except`), field-level *conditions* (a field visible only when …), and computed/derived fields.
+- Encrypting or hashing hidden fields; redaction removes, it does not transform.
+- Index-, cost- or aggregate-aware constraints.
+
+## Open Questions
+
+- Should redaction on struct data return a map, or a zeroed struct with a "redacted fields" side channel? Recommendation: map, so absence is unambiguous.
+- Should a rule be able to allow `fields` for reads and a different list for writes in one rule, or must that be two rules? Recommendation: two rules; simpler precedence.

--- a/spec/features/access-policies/principal-bindings/README.md
+++ b/spec/features/access-policies/principal-bindings/README.md
@@ -1,0 +1,207 @@
+---
+format: https://specscore.md/feature-specification
+status: Draft
+---
+
+# Feature: Principal bindings — policies per user, group and role
+
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/principal-bindings?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/principal-bindings?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/principal-bindings?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/principal-bindings?op=request-change) |
+**Status:** Draft
+**Date:** 2026-09-02
+**Owner:** alex
+**Source Ideas:** row-level-access-conditions
+**Tracking:** [dal-go/dalgo#133](https://github.com/dal-go/dalgo/issues/133)
+
+## Summary
+
+Let a policy document bind **rule sets to principals** — `roles`, `groups`,
+`users`, and `everyone` — and let the request carry its principal (`id`,
+`roles`, `groups`) on the context. The secured wrapper computes the request's
+**effective principal policy** as the union of every rule set the principal is
+bound to, compiled as one policy so the parent feature's precedence resolves
+overlaps, and then intersects that single policy with database-bound policies
+exactly as today. Additive within a principal, monotonic across layers.
+
+The product promise is: **declare once what a role, a group or a user may do,
+in the same document as the paths and rows, and DALgo derives the caller's
+authority from who they are.**
+
+## Problem
+
+Access policies attach to a database handle or to a context; nothing relates
+them to *who is calling*. A host that wants "members may read, admins may
+write, the owner may delete their own" must build the policy per request in
+code, choosing rule sets by role by hand — which is the same per-call-site
+logic that access policies were meant to replace. Directus attaches reusable
+policies to roles or users and unions them; Firestore rules read the caller's
+claims. DALgo has no principal at all.
+
+## Design Principles
+
+- **Identity-agnostic.** DALgo never looks a user up; the host puts a principal
+  on the context. Roles and groups are opaque strings.
+- **Additive within the principal, monotonic across layers.** Bindings union;
+  layers intersect. A binding can never widen a database-level denial.
+- **One policy, one precedence.** The union is compiled as a single policy so
+  most-specific-wins and deny-on-tie resolve overlaps between bindings without
+  a new rule.
+- **Same document, same codec.** Bindings live in the versioned YAML/JSON policy
+  model beside paths, conditions and fields.
+
+## Behavior
+
+### REQ: principal-on-context
+
+The package MUST provide `access.WithPrincipal(ctx, Principal)` where
+`Principal` carries an `ID`, a set of `Roles` and a set of `Groups`, all opaque
+strings, and `access.PrincipalFrom(ctx)`. The principal's `ID` MUST be what
+`$currentUser` resolves to; `$principal.roles` and `$principal.groups` MUST be
+available as array-valued variables in conditions.
+
+#### AC-1: principal-drives-current-user
+
+**Given** a context carrying principal `u1` with role `member`
+**When** a rule conditioned on `ownerID == $currentUser` is evaluated
+**Then** the condition compares against `u1`.
+
+### REQ: bindings-document
+
+A policy document MUST accept a `bindings` section mapping `roles`, `groups`
+and `users` to named rule sets, plus an `everyone` rule set that applies to any
+principal, including an absent one. Rule sets MUST use the same rule shape as
+the parent feature (scopes, operations, effect) including `where`/`check` and
+`fields` when those features are present. A binding MAY reference a rule set
+by name so several roles share one.
+
+#### AC-1: shared-rule-set
+
+**Given** a document whose `editor` and `admin` roles both reference rule set `content-write`
+**When** principals with either role write under the rule set's paths
+**Then** both are allowed by the same rule id.
+
+### REQ: effective-policy-union
+
+For a request, the wrapper MUST collect every rule set bound to the principal's
+`ID`, each of its `Roles`, each of its `Groups`, and `everyone`, and MUST
+compile them into **one** policy for evaluation. Within that policy the parent
+feature's precedence MUST apply unchanged: greatest depth, then literal
+specificity, then deny on tie, declaration order irrelevant. A rule from one
+binding MAY therefore be overridden by a more specific rule from another
+binding, and an equally specific deny from any binding MUST win.
+
+#### AC-1: roles-union
+
+**Given** role `reader` allowing `Get` under `/docs/**` and role `writer` allowing `Insert` there
+**When** a principal with both roles gets and inserts under `/docs/`
+**Then** both operations are allowed.
+
+#### AC-2: specific-deny-across-bindings
+
+**Given** role `member` allowing `ReadWrite` under `/spaces/*/**` and group `suspended` denying `Write` under `/spaces/*/**`
+**When** a suspended member writes under a space
+**Then** the write is denied (equal specificity, deny wins).
+
+### REQ: layer-intersection
+
+The effective principal policy MUST be treated as one more policy in the parent
+feature's intersection with database-bound and context-bound policies. A binding
+MUST NOT reopen a resource a database policy denies. When no binding applies and
+no `everyone` rule set exists, the principal policy MUST deny everything
+(default deny).
+
+#### AC-1: binding-cannot-widen
+
+**Given** a database policy denying `Delete` under `/audit/**` and an `admin` role binding allowing `ReadWrite` there
+**When** an admin deletes under `/audit/`
+**Then** the delete is denied.
+
+#### AC-2: unbound-principal-denied
+
+**Given** a document with no `everyone` rule set and a principal with no bound role, group or user entry
+**When** any operation is evaluated
+**Then** it is denied with an explanation stating that no binding applies.
+
+### REQ: explanations-name-binding
+
+A decision produced through bindings MUST name the binding kind and value
+(`role:admin`, `group:staff`, `user:u1`, `everyone`) alongside the policy and
+rule ids.
+
+#### AC-1: binding-in-explanation
+
+**Given** a denial produced by a rule bound through group `suspended`
+**When** the `DeniedError` is formatted
+**Then** the text contains `group:suspended` and the rule id.
+
+## Acceptance Criteria
+
+### AC: principal-drives-current-user (verifies REQ:principal-on-context)
+
+**Given** a context carrying principal `u1` with role `member`
+**When** a rule conditioned on `ownerID == $currentUser` is evaluated
+**Then** the condition compares against `u1`.
+
+### AC: shared-rule-set (verifies REQ:bindings-document)
+
+**Given** a document whose `editor` and `admin` roles both reference rule set `content-write`
+**When** principals with either role write under the rule set's paths
+**Then** both are allowed by the same rule id.
+
+### AC: roles-union (verifies REQ:effective-policy-union)
+
+**Given** role `reader` allowing `Get` under `/docs/**` and role `writer` allowing `Insert` there
+**When** a principal with both roles gets and inserts under `/docs/`
+**Then** both operations are allowed.
+
+### AC: binding-cannot-widen (verifies REQ:layer-intersection)
+
+**Given** a database policy denying `Delete` under `/audit/**` and an `admin` role binding allowing `ReadWrite` there
+**When** an admin deletes under `/audit/`
+**Then** the delete is denied.
+
+### AC: binding-in-explanation (verifies REQ:explanations-name-binding)
+
+**Given** a denial produced by a rule bound through group `suspended`
+**When** the `DeniedError` is formatted
+**Then** the text contains `group:suspended` and the rule id.
+
+## Architecture
+
+- `access.Principal` and the context helpers live in the `access` package.
+- The document model gains `ruleSets` (named) and `bindings` (`roles`, `groups`,
+  `users`, `everyone` → rule-set names). Codecs extend the versioned model.
+- A `PrincipalPolicySet` compiles the document once; per request it selects the
+  bound rule sets and compiles their union into an `AccessPolicy`, cached by
+  the sorted tuple of binding keys so repeated requests by the same role
+  combination do not recompile.
+- The secured wrapper treats the derived policy as one more entry in its
+  intersection; no change to the evaluator.
+
+No adapter is modified.
+
+## Error Handling and Failure Modes
+
+- Binding references an unknown rule set: document error at load.
+- No binding applies and no `everyone`: deny with an explanation naming the principal id (never its roles' contents beyond names).
+- Principal absent from context and document has an `everyone` rule set: only `everyone` applies.
+- Conflicting equally specific rules across bindings: deny wins, as in the parent.
+
+## Testing Strategy
+
+- Document round-trip fixtures with rule sets and bindings in YAML and JSON.
+- Union/precedence table tests across two, three and many bindings, reversed declaration order.
+- Intersection tests proving no widening against database and context policies.
+- Cache tests: identical binding tuples reuse one compiled policy; different tuples do not.
+- The parent feature's full suite re-run with a bindings document producing the same effective policy.
+
+## Out of Scope
+
+- Storing or resolving memberships; the host supplies the principal.
+- Role hierarchies or inheritance between roles (a role is a flat name).
+- Per-principal audit selection (audit policies remain path-only).
+- Time-bound or conditional bindings ("admin until Friday").
+
+## Open Questions
+
+- Should role and group names accept wildcard patterns in bindings (`role:space-*`)? Recommendation: not in the first slice; exact names only.
+- Should `everyone` be able to grant, or only deny, when a principal is absent? Recommendation: it may grant; anonymous read of public paths is a common need.

--- a/spec/features/access-policies/row-level-conditions/README.md
+++ b/spec/features/access-policies/row-level-conditions/README.md
@@ -1,0 +1,427 @@
+---
+format: https://specscore.md/feature-specification
+status: Draft
+---
+
+# Feature: Row-level access conditions with runtime variables
+
+> [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/row-level-conditions?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/row-level-conditions?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/row-level-conditions?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/row-level-conditions?op=request-change) |
+**Status:** Draft
+**Date:** 2026-09-02
+**Owner:** alex
+**Source Ideas:** row-level-access-conditions
+**Tracking:** [dal-go/dalgo#133](https://github.com/dal-go/dalgo/issues/133)
+
+## Summary
+
+Extend [hierarchical access policies](../README.md) so that an **allow rule may
+carry a row condition**. The condition is a `dal.Condition` — the same
+expression tree `dal.StructuredQuery` uses and DTQL serialises — over the
+record's fields, with **runtime variables** (`$currentUser`, `$now`, `$principal.roles`,
+named variables, and **path captures** such as `$path.spaceID` bound from a
+named wildcard segment) resolved from the operation's `context.Context`. Two slots follow the
+PostgreSQL row-level-security shape: `where` names the rows the rule applies to;
+`check` names the shape a written row must have afterwards and defaults to
+`where`.
+
+The secured wrapper enforces the condition in the way each operation needs:
+evaluated on the record after a point read; **AND-rewritten into the structured
+query** before execution so the engine filters; evaluated on the pre-image and
+post-image of writes inside the same transaction. Policy documents carry
+conditions in DTQL's condition syntax plus a `param` node.
+
+The product promise is: **say which rows once, and every adapter — including the
+in-memory one — enforces it, engine-side where the engine can.**
+
+## Problem
+
+Access policies are path-scoped. A rule can grant `Update` under
+`/spaces/*/ext/trackus/**` but cannot say "only records the caller created", and
+a reporting tool can be granted `Query` on `orders` only for the whole
+collection, never for one tenant's rows. Every application re-implements these
+predicates in code, per endpoint and per adapter, and the failure mode is
+familiar: one endpoint forgets the check and a whole collection is exposed.
+
+The parent feature reserved this space explicitly ("Query constraints over
+`WHERE` … preserve room for these follow-ups") and kept `Query` a distinct
+operation with the structured query on the request for that reason. Nothing
+evaluates a record's fields today.
+
+## Design Principles
+
+- **One expression vocabulary.** Conditions are `dal.Condition` values. No second
+  predicate language, no parser; DTQL already serialises the tree.
+- **Engine-side when possible, wrapper-side always.** `Query` is rewritten so the
+  engine filters and paging stays correct; point reads and writes are checked by
+  the wrapper because there is nothing to rewrite.
+- **Fail closed.** An unresolved variable, a post-image the wrapper cannot
+  compute, a non-transactional adapter for a conditional write, a condition on a
+  resource kind it cannot apply to — all deny.
+- **Additive.** Unconditional rules, precedence, composition, documents and
+  explanations behave exactly as the parent feature specifies; adding a
+  condition can only narrow.
+- **Explainable without disclosure.** A denial names the rule, the slot and the
+  condition text with parameter names; it never includes resolved values or
+  record contents.
+- **Adapter-independent.** Adapters never see a variable: the wrapper resolves
+  parameters to constants before delegating. No adapter changes are required.
+
+## Behavior
+
+### REQ: condition-vocabulary
+
+A rule condition MUST be a `dal.Condition` composed of `dal.Comparison` nodes
+and And/Or `dal.GroupCondition` nodes. A comparison's left operand MUST be a
+`dal.FieldRef` naming a field of the record under evaluation; its right operand
+MUST be a `dal.Constant`, a `dal.Array` (for `In`) or a **parameter
+expression**. The operators MUST be exactly those the query model defines
+(`==`, `In`, `>`, `>=`, `<`, `<=`). The package MUST introduce a parameter
+expression type in `dal` (a `FieldRef`/`Constant` sibling) whose string form is
+`$<name>`; it MUST be usable in any `dal.StructuredQuery` as well as in policy
+conditions.
+
+#### AC-1: comparison-and-groups
+
+**Given** a rule whose condition is `And(createdBy == $currentUser, status In [draft, review])`
+**When** the policy is constructed
+**Then** construction succeeds and the compiled rule reports both field names it references.
+
+#### AC-2: unsupported-node-rejected
+
+**Given** a rule whose condition's left operand is a constant rather than a field reference
+**When** the policy is constructed
+**Then** construction fails with an error naming the rule and the offending node.
+
+### REQ: rule-condition-slots
+
+A rule MUST accept two optional conditions: `where` and `check`. `check` MUST
+default to `where` when absent. In this feature, conditions MUST be accepted on
+**allow** rules only; constructing a deny rule with a condition MUST fail. A
+condition MUST NOT be accepted on a rule that grants `Truncate`, on a
+collection-group resource rule, or on an opaque-query rule.
+
+#### AC-1: check-defaults-to-where
+
+**Given** an allow rule with only `where: ownerID == $currentUser`
+**When** an `Insert` is evaluated with data whose `ownerID` differs from the current user
+**Then** the insert is denied with the explanation naming the `check` slot.
+
+#### AC-2: conditional-deny-rejected
+
+**Given** a deny rule carrying a `where` condition
+**When** the policy is constructed
+**Then** construction fails and the error states that conditional deny rules are not supported.
+
+### REQ: variable-resolution
+
+The package MUST resolve parameter expressions from the operation context
+through a variables carrier attached with `access.WithVariables(ctx, …)` and a
+convenience `access.WithCurrentUser(ctx, id)`. `$currentUser` MUST resolve from
+that convenience (or from the principal's `ID` when a principal is present);
+`$now` MUST resolve to the evaluation time; `$principal.roles` and
+`$principal.groups` MUST resolve to the principal's role and group sets as
+arrays usable on the right of `In`. All parameters of
+a request MUST be resolved once, before any enforcement step, so one request
+sees one consistent set of values. An unresolved parameter MUST deny the request
+with an explanation naming the parameter and MUST NOT fall back to a default.
+
+#### AC-1: missing-variable-denies
+
+**Given** a rule conditioned on `tenantID == $tenant` and a context carrying no `tenant` variable
+**When** a query on the matching collection is executed
+**Then** the query is denied before the adapter is called and the explanation names `$tenant`.
+
+#### AC-2: consistent-snapshot
+
+**Given** a batch write of three records under a rule conditioned on `$now`
+**When** the batch is evaluated
+**Then** every record is evaluated against the same `$now` value.
+
+### REQ: path-captures
+
+A path pattern MUST accept a **named wildcard segment** written `{name}` in
+place of a single-ID wildcard, matching exactly what `*` matches. When a rule
+under such a pattern is evaluated for a resource, the matched segment value
+MUST be bound to the variable `$path.<name>` for that rule's conditions. A
+`$path.` variable referenced by a condition whose pattern does not capture that
+name MUST fail construction. Captures MUST be available to `where` and `check`
+for every operation, including `Query`, where the capture binds from the
+query's collection path.
+
+#### AC-1: capture-in-condition
+
+**Given** a rule on `/spaces/{spaceID}/ext/trackus/**` conditioned on `spaceID == $path.spaceID`
+**When** a record under `/spaces/s1/ext/trackus/items/i1` whose `spaceID` is `s1` is read, and one whose `spaceID` is `s2`
+**Then** the first read is allowed and the second is denied.
+
+#### AC-2: unknown-capture-rejected
+
+**Given** a rule on `/spaces/*/ext/trackus/**` conditioned on `$path.spaceID`
+**When** the policy is constructed
+**Then** construction fails naming the missing capture.
+
+### REQ: point-read-enforcement
+
+For `Get`, the wrapper MUST delegate the read and then evaluate `where` against
+the returned record; when the condition is false the wrapper MUST deny and MUST
+NOT return the record's data. For `Exists`, when the winning rule is conditional
+the wrapper MUST perform a read instead of the adapter's existence check so the
+condition can be evaluated; an unconditional rule MUST keep using the adapter's
+existence check. A denied conditional read MUST surface as a `DeniedError`
+unless the policy option to hide denied records is set, in which case it MUST
+surface as `dal.ErrRecordNotFound`.
+
+#### AC-1: get-other-users-record
+
+**Given** an allow rule `Get where ownerID == $currentUser` and a record owned by someone else
+**When** the caller gets that record
+**Then** the call is denied and the returned record carries no data.
+
+#### AC-2: exists-upgraded-to-read
+
+**Given** the same rule and a recording adapter
+**When** the caller checks existence of a record
+**Then** the adapter observes a get, not an exists, and the result reflects the condition.
+
+### REQ: query-rewrite
+
+For a `Query` whose base source is authorised by a conditional allow rule, the
+wrapper MUST resolve the parameters and add the `where` condition to the
+structured query's `Where` as a conjunct (`And`) before delegating, preserving
+the caller's own conditions, `Columns`, `OrderBy`, `Limit`, `Offset` and cursor.
+When several policies each contribute a conditional allow for the same source,
+all their conditions MUST be conjoined. Joined sources MUST be treated the same
+way, each with its own rules. A conditional rule MUST NOT authorise a
+collection-group query or an opaque query; those keep the parent feature's
+explicit-rule requirement. The wrapper MAY, when a strict option is set,
+re-evaluate `where` on returned records whose projection includes every
+referenced field, and MUST deny the result set if any record fails.
+
+#### AC-1: tenant-slice
+
+**Given** an allow rule `Query where tenantID == $tenant` on `/orders` and a context with `tenant = t1`
+**When** the caller queries `orders` with `Limit 10` ordered by `createdAt`
+**Then** the adapter executes a query whose `Where` conjoins `tenantID == "t1"` with the caller's conditions, and the ten returned rows all belong to `t1`.
+
+#### AC-2: conditions-conjoined-across-policies
+
+**Given** a database policy conditioning `Query` on `tenantID == $tenant` and a context policy conditioning it on `status == active`
+**When** the caller queries the collection
+**Then** the delegated query's `Where` contains both conjuncts.
+
+#### AC-3: no-variables-reach-adapter
+
+**Given** any conditional rule
+**When** the wrapper delegates a query
+**Then** the delegated query contains no parameter expressions, only constants.
+
+### REQ: write-enforcement
+
+Conditional writes MUST be enforced as follows. `Insert`: evaluate `check` on
+the new data. `Set`: read the pre-image inside the transaction; if it exists,
+evaluate `where` on it; evaluate `check` on the new data. `Update`: read the
+pre-image, evaluate `where` on it, compute the post-image by applying the update
+and evaluate `check` on it; if the wrapper cannot compute the post-image for the
+update's operations it MUST deny. `Delete`: read the pre-image and evaluate
+`where` on it. Multi-record writes MUST be evaluated in full before any record
+is written and denied whole if any record fails. On an adapter without
+transactions, a conditional write MUST be denied unless the policy sets an
+explicit best-effort option, in which case the pre-image read precedes the
+write without isolation and the decision explanation states so.
+
+#### AC-1: cannot-take-ownership
+
+**Given** an allow rule `Set where ownerID == $currentUser` and an existing record owned by another user
+**When** the caller sets that key with data whose `ownerID` is the caller
+**Then** the write is denied because `where` fails on the pre-image.
+
+#### AC-2: update-post-image
+
+**Given** an allow rule `Update where ownerID == $currentUser check ownerID == $currentUser`
+**When** the caller updates their own record by setting `ownerID` to someone else
+**Then** the update is denied because `check` fails on the computed post-image.
+
+#### AC-3: batch-all-or-nothing
+
+**Given** a conditional `Delete` rule and a multi-delete where one key's pre-image fails `where`
+**When** the batch is executed
+**Then** nothing is deleted.
+
+### REQ: precedence-with-conditions
+
+The parent feature's precedence — greatest depth, then literal specificity,
+then deny on tie, declaration order irrelevant — MUST be unchanged. A
+conditional rule whose condition evaluates false MUST be treated as not
+matching for that record. An unconditional deny at the same specificity as a
+conditional allow MUST still win. Composition across policies MUST remain
+intersection: a conditional allow in one policy cannot reopen a denial in
+another.
+
+#### AC-1: unconditional-suite-unchanged
+
+**Given** the parent feature's complete acceptance suite
+**When** it is re-run with conditional rules added at every depth of every policy
+**Then** every unconditional request receives the same decision as before.
+
+#### AC-2: conditional-allow-cannot-reopen
+
+**Given** a database policy denying `Update` under `/system/**` and a context policy allowing `Update where ownerID == $currentUser` there
+**When** the owner updates a record under `/system/`
+**Then** the update is denied.
+
+### REQ: portable-condition-documents
+
+YAML and JSON policy documents MUST accept `where` and `check` on a rule, each
+holding a condition in the **DTQL condition syntax** (`op`/`left`/`right`
+comparisons, `and`/`or` groups, `field`/`value`/`values` expressions) extended
+with a `param: <name>` expression. Documents without conditions MUST remain
+valid unchanged. DTQL MUST gain the same `param` expression so a saved query and
+a policy condition are written identically; that DTQL change is specified as a
+change request on the [`dtql`](../../dtql/README.md) feature and referenced here.
+
+#### AC-1: yaml-roundtrip
+
+**Given** a YAML policy with a rule carrying `where: { op: "==", left: { field: ownerID }, right: { param: currentUser } }`
+**When** it is decoded, evaluated against fixtures, encoded and decoded again
+**Then** every decision is identical across both decodings.
+
+### REQ: explanations-without-values
+
+A denial caused by a condition MUST carry a decision whose explanation names the
+policy, the rule, the slot (`where` or `check`) and the condition in its string
+form with parameter names. It MUST NOT include resolved parameter values or any
+field value of the record.
+
+#### AC-1: no-leak
+
+**Given** a denied conditional `Get` on a record with a secret field
+**When** the `DeniedError` is formatted
+**Then** the text contains the rule id and `$currentUser`, and contains neither the resolved user id nor any record value.
+
+## Acceptance Criteria
+
+### AC: comparison-and-groups (verifies REQ:condition-vocabulary)
+
+**Given** a rule whose condition is `And(createdBy == $currentUser, status In [draft, review])`
+**When** the policy is constructed
+**Then** construction succeeds and the compiled rule reports both field names it references.
+
+### AC: conditional-deny-rejected (verifies REQ:rule-condition-slots)
+
+**Given** a deny rule carrying a `where` condition
+**When** the policy is constructed
+**Then** construction fails and the error states that conditional deny rules are not supported.
+
+### AC: missing-variable-denies (verifies REQ:variable-resolution)
+
+**Given** a rule conditioned on `tenantID == $tenant` and a context carrying no `tenant` variable
+**When** a query on the matching collection is executed
+**Then** the query is denied before the adapter is called and the explanation names `$tenant`.
+
+### AC: capture-in-condition (verifies REQ:path-captures)
+
+**Given** a rule on `/spaces/{spaceID}/ext/trackus/**` conditioned on `spaceID == $path.spaceID`
+**When** a record under `/spaces/s1/ext/trackus/items/i1` whose `spaceID` is `s1` is read, and one whose `spaceID` is `s2`
+**Then** the first read is allowed and the second is denied.
+
+### AC: get-other-users-record (verifies REQ:point-read-enforcement)
+
+**Given** an allow rule `Get where ownerID == $currentUser` and a record owned by someone else
+**When** the caller gets that record
+**Then** the call is denied and the returned record carries no data.
+
+### AC: tenant-slice (verifies REQ:query-rewrite)
+
+**Given** an allow rule `Query where tenantID == $tenant` on `/orders` and a context with `tenant = t1`
+**When** the caller queries `orders` with `Limit 10` ordered by `createdAt`
+**Then** the adapter executes a query whose `Where` conjoins `tenantID == "t1"` with the caller's conditions, and the ten returned rows all belong to `t1`.
+
+### AC: cannot-take-ownership (verifies REQ:write-enforcement)
+
+**Given** an allow rule `Set where ownerID == $currentUser` and an existing record owned by another user
+**When** the caller sets that key with data whose `ownerID` is the caller
+**Then** the write is denied because `where` fails on the pre-image.
+
+### AC: unconditional-suite-unchanged (verifies REQ:precedence-with-conditions)
+
+**Given** the parent feature's complete acceptance suite
+**When** it is re-run with conditional rules added at every depth of every policy
+**Then** every unconditional request receives the same decision as before.
+
+### AC: yaml-roundtrip (verifies REQ:portable-condition-documents)
+
+**Given** a YAML policy with a rule carrying a `where` condition using `param: currentUser`
+**When** it is decoded, evaluated against fixtures, encoded and decoded again
+**Then** every decision is identical across both decodings.
+
+### AC: no-leak (verifies REQ:explanations-without-values)
+
+**Given** a denied conditional `Get` on a record with a secret field
+**When** the `DeniedError` is formatted
+**Then** the text contains the rule id and `$currentUser`, and contains neither the resolved user id nor any record value.
+
+## Architecture
+
+- **`dal`** gains a parameter expression type (string form `$<name>`), usable in
+  `StructuredQuery` conditions. Adapters are not required to understand it: the
+  secured wrapper substitutes constants before delegating, and an adapter that
+  receives a parameter unexpectedly returns `dal.ErrNotSupported`.
+- **`access`** extends `Rule` with `Where` and `Check` (`dal.Condition`), the
+  compiled rule with the referenced field set, and the evaluator with a
+  record-condition step. Variables travel on `context.Context`
+  (`WithVariables`, `WithCurrentUser`); resolution produces a substituted
+  condition per request.
+- **Condition evaluation over record data** reuses the in-memory condition
+  evaluator that `dalgo2memory` already implements to execute structured
+  queries; it is extracted into a shared package so the adapter and the policy
+  wrapper share one implementation. Struct data is evaluated through the same
+  field access the query model uses; map data directly.
+- **Path patterns** gain named captures (`{name}`), compiled to the same
+  matcher as `*`; the match records the bound values for the rule's evaluation.
+- **Query rewrite** operates on `dal.StructuredQuery` only; text or otherwise
+  opaque queries keep the parent feature's explicit-rule rule.
+- **Pre-image capture** for conditional writes is one step in the secured
+  write path, executed inside the caller's transaction (or one the wrapper
+  opens); it is designed to be shared with the pre-image the triggers idea
+  needs.
+- **Codecs** extend the versioned document model with `where`/`check` using
+  DTQL's condition mapping plus `param`.
+
+No adapter is modified.
+
+## Error Handling and Failure Modes
+
+- Unresolved parameter: deny before delegation; explanation names the parameter.
+- Post-image not computable for an update: deny; explanation names the update operation.
+- Conditional write on a non-transactional adapter without the best-effort option: deny.
+- Condition references a field absent from the record: the comparison is false; the request is denied by that rule (fail closed), never treated as a match.
+- Condition on a deny rule, on `Truncate`, on a collection-group or opaque-query rule: constructor error; `Must…` panics.
+- Strict re-evaluation after a query finds a violating record: deny the whole result; explanation names the rule.
+- Denied conditional `Get`/`Exists`: `DeniedError` (default) or `ErrRecordNotFound` (hide option), never data.
+
+## Testing Strategy
+
+- Table tests for condition construction, referenced-field extraction, slot defaulting and constructor rejections.
+- Evaluator tests over struct and map records, missing fields, `In` arrays, and every operator.
+- Recording fake sessions proving: `Exists` upgrade to a read, delegated queries contain constants only, pre-image reads occur inside the transaction, batches deny whole.
+- Query-rewrite tests preserving caller `Where`, `Columns`, `OrderBy`, `Limit`, `Offset` and cursor, on single and joined sources, across multiple policies.
+- The parent feature's full acceptance suite re-run with conditional rules injected (no decision changes for unconditional requests).
+- `end2end` conformance cases for conditional policies on `dalgo2memory`, `dalgo2sql` (SQLite and PostgreSQL) and `dalgo2firestore`.
+- Codec round-trip fixtures in YAML and JSON, including invalid `param` shapes.
+- Explanation-text tests asserting the absence of resolved values and record contents.
+
+## Out of Scope
+
+- Conditional **deny** rules (need negation in the query AST).
+- Field-level constraints, projections or redaction.
+- Conditions referencing other records, sub-queries or aggregates.
+- Push-down to adapter-native row-level security (PostgreSQL RLS, Firestore rules); left as a later optional capability.
+- Any change to adapters' query execution.
+- Persisting variables, sessions or identity; the host supplies them on the context.
+
+## Open Questions
+
+- Default behaviour of a denied conditional point read: `DeniedError` (recommended, consistent and explainable) or `ErrRecordNotFound` (resists enumeration)? The hide option exists either way; the default is the decision.
+- Should the parameter expression live in `dal` (usable by any query) or in `access` only? Recommended: `dal`, because DTQL and DataTug need it independently.
+- Should the `dtql` change (the `param` node) be filed as a change request on the `dtql` feature before this feature leaves Draft?
+- Which named variables, beyond `currentUser` and `now`, deserve a built-in convenience?

--- a/spec/ideas/README.md
+++ b/spec/ideas/README.md
@@ -27,7 +27,9 @@ The Idea format follows [SpecScore](https://specscore.md/idea-specification).
 | [query-group-by-aggregation](query-group-by-aggregation.md) | Implemented | 2026-06-05 | alex | query-group-by-aggregation |
 | [recordops](recordops.md) | Approved | 2026-05-15 | alex | — |
 | [recordset-computed-columns](recordset-computed-columns.md) | Specified | 2026-06-02 | alex | recordset-computed-columns |
+| [row-level-access-conditions](row-level-access-conditions.md) | Specifying | 2026-09-02 | alex | access-policies/row-level-conditions, access-policies/principal-bindings, access-policies/field-patterns |
 | [transaction-message](transaction-message.md) | Approved | 2026-06-02 | alex | — |
+| [triggers-and-webhooks](triggers-and-webhooks.md) | Draft | 2026-09-02 | alex | — |
 
 ## Open Questions
 

--- a/spec/ideas/row-level-access-conditions.md
+++ b/spec/ideas/row-level-access-conditions.md
@@ -1,0 +1,191 @@
+---
+format: https://specscore.md/idea-specification
+status: Specifying
+---
+# Idea: Declarative per-principal policies with row-level conditions, path captures and field patterns
+
+**Status:** Specifying
+**Date:** 2026-09-02
+**Owner:** alex
+**Promotes To:** access-policies/row-level-conditions, access-policies/principal-bindings, access-policies/field-patterns
+**Supersedes:** —
+**Related Ideas:** extends:access-policies
+
+## Problem Statement
+
+How might we let people declare, in one portable document, what a user, a
+group or a role may do — down to *which rows* ("records where `createdBy` is
+the current user", "orders where `tenantID` is the caller's tenant") and *which
+fields* — using wildcard paths and DTQL conditions the way Firestore security
+rules read, so that ownership, tenant isolation and field exposure are enforced
+once across every DALgo adapter, and ad-hoc reporting built on DALgo can be
+granted a safe slice of a collection without a data-model change?
+
+## Context
+
+[Access policies](access-policies.md) are **path-scoped**: a rule allows or
+denies an operation on a structural path such as `/spaces/*/ext/trackus/**`.
+They cannot express a predicate over the record, cannot restrict fields, and
+have no notion of *who* — a policy is attached to a database handle or a
+context, never to a role or a user. The original idea reserved the room
+deliberately ("field, predicate, projection, index, and cost constraints"). That
+room is still empty: nothing in the `access` package evaluates a record's fields
+(verified against `access/*.go` on 2026-09-02).
+
+The consequence is that every application re-implements row and field rules in
+code, per call site and per adapter, and the same class of bug recurs: an
+[`AdminOnly` check missing on one endpoint](https://github.com/sneat-co/backstage/blob/main/docs/roadmaps/ecosystem-roadmap-2026-H2.md)
+grants a whole collection.
+
+Two systems prove the shape. **Firestore security rules** match paths with
+wildcards and named captures (`/spaces/{spaceID}/...`), grant per operation
+(`get`, `list`, `create`, `update`, `delete`), and test `resource.data` (the
+existing row) and `request.resource.data` (the row after the write) against
+`request.auth`. **Directus** attaches reusable policies to roles *or* users,
+unions them, and filters with runtime variables (`$CURRENT_USER`); PostgreSQL
+row-level security names the same two slots `USING` and `WITH CHECK`. None of
+them is portable across DALgo's adapters or present in the in-memory test
+adapter.
+
+The founder's direction (2026-09-02): row-level conditions are "super useful for
+DataTug and any ad-hoc reporting built on top of dalgo"; **internally use
+`dal.Condition`, but users should declare policies declaratively, per
+user/group/role, using DTQL**; add wildcard patterns for tables and fields;
+"think Firestore rules". Tracked as
+[dal-go/dalgo#133](https://github.com/dal-go/dalgo/issues/133).
+
+## Recommended Direction
+
+**One declarative policy document — YAML, conditions in DTQL, bound to
+principals — compiled to the existing `access` model plus `dal.Condition`, and
+enforced by the secured wrapper in the way each operation needs.** Three parts,
+each its own child feature of access-policies, shipped in this order.
+
+**1. Row-level conditions (`access-policies/row-level-conditions`).** An allow
+rule may carry `where` (the rows it applies to — `resource.data` in Firestore
+terms) and `check` (the shape a written row must have afterwards —
+`request.resource.data`; defaults to `where`). Both are `dal.Condition` trees:
+`Comparison` and And/Or groups, the same AST `dal.StructuredQuery` uses and DTQL
+serialises — no second predicate language. Variables are a new parameter
+expression resolved from the context and substituted before any adapter sees a
+query: `$currentUser`, `$now`, `$principal.roles`, named variables, and
+**path captures** — a wildcard segment may be named (`/spaces/{spaceID}/**`) and
+referenced as `$path.spaceID`. Enforcement per operation: `Get`/`Exists`
+evaluate `where` on the read record; `Query` **AND-rewrites** `where` into the
+structured query so the engine filters and paging stays correct; `Insert`
+evaluates `check`; `Set`/`Update` evaluate `where` on the pre-image and `check`
+on the post-image inside the same transaction; `Delete` evaluates `where` on the
+pre-image. Conditions on allow rules only in the first slice (a conditional deny
+needs a `NOT`/`!=` the AST lacks). Precedence, composition and explanations are
+unchanged; denials never leak values.
+
+**2. Principal bindings (`access-policies/principal-bindings`).** A document
+binds rule sets to `roles`, `groups`, `users` and `everyone`. The request's
+principal (`id`, `roles`, `groups`) travels on the context. The effective policy
+for a request is the **union** of the rule sets its principal is bound to,
+compiled as *one* policy — so most-specific-wins and deny-on-tie resolve
+overlaps exactly as today — and that single principal policy then
+**intersects** with database-bound policies, so a binding can never reopen what
+the database denies. Additive within the principal (Directus), monotonic across
+layers (DALgo).
+
+**3. Field patterns (`access-policies/field-patterns`).** A rule may carry
+`fields`: an allow-list of field names and dotted paths with `*` wildcards
+(`name`, `address.*`, `public_*`). On reads the wrapper limits a query's
+projection and redacts point reads to the allowed fields; on writes only allowed
+fields may be present (`Insert`/`Set`) or touched (`Update`). Wildcards for
+*tables* are already the path patterns; this extends the same habit to fields.
+
+**The document, in Firestore-rules terms.** `match` = a path pattern with
+captures; `allow get, list, create, update, delete` = the operation vocabulary;
+`if resource.data.owner == request.auth.uid` = `where` with `$currentUser`;
+`request.resource.data` = `check`; `request.auth.token.role` = the principal's
+roles, available both as bindings and as `$principal.roles` in conditions. What
+DALgo adds that Firestore rules lack: portability across engines, engine-side
+query rewriting, and the in-memory adapter enforcing the same document in tests.
+
+## Alternatives Considered
+
+- **Post-filter everything in the wrapper (no query rewrite).** Simple and
+  adapter-neutral, but it breaks `Limit`/`Offset` and cursor semantics (a page
+  of 10 may shrink to 3), moves the whole collection over the wire, and cannot
+  be verified when the query projects away the condition's fields. Rewrite is
+  the primary mechanism; post-filter stays as an optional strict-mode check.
+- **Map conditions to native row-level security per adapter** (PostgreSQL RLS,
+  Firestore rules). Strong defence in depth, but only two adapters have it,
+  the in-memory adapter has none, and it splits the policy into per-backend
+  dialects — the exact non-portability access policies exist to remove. Left
+  as a later push-down capability an adapter may advertise.
+- **A separate predicate language for policies** (CEL, a Firestore-rules-like
+  grammar, a mini-DSL). Adds a parser, an evaluator and a second thing to
+  learn; the query AST already has the operators the use cases need and DTQL
+  already serialises it. The Firestore-rules *concepts* are adopted; its syntax
+  is not.
+- **Union across all policies (Directus-style additive everywhere).** Would let
+  a context policy widen a database policy, which breaks the parent feature's
+  monotonic-composition guarantee. Union is confined to the bindings of one
+  principal; layers still intersect.
+- **Conditions on deny rules in the first slice.** Attractive for "everything
+  except locked rows", but without `NOT`/`!=` in the AST a conditional deny
+  cannot be rewritten into a query, so it would silently fall back to
+  post-filtering. Deferred until the AST grows negation.
+
+## MVP Scope
+
+Part 1 in full: `where`/`check` on allow rules with `Comparison` and And/Or
+groups, `$currentUser`, `$now`, `$principal.*`, named variables and path
+captures; enforced for `Get`, `Exists`, `Query` (AND-rewrite), `Insert`, `Set`,
+`Update`, `Delete`; YAML/JSON codec support; DTQL `param` node; conformance on
+`dalgo2memory` and the `end2end` suite; denial explanations without values.
+Parts 2 and 3 are specified alongside and follow in the next two releases, in
+that order: bindings first because a reporting tool needs "this role may query
+these rows" before it needs field masks. Timebox: one `dalgo` release per part.
+
+## Not Doing (and Why)
+
+- Conditional **deny** rules — need negation in the query AST first; deferred
+- A Firestore-rules-syntax parser — concepts adopted, syntax not; YAML + DTQL is
+  the document
+- Conditions that reference other records or sub-queries (Firestore's `get()`
+  in rules) — no sub-query node in the AST and no cost model; single-record
+  predicates only, designed so a bounded lookup can be added later
+- Adapter-native push-down (PostgreSQL RLS, Firestore rules) — a later optional
+  capability; the wrapper must be complete without it
+- Identity, sessions, role storage — the host puts the principal on the
+  context; DALgo never looks users up
+- Best-effort checking on non-transactional adapters by default — fail closed;
+  an explicit opt-in exists for adapters that cannot open a transaction
+
+## Key Assumptions to Validate
+
+| Tier | Assumption | How to validate |
+|------|------------|-----------------|
+| Must-be-true | AND-rewriting a rule condition into `dal.StructuredQuery.Where` preserves the caller's results exactly (same rows minus the forbidden ones), including `Limit`, `Offset`, `OrderBy` and cursors, on every adapter. | Extend the `end2end` conformance suite with conditional-policy cases per adapter; compare rewritten results against an unconstrained query filtered in memory. |
+| Must-be-true | Pre-image reads for conditional `Set`/`Update`/`Delete` can run inside the same read-write transaction on every transactional adapter without changing adapter code. | Prove through the secured wrapper against `dalgo2memory`, `dalgo2sql` (SQLite/PostgreSQL) and `dalgo2firestore`; a concurrent writer changing ownership between read and write must be rejected by the transaction, not slip through. |
+| Must-be-true | Union-within-principal, intersection-across-layers keeps the parent feature's guarantees: order independence, most-specific wins, deny on tie, and no widening of a database denial. | Re-run the whole access-policies acceptance suite with bindings and conditions added at every depth; no decision may change for unconditional requests; add widening-attempt cases that must deny. |
+| Should-be-true | The DTQL condition syntax plus `param` and path captures is enough for policy documents; no separate grammar is needed. | Author the Sneat extension policies, a DataTug tenant-reporting policy and a Firestore-rules sample translated one-to-one, in YAML; round-trip through the codec and compare decisions. |
+| Should-be-true | Field patterns can be enforced as projection on reads and touched-field checks on writes without adapter changes. | Prototype on `dalgo2memory` and `dalgo2sql`; a query for `*` under a `fields: [name]` rule must reach the adapter as a projection of `name`. |
+| Should-be-true | `Exists` upgraded to a read for conditional rules is an acceptable cost. | Measure on `dalgo2firestore`; document the cost; keep unconditional `Exists` untouched. |
+| Might-be-true | Adapters with native row-level security can accept a push-down of the same condition later without changing the policy documents. | Defer; keep the condition as a `dal.Condition` value the adapter can inspect. |
+
+## SpecScore Integration
+
+- **New Features this would create:** [access-policies/row-level-conditions](../features/access-policies/row-level-conditions/README.md), [access-policies/principal-bindings](../features/access-policies/principal-bindings/README.md), [access-policies/field-patterns](../features/access-policies/field-patterns/README.md)
+- **Existing Features affected:** [access-policies](../features/access-policies/README.md) (rule model, secured wrapper, codecs, path patterns gain named captures), [dtql](../features/dtql/README.md) (parameter expression node), the query builder (`dal.Condition` gains a parameter expression)
+- **Dependencies:** none beyond the shipped access-policies feature; shares the pre-image read mechanism and the condition/parameter machinery with [triggers-and-webhooks](triggers-and-webhooks.md)
+
+## Open Questions
+
+- Should a row-level denial on `Get` surface as a `DeniedError` (explainable,
+  consistent with path denials) or as `ErrRecordNotFound` (RLS-style, resists
+  enumeration)? Recommendation: `DeniedError` by default with a policy option to
+  hide denied records.
+- Where do role and group *memberships* come from — always the host via the
+  context, or may a binding document also declare group membership? Recommendation:
+  host only; DALgo stays identity-agnostic.
+- Should the DTQL parameter node be specified inside the `dtql` feature as a
+  change request, or inside the row-level-conditions feature? Recommendation:
+  change request on `dtql`, referenced from the feature.
+- Should a bounded cross-record lookup (Firestore's `get()` in rules) be
+  designed into the condition vocabulary now, so the slot exists, or left
+  entirely to a later idea?

--- a/spec/ideas/triggers-and-webhooks.md
+++ b/spec/ideas/triggers-and-webhooks.md
@@ -1,0 +1,158 @@
+---
+format: https://specscore.md/idea-specification
+status: Draft
+---
+# Idea: Triggers and webhooks for trigger-less stores
+
+**Status:** Draft
+**Date:** 2026-09-02
+**Owner:** alex
+**Promotes To:** —
+**Supersedes:** —
+**Related Ideas:** extends:transaction-message, depends_on:row-level-access-conditions
+
+## Problem Statement
+
+How might we let an application react to data changes — run a handler, call a
+webhook — portably across every DALgo adapter, including stores that have no
+native triggers or change feeds (SQLite, files, inGitDB, the in-memory
+adapter), with a delivery guarantee an application can reason about?
+
+## Context
+
+DALgo's hooks run **before** a write: `AddBeforeSaveHook` and
+`AddBeforeDeleteHook` are process-wide validation points in the framework write
+pipeline (`dal/hooks.go`, `dal/write_pipeline.go`). Nothing runs **after** a
+successful write or commit, and nothing leaves the process. Stores with native
+change capture (Firestore listeners, PostgreSQL `LISTEN/NOTIFY` and logical
+replication) expose it in incompatible ways; SQLite, plain files, inGitDB and
+`dalgo2memory` expose nothing at all.
+
+So every consumer rebuilds the same thing above DALgo: the Sneat products each
+run their own schedulers and dispatchers for reminders, renewals and settlement
+timers; a Git-backed store cannot tell a mirror it changed; a reporting tool
+cannot "watch this query". The founder's framing (2026-09-02): *"we can
+introduce triggers and webhooks in dalgo so people can have triggers on
+trigger-less DBs (like SQLite, files, etc.)"*, and the open question of where
+triggers should live at all. Tracked as
+[dal-go/dalgo#134](https://github.com/dal-go/dalgo/issues/134).
+
+Two shipped and specified pieces make this cheaper than it looks. The
+[transaction message](transaction-message.md) gives every change a
+human-readable reason. The access-policies matcher already expresses "which
+paths and operations" and, with
+[row-level conditions](row-level-access-conditions.md), "which rows" — a trigger
+needs exactly those two things plus an action.
+
+## Recommended Direction
+
+**A `triggers` package beside `dal` — not inside `dal.DB` — that turns
+successful writes into change events, matches them against declarative
+triggers, and delivers actions with an at-least-once guarantee built from a
+transactional outbox, so trigger-less stores get triggers without native
+support.**
+
+- **Change event.** Emitted by the framework write pipeline after a successful
+  write (or, inside a transaction, after commit): operation, key, optional
+  pre-image, post-image, transaction id, the transaction `Message()`, timestamp
+  and actor (from context variables). One event per record, batches fan out.
+- **Trigger = match + when + action.** *Match* reuses the access-policies path
+  pattern and operation vocabulary (`/spaces/*/ext/trackus/**`, `Insert|Update`).
+  *When* is an optional `dal.Condition` over the post-image (or pre-image for
+  deletes), the same AST row-level conditions use. *Action* is an in-process
+  handler or a **webhook**: HTTP POST of the event, HMAC-signed, with timeout,
+  exponential-backoff retries and a dead-letter state after N attempts.
+- **Delivery on trigger-less stores = transactional outbox.** When the adapter
+  supports transactions, the pipeline writes the event as a record into an
+  outbox collection **inside the same transaction** as the data write, so
+  commit persists both or neither. A dispatcher — an in-process loop or an
+  explicit `Dispatch(ctx)` call a CLI can drive — reads pending outbox records,
+  evaluates triggers, delivers, and marks them delivered. At-least-once; the
+  outbox record id is the idempotency key the receiver de-duplicates on.
+- **Capability, not assumption.** Adapters without transactions emit
+  best-effort in-process events and report `Guarantee: best-effort`; adapters
+  with native change capture may later implement a `ChangeSource` capability
+  that feeds the same trigger model, replacing the outbox as the event source.
+- **Boundaries.** Triggers decide *that* something happened and *who* is told;
+  they are not a workflow engine. Chained operations, conditions between steps
+  and schedules belong to the consumer (an automation core above DALgo), which
+  subscribes to these events.
+- **Governed like data.** The outbox is an ordinary collection: access policies
+  decide who may read or truncate it, and the audit selector can include it.
+
+## Alternatives Considered
+
+- **Extend the existing before-hooks into after-hooks and stop there.** In-process
+  only, no persistence, lost on crash, no webhooks — the exact thing a
+  trigger-less store cannot offer and the reason applications rebuild
+  dispatchers. After-hooks are a useful degenerate case of the design, not the
+  design.
+- **Rely on each store's native change feed** (Firestore listeners, PostgreSQL
+  replication) and give up on the others. Leaves SQLite, files, inGitDB and
+  the test adapter — the stores DALgo exists to make interchangeable — without
+  triggers, and gives every consumer three integration codepaths.
+- **Put the whole thing in a separate module (`dalgo-triggers`).** Keeps core
+  lean, but the outbox write must happen inside the framework write pipeline to
+  be atomic with the data write, and that pipeline is in `dal`. The split that
+  works is: event model, outbox and matching in `dalgo`; the webhook action's
+  HTTP client is standard library; queue or broker actions live in separate
+  modules.
+- **Polling the store for changes instead of an outbox.** Works nowhere
+  generically (no change timestamps guaranteed), misses deletes, and scans
+  whole collections.
+
+## MVP Scope
+
+Change events for `Insert`, `Set`, `Update` and `Delete` emitted by the write
+pipeline; the outbox collection written in-transaction on transactional
+adapters; a dispatcher with at-least-once delivery, retries, backoff and
+dead-letter; two actions — in-process handler and signed webhook; trigger match
+by path pattern and operation with an optional `when` condition; a
+`Guarantee` capability flag; conformance on `dalgo2memory` and SQLite
+(`dalgo2sql`), proven by a webhook receiver that observes exactly the committed
+changes after a simulated crash between commit and delivery. Timebox: one
+release after the row-level-conditions feature lands.
+
+## Not Doing (and Why)
+
+- A workflow or automation engine (operation chains, schedules, cron) — that is
+  the consumer's layer; triggers emit and deliver, nothing more
+- Exactly-once delivery — at-least-once plus an idempotency key is the honest
+  contract an outbox can keep; exactly-once needs receiver cooperation anyway
+- Cross-collection ordering guarantees — per-outbox order only; global ordering
+  is a broker's job
+- Native change-capture adapters in the MVP — the `ChangeSource` capability is
+  designed for, not built, until a consumer needs lower latency than the
+  outbox gives
+- A UI for triggers — declarative YAML alongside access policies is the
+  authoring surface; anything visual belongs to a product
+
+## Key Assumptions to Validate
+
+| Tier | Assumption | How to validate |
+|------|------------|-----------------|
+| Must-be-true | The outbox record can be written inside the same transaction as the data write on every transactional adapter, from the framework pipeline, without adapter changes. | Prototype on `dalgo2memory` and SQLite via `dalgo2sql`; kill the process between commit and dispatch and confirm the event survives and is delivered on restart. |
+| Must-be-true | Reusing the access-policies path matcher and the `dal.Condition` AST for trigger matching needs no new grammar. | Author the Sneat reminder and the inGitDB-mirror triggers in YAML with the existing vocabulary; anything they cannot express is a design gap, not a grammar request. |
+| Must-be-true | Emitting events from the write pipeline does not change write latency measurably on stores without an outbox and stays within one extra write on stores with one. | Benchmark the pipeline with triggers disabled, enabled-no-match, and enabled-with-outbox on SQLite and memory. |
+| Should-be-true | Capturing a pre-image for `Update`/`Delete` can share the read-before-write mechanism row-level conditions need, so the cost is paid once. | Implement pre-image capture as one pipeline step consumed by both features. |
+| Should-be-true | A signed webhook with retries and a dead-letter state is enough for the first consumers; no broker is needed. | Run the Sneat automation-core prototype and an inGitDB post-commit sync on webhooks only for a month of fixture traffic. |
+| Might-be-true | Adapters with native change capture will want to replace the outbox rather than complement it. | Defer; keep `ChangeSource` as an optional capability behind the same trigger model. |
+
+## SpecScore Integration
+
+- **New Features this would create:** a `triggers` umbrella (change events, outbox and dispatcher, trigger matching, webhook action, guarantee capability) — decomposed at specify time
+- **Existing Features affected:** [transaction-message](../features/transaction-message/README.md) (message carried on the event), [access-policies](../features/access-policies/README.md) (matcher reuse; outbox governed as a collection), the framework write pipeline
+- **Dependencies:** [row-level-access-conditions](row-level-access-conditions.md) for the condition/parameter node and the shared pre-image read; adapters advertise transaction support already
+
+## Open Questions
+
+- Where exactly should triggers live: a `triggers` package in this module, or
+  event model here and dispatcher elsewhere? Recommendation: model, outbox and
+  matching here; broker actions in separate modules.
+- Package and collection naming: `triggers` vs `events` vs `cdc`; the default
+  outbox path (`/_dalgo/outbox/*`?) and whether it is configurable per database.
+- Should the pre-image be captured by default for `Update` and `Delete`, or only
+  when a trigger or a row-level condition needs it? Recommendation: only when
+  needed, decided at pipeline time from the registered triggers and policies.
+- What is the minimum webhook contract (payload shape, signature header, retry
+  schedule) receivers can rely on, and is it versioned like policy documents?


### PR DESCRIPTION
Closes nothing yet; tracks #133 and #134.

- `spec/ideas/row-level-access-conditions.md` (Specifying) — declarative policies in YAML with DTQL conditions compiled to `dal.Condition`; per user/group/role bindings; Firestore-rules-shaped path captures (`/spaces/{spaceID}/**` → `$path.spaceID`); wildcard field patterns.
- `spec/features/access-policies/row-level-conditions/` (Draft) — `where`/`check`, runtime variables, query AND-rewrite, pre-/post-image checks inside the transaction, explanations without values.
- `spec/features/access-policies/principal-bindings/` (Draft) — rule sets bound to roles/groups/users/everyone; union within the principal, intersection across layers.
- `spec/features/access-policies/field-patterns/` (Draft) — `fields` allow-lists with `*`; projection/redaction on reads, touched-field checks on writes (list `users` without `passwordHash`).
- `spec/ideas/triggers-and-webhooks.md` (Draft) — after-commit change events, transactional outbox + dispatcher for trigger-less stores, signed webhooks.

Spec-only. `specscore spec lint` reports no violations in the added files; the 46 pre-existing violations on `main` (stale feature-index rows, plan frontmatter) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEVhqasFJJ3iAcARe7Wts6