### PR TITLE
chore(spec): make specscore lint green; add pinned SpecScore lint CI job

### DIFF
--- a/.github/workflows/specscore.yml
+++ b/.github/workflows/specscore.yml
@@ -1,0 +1,32 @@
+name: SpecScore lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: specscore-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install specscore CLI
+        # Pinned deliberately: an unpinned `latest` install lets a CLI release
+        # change what the lint rules expect and redden main with no repo-side
+        # change (see sneat-co/backstage's specscore.yml for the incident).
+        # Bump in the same commit that updates the spec tree to match.
+        env:
+          SPECSCORE_VERSION: v0.38.4
+        run: |
+          curl -fsSL https://specscore.md/install/get-cli | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Lint spec tree
+        run: specscore spec lint --caller ci

--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -14,26 +14,26 @@ The Feature format follows [SpecScore](https://specscore.md/feature-specificatio
 
 | Feature | Status | Summary |
 |---|---|---|
-| [concurrency-capability](concurrency-capability/README.md) | Implemented | Add `dal.ConcurrencyAware` capability interface embedded in `dal.DB`, plus `NoConcurrency`/`ConcurrencyAvailable` embeddable helper structs, so consumers can size worker pools without engine-specific knowledge. |
-| [dbschema](dbschema/README.md) | Implemented | Umbrella for the schema-description vocabulary AND the read-side (introspection) capability (new top-level `dbschema` package). Tier-1 types (`FieldDef`, `CollectionDef`, `IndexDef`, `Type`, `Precision`, `DefaultExpr`), `SchemaReader` capability interface + helpers, and the shared `NotSupportedError` typed error. Designed for three-tier composition: Tier-2 engine extensions in driver repos; Tier-3 app wrappers in consumers (datatug-cli, etc.). |
-| [ddl](ddl/README.md) | Implemented | Umbrella for the schema-modification execution surface (new top-level `ddl` package). 3-method `SchemaModifier` capability interface (`CreateCollection`, `DropCollection`, `AlterCollection`); composable `AlterOp` model with six constructors (`AddField`, `DropField`, `ModifyField`, `RenameField`, `AddIndex`, `DropIndex`) — all accept `Option` for opt-in idempotency; `TransactionalDDL` capability for atomicity advertisement; `PartialSuccessError` for non-transactional partial failures. Imports `dbschema` for types AND for the shared `NotSupportedError`. |
-| [recordops](recordops/README.md) | Implemented | Umbrella for the `recordops` package — pure, dependency-free analytical / inspection helpers over dalgo record collections. MVP introduces one child: [diff](recordops/diff/README.md) — one baseline vs. N candidates via K-way merge over ID-sorted `iter.Seq2` streams, with four renderers (git-style YAML, by-ID YAML, plain YAML, JSON) and bridge helpers `SliceToSeq` + `ReaderToSeq`. |
-| [transaction-message](transaction-message/README.md) | Approved | — |
-| [recordset-computed-columns](recordset-computed-columns/README.md) | Approved | — |
-| [dtql](dtql/README.md) | Approved | — |
-| [query-joins](query-joins/README.md) | Approved | — |
-| [qualified-orderby-resolution](qualified-orderby-resolution/README.md) | Approved | — |
-| [query-column-projection](query-column-projection/README.md) | Stable | — |
-| [query-group-by-aggregation](query-group-by-aggregation/README.md) | Stable | — |
-| [storage-engine-seam](storage-engine-seam/README.md) | Stable | — |
-| [serialized-storage](serialized-storage/README.md) | Stable | — |
-| [columnar-storage](columnar-storage/README.md) | Stable | — |
-| [columnar-mixed-mode-maps](columnar-mixed-mode-maps/README.md) | Stable | — |
-| [typed-collection](typed-collection/README.md) | Approved | — |
-| [collection-generated-insert](collection-generated-insert/README.md) | Approved | — |
-| [typed-collection-extras](typed-collection-extras/README.md) | Approved | — |
-| [dalgo2namecheap-namecheap-api-adapter](dalgo2namecheap-namecheap-api-adapter/README.md) | Approved | — |
-| [access-policies](access-policies/README.md) | Stable | — |
+| [Concurrency Capability](concurrency-capability/README.md) | Implemented | Add `dal.ConcurrencyAware` capability interface embedded in `dal.DB`, plus `NoConcurrency`/`ConcurrencyAvailable` embeddable helper structs, so consumers can size worker pools without engine-specific knowledge. |
+| [Schema Description Vocabulary & Read Capability (`dbschema`)](dbschema/README.md) | Implemented | Umbrella for the schema-description vocabulary AND the read-side (introspection) capability (new top-level `dbschema` package). Tier-1 types (`FieldDef`, `CollectionDef`, `IndexDef`, `Type`, `Precision`, `DefaultExpr`), `SchemaReader` capability interface + helpers, and the shared `NotSupportedError` typed error. Designed for three-tier composition: Tier-2 engine extensions in driver repos; Tier-3 app wrappers in consumers (datatug-cli, etc.). |
+| [Schema Modification (DDL) Execution Surface (`ddl`)](ddl/README.md) | Implemented | Umbrella for the schema-modification execution surface (new top-level `ddl` package). 3-method `SchemaModifier` capability interface (`CreateCollection`, `DropCollection`, `AlterCollection`); composable `AlterOp` model with six constructors (`AddField`, `DropField`, `ModifyField`, `RenameField`, `AddIndex`, `DropIndex`) — all accept `Option` for opt-in idempotency; `TransactionalDDL` capability for atomicity advertisement; `PartialSuccessError` for non-transactional partial failures. Imports `dbschema` for types AND for the shared `NotSupportedError`. |
+| [`recordops` package](recordops/README.md) | Implemented | Umbrella for the `recordops` package — pure, dependency-free analytical / inspection helpers over dalgo record collections. MVP introduces one child: [diff](recordops/diff/README.md) — one baseline vs. N candidates via K-way merge over ID-sorted `iter.Seq2` streams, with four renderers (git-style YAML, by-ID YAML, plain YAML, JSON) and bridge helpers `SliceToSeq` + `ReaderToSeq`. |
+| [Transaction Message](transaction-message/README.md) | Approved | — |
+| [Computed Columns in recordset (neutral evaluator contract)](recordset-computed-columns/README.md) | Approved | — |
+| [DTQL — YAML serialization of dal.StructuredQuery](dtql/README.md) | Approved | — |
+| [First-class INNER/LEFT joins in dal's query model](query-joins/README.md) | Approved | — |
+| [Source-qualified, multi-key ORDER BY resolution in dalgo2memory](qualified-orderby-resolution/README.md) | Approved | — |
+| [Column selection in the query builder, projected by dalgo2memory](query-column-projection/README.md) | Stable | — |
+| [GROUP BY with aggregation in the query builder, executed by dalgo2memory](query-group-by-aggregation/README.md) | Stable | — |
+| [Pluggable per-collection storage engine seam (dalgo2memory)](storage-engine-seam/README.md) | Stable | — |
+| [Serialized storage engine (dalgo2memory default)](serialized-storage/README.md) | Stable | — |
+| [Columnar storage engine (dalgo2memory)](columnar-storage/README.md) | Stable | — |
+| [Mixed-mode columnar storage for map[string]any collections (dalgo2memory)](columnar-mixed-mode-maps/README.md) | Stable | — |
+| [Typed Collection[K, T] convenience layer (point CRUD)](typed-collection/README.md) | Approved | — |
+| [Generated-ID Insert for Collection[T] (approach C)](collection-generated-insert/README.md) | Approved | — |
+| [Collection[K, T] batch insert and Count/Exists/First terminals](typed-collection-extras/README.md) | Approved | — |
+| [dalgo2namecheap: NameCheap API Adapter](dalgo2namecheap-namecheap-api-adapter/README.md) | Approved | — |
+| [Hierarchical access and audit policies](access-policies/README.md) | Stable | — |
 
 ## Open Questions
 

--- a/spec/plans/2026-06-02-recordset-computed-columns.md
+++ b/spec/plans/2026-06-02-recordset-computed-columns.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/plan-specification
+status: Implemented
+---
+
 # Plan: Computed Columns in recordset (neutral evaluator contract)
 
 **Status:** Implemented

--- a/spec/plans/2026-06-02-transaction-message.md
+++ b/spec/plans/2026-06-02-transaction-message.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/plan-specification
+status: Approved
+---
+
 # Plan: Transaction Message
 
 **Status:** Approved

--- a/spec/plans/2026-06-05-dtql.md
+++ b/spec/plans/2026-06-05-dtql.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/plan-specification
+status: Approved
+---
+
 # Plan: DTQL — YAML serialization of dal.StructuredQuery
 
 **Status:** Approved

--- a/spec/plans/2026-06-05-qualified-orderby-resolution.md
+++ b/spec/plans/2026-06-05-qualified-orderby-resolution.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/plan-specification
+status: Implemented
+---
+
 # Plan: Source-qualified, multi-key ORDER BY resolution in dalgo2memory
 
 **Status:** Implemented

--- a/spec/plans/2026-06-05-query-column-projection.md
+++ b/spec/plans/2026-06-05-query-column-projection.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/plan-specification
+status: Implemented
+---
+
 # Plan: Column selection in the query builder, projected by dalgo2memory
 
 **Status:** Implemented

--- a/spec/plans/2026-06-05-query-group-by-aggregation.md
+++ b/spec/plans/2026-06-05-query-group-by-aggregation.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/plan-specification
+status: Implemented
+---
+
 # Plan: GROUP BY with aggregation in the query builder, executed by dalgo2memory
 
 **Status:** Implemented

--- a/spec/plans/2026-06-05-query-joins.md
+++ b/spec/plans/2026-06-05-query-joins.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/plan-specification
+status: Implemented
+---
+
 # Plan: First-class INNER/LEFT joins in dal's query model
 
 **Status:** Implemented

--- a/spec/plans/2026-06-06-columnar-mixed-mode-maps.md
+++ b/spec/plans/2026-06-06-columnar-mixed-mode-maps.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/plan-specification
+status: Implemented
+---
+
 # Plan: Mixed-mode columnar storage for map[string]any collections (dalgo2memory)
 
 **Status:** Implemented

--- a/spec/plans/2026-06-06-columnar-storage.md
+++ b/spec/plans/2026-06-06-columnar-storage.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/plan-specification
+status: Implemented
+---
+
 # Plan: Columnar storage engine (dalgo2memory)
 
 **Status:** Implemented

--- a/spec/plans/2026-06-06-serialized-storage.md
+++ b/spec/plans/2026-06-06-serialized-storage.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/plan-specification
+status: Implemented
+---
+
 # Plan: Serialized storage engine (dalgo2memory default)
 
 **Status:** Implemented

--- a/spec/plans/2026-06-06-storage-engine-seam.md
+++ b/spec/plans/2026-06-06-storage-engine-seam.md
@@ -1,3 +1,8 @@
+---
+format: https://specscore.md/plan-specification
+status: Implemented
+---
+
 # Plan: Pluggable per-collection storage engine seam (dalgo2memory)
 
 **Status:** Implemented

--- a/spec/plans/access-policies.md
+++ b/spec/plans/access-policies.md
@@ -1,6 +1,6 @@
 ---
 format: https://specscore.md/plan-specification
-status: Approved
+status: Implemented
 ---
 
 # Plan: Implement hierarchical access policies

--- a/spec/plans/collection-generated-insert.md
+++ b/spec/plans/collection-generated-insert.md
@@ -1,6 +1,6 @@
 ---
 format: https://specscore.md/plan-specification
-status: Draft
+status: Implemented
 ---
 # Plan: Collection Generated Insert
 

--- a/spec/plans/typed-collection-extras.md
+++ b/spec/plans/typed-collection-extras.md
@@ -1,6 +1,6 @@
 ---
 format: https://specscore.md/plan-specification
-status: Draft
+status: Implemented
 ---
 # Plan: Typed Collection Extras
 

--- a/spec/plans/typed-collection.md
+++ b/spec/plans/typed-collection.md
@@ -1,6 +1,6 @@
 ---
 format: https://specscore.md/plan-specification
-status: Draft
+status: Implemented
 ---
 # Plan: Typed Collection
 


### PR DESCRIPTION
`specscore spec lint` on `main` reported 46 violations (11 plans without `format:`/`status:` frontmatter, 4 plans whose frontmatter status disagreed with the body, 20 stale feature-index rows). This PR:

- backfills plan frontmatter via `specscore migrate` and aligns the four mismatched statuses;
- resyncs the feature-index rows via `specscore spec lint --fix` (verified: full summaries, no truncation);
- adds `.github/workflows/specscore.yml` running `specscore spec lint` with the CLI pinned to v0.38.4, so the tree stays green.

Result: 0 violations. Spec and workflow files only; no Go changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEVhqasFJJ3iAcARe7Wts6