### PR TITLE
spec: record founder decisions — triggers live in dalgo; DeniedError by default

### DIFF
--- a/spec/features/access-policies/row-level-conditions/README.md
+++ b/spec/features/access-policies/row-level-conditions/README.md
@@ -421,7 +421,7 @@ No adapter is modified.
 
 ## Open Questions
 
-- Default behaviour of a denied conditional point read: `DeniedError` (recommended, consistent and explainable) or `ErrRecordNotFound` (resists enumeration)? The hide option exists either way; the default is the decision.
+- Default behaviour of a denied conditional point read: *Decided 2026-09-03 (founder):* `DeniedError` by default (consistent and explainable); the policy option to hide denied records as `ErrRecordNotFound` remains available for enumeration-sensitive collections.
 - Should the parameter expression live in `dal` (usable by any query) or in `access` only? Recommended: `dal`, because DTQL and DataTug need it independently.
 - Should the `dtql` change (the `param` node) be filed as a change request on the `dtql` feature before this feature leaves Draft?
 - Which named variables, beyond `currentUser` and `now`, deserve a built-in convenience?

--- a/spec/ideas/row-level-access-conditions.md
+++ b/spec/ideas/row-level-access-conditions.md
@@ -176,10 +176,9 @@ these rows" before it needs field masks. Timebox: one `dalgo` release per part.
 
 ## Open Questions
 
-- Should a row-level denial on `Get` surface as a `DeniedError` (explainable,
-  consistent with path denials) or as `ErrRecordNotFound` (RLS-style, resists
-  enumeration)? Recommendation: `DeniedError` by default with a policy option to
-  hide denied records.
+- Should a row-level denial on `Get` surface as a `DeniedError` or as
+  `ErrRecordNotFound`? *Decided 2026-09-03 (founder):* `DeniedError` by default,
+  with a policy option to hide denied records as not found.
 - Where do role and group *memberships* come from — always the host via the
   context, or may a binding document also declare group membership? Recommendation:
   host only; DALgo stays identity-agnostic.

--- a/spec/ideas/triggers-and-webhooks.md
+++ b/spec/ideas/triggers-and-webhooks.md
@@ -146,9 +146,11 @@ release after the row-level-conditions feature lands.
 
 ## Open Questions
 
-- Where exactly should triggers live: a `triggers` package in this module, or
-  event model here and dispatcher elsewhere? Recommendation: model, outbox and
-  matching here; broker actions in separate modules.
+- Where exactly should triggers live? *Decided 2026-09-03 (founder):* the change-event
+  model, the transactional outbox and trigger matching live in this module (a
+  `triggers` package beside `dal`), because the outbox write must be atomic with
+  the data write inside the framework write pipeline; the webhook action uses the
+  standard library; broker and queue actions live in separate modules.
 - Package and collection naming: `triggers` vs `events` vs `cdc`; the default
   outbox path (`/_dalgo/outbox/*`?) and whether it is configurable per database.
 - Should the pre-image be captured by default for `Update` and `Delete`, or only


### PR DESCRIPTION
Founder decisions (2026-09-03) recorded in the specs:
- #134 triggers: the change-event model, transactional outbox and trigger matching live in dalgo (`triggers` package beside `dal`); broker/queue actions in separate modules.
- #133 row-level conditions: a denied conditional `Get` returns `DeniedError` by default; hide-as-not-found remains an opt-in policy option.

Spec-only; lint 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEVhqasFJJ3iAcARe7Wts6