### PR TITLE
feat(access): row-level conditions on allow rules — read-side MVP

### DIFF
--- a/access/condition.go
+++ b/access/condition.go
@@ -1,0 +1,194 @@
+package access
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/dal-go/dalgo/condeval"
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/record"
+)
+
+// residual is one policy's resolved row condition for one request resource,
+// with the attribution needed to explain a denial without leaking values.
+type residual struct {
+	policy       string
+	policySource string
+	rule         string
+	text         string
+	resource     Resource
+	condition    dal.Condition
+}
+
+func (r residual) deny(operation Operations, explanation string) *DeniedError {
+	return &DeniedError{Decision: Decision{
+		Operation:    operation,
+		Resource:     r.resource,
+		Policy:       r.policy,
+		PolicySource: r.policySource,
+		Rule:         r.rule,
+		Effect:       effectDeny.String(),
+		Condition:    r.text,
+		Explanation:  explanation,
+	}}
+}
+
+// matchResiduals evaluates every residual for one resource against record
+// data. The first failing residual is returned as a denial that names its
+// rule and condition text, never the record's values.
+func matchResiduals(operation Operations, data map[string]any, residuals []residual) error {
+	for _, r := range residuals {
+		ok, err := condeval.Match(data, r.condition)
+		if err != nil {
+			return r.deny(operation, fmt.Sprintf("row condition could not be evaluated for rule %q: %v", r.rule, err))
+		}
+		if !ok {
+			return r.deny(operation, fmt.Sprintf("row condition not satisfied for rule %q (where: %s)", r.rule, r.text))
+		}
+	}
+	return nil
+}
+
+// checkRecord enforces the residuals of a point read on a record the adapter
+// has just loaded. A record that does not exist needs no check. On denial the
+// record's data is cleared and its error set, so the caller receives nothing
+// but the denial.
+func checkRecord(operation Operations, rec record.Record, residuals []residual) error {
+	if len(residuals) == 0 || !rec.Exists() {
+		return nil
+	}
+	data, err := condeval.ToMap(rec.Data())
+	if err != nil {
+		denied := residuals[0].deny(operation, fmt.Sprintf("row condition could not be evaluated: %v", err))
+		clearRecord(rec, denied)
+		return denied
+	}
+	if err := matchResiduals(operation, data, residuals); err != nil {
+		clearRecord(rec, err)
+		return err
+	}
+	return nil
+}
+
+// clearRecord removes the loaded data from a denied record: a pointer target
+// is zeroed, a map is emptied, and the record's error is set to the denial. A
+// record that is not in the loaded state (not found, or already denied) has
+// no data to clear and only receives the error.
+func clearRecord(rec record.Record, denied error) {
+	if err := rec.Error(); err != nil && !errors.Is(err, record.ErrNoError) {
+		rec.SetError(denied)
+		return
+	}
+	value := reflect.ValueOf(rec.Data())
+	switch value.Kind() {
+	case reflect.Pointer:
+		if !value.IsNil() {
+			value.Elem().Set(reflect.Zero(value.Elem().Type()))
+		}
+	case reflect.Map:
+		for _, key := range value.MapKeys() {
+			value.SetMapIndex(key, reflect.Value{})
+		}
+	}
+	rec.SetError(denied)
+}
+
+// conditionalQuery is a structured query whose Where has the residual row
+// condition conjoined. It delegates everything else to the caller's query and
+// hands itself, not the original, to the executor.
+type conditionalQuery struct {
+	dal.StructuredQuery
+	where dal.Condition
+}
+
+func withResidual(query dal.StructuredQuery, condition dal.Condition) conditionalQuery {
+	where := condition
+	if existing := query.Where(); existing != nil {
+		where = dal.NewGroupCondition(dal.And, existing, condition)
+	}
+	return conditionalQuery{StructuredQuery: query, where: where}
+}
+
+func (q conditionalQuery) Where() dal.Condition { return q.where }
+
+func (q conditionalQuery) String() string {
+	return q.StructuredQuery.String() + " /* access: WHERE " + q.where.String() + " */"
+}
+
+func (q conditionalQuery) GetRecordsReader(ctx context.Context, qe dal.QueryExecutor) (dal.RecordsReader, error) {
+	return qe.ExecuteQueryToRecordsReader(ctx, q)
+}
+
+func (q conditionalQuery) GetRecordsetReader(ctx context.Context, qe dal.QueryExecutor) (dal.RecordsetReader, error) {
+	return qe.ExecuteQueryToRecordsetReader(ctx, q)
+}
+
+var _ dal.StructuredQuery = conditionalQuery{}
+
+// rewriteQuery applies the residuals of a Query request. Only the base source
+// (resource index 0) may carry a residual in this version; a residual on a
+// joined source is refused. A residual on a non-structured query cannot occur,
+// because conditional rules are not valid on opaque-query scopes, but it is
+// refused as well rather than assumed away.
+func rewriteQuery(query dal.Query, residuals [][]residual) (dal.Query, error) {
+	if len(residuals) == 0 {
+		return query, nil
+	}
+	for i := 1; i < len(residuals); i++ {
+		for _, r := range residuals[i] {
+			return nil, r.deny(Query, fmt.Sprintf("conditional rule %q applies to a joined source; conditional rules on joins are not supported in this version", r.rule))
+		}
+	}
+	base := residuals[0]
+	if len(base) == 0 {
+		return query, nil
+	}
+	structured, ok := query.(dal.StructuredQuery)
+	if !ok {
+		return nil, base[0].deny(Query, "row conditions require a structured query")
+	}
+	conditions := make([]dal.Condition, len(base))
+	for i, r := range base {
+		conditions[i] = r.condition
+	}
+	condition := conditions[0]
+	if len(conditions) > 1 {
+		condition = dal.NewGroupCondition(dal.And, conditions...)
+	}
+	return withResidual(structured, condition), nil
+}
+
+// existsThroughRead upgrades an existence check to a read so a residual can be
+// evaluated. The record is read into a private map, never into caller memory.
+func existsThroughRead(ctx context.Context, session dal.ReadSession, key *record.Key, residuals []residual) (bool, error) {
+	shadow := record.NewRecordWithData(key, &map[string]any{})
+	if err := session.Get(ctx, shadow); err != nil {
+		return false, err
+	}
+	if !shadow.Exists() {
+		return false, nil
+	}
+	if err := checkRecord(Exists, shadow, residuals); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// checkRecords enforces residuals on a multi-record read. Any denial clears
+// every record, so a batch never returns a partial result.
+func checkRecords(operation Operations, records []record.Record, residuals [][]residual) error {
+	if len(residuals) == 0 {
+		return nil
+	}
+	for i, rec := range records {
+		if err := checkRecord(operation, rec, residuals[i]); err != nil {
+			for _, other := range records {
+				clearRecord(other, err)
+			}
+			return err
+		}
+	}
+	return nil
+}

--- a/access/conditions_test.go
+++ b/access/conditions_test.go
@@ -1,0 +1,623 @@
+package access
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dal-go/dalgo/adapters/dalgo2memory"
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/dalgo/recordset"
+	"github.com/dal-go/record"
+	"github.com/dal-go/record/update"
+)
+
+type customer struct {
+	Name       string `json:"name"`
+	AssignedTo string `json:"assignedTo"`
+	TenantID   string `json:"tenantID"`
+	ExpiresAt  string `json:"expiresAt,omitempty"`
+}
+
+func assignedToCurrentUser() dal.Condition {
+	return dal.WhereField("assignedTo", dal.Equal, dal.NewParam("currentUser"))
+}
+
+func customersPolicy(t *testing.T) *AccessPolicy {
+	t.Helper()
+	policy, err := NewPolicy("customers",
+		Scope("customers", AnyID,
+			Allow(Read, "read-all"),
+			Allow(Update|Delete, "edit-assigned").Where(assignedToCurrentUser()),
+		),
+	)
+	if err != nil {
+		t.Fatalf("NewPolicy: %v", err)
+	}
+	return policy
+}
+
+func mustDecideAllowed(t *testing.T, decision Decision) {
+	t.Helper()
+	if !decision.Allowed {
+		t.Fatalf("expected allowed, got %+v", decision)
+	}
+}
+
+func TestConditionalRuleCompilation(t *testing.T) {
+	condition := assignedToCurrentUser()
+	for name, rules := range map[string][]Rule{
+		"conditional deny":         {Root(Deny(Get, "d").Where(condition))},
+		"condition on scope":       {Under(Path("x"), Allow(Get)).Where(condition)},
+		"collection group":         {CollectionGroupScope("g", Allow(Query, "q").Where(condition))},
+		"opaque query":             {OpaqueQueryScope(Allow(Query, "q").Where(condition))},
+		"explicit truncate":        {Root(Allow(Get|Truncate, "t").Where(condition))},
+		"invalid condition":        {Root(Allow(Get, "bad").Where(dal.Comparison{Operator: dal.Equal, Left: dal.Constant{Value: 1}, Right: dal.Constant{Value: 1}}))},
+		"invalid nested condition": {Root(Allow(Get, "bad").Where(dal.NewGroupCondition(dal.And)))},
+	} {
+		if _, err := NewPolicy("p", rules...); err == nil {
+			t.Errorf("%s: expected a compile error", name)
+		}
+	}
+	if _, err := NewAuditPolicy("a", Root(Audit(Get, "x").Where(condition))); err == nil {
+		t.Error("conditional audit rule must be rejected")
+	}
+	// The write and readwrite groups drop Truncate rather than failing.
+	for _, operations := range []Operations{Write, ReadWrite} {
+		policy := MustPolicy("p", Scope("notes", AnyID, Allow(operations, "own").Where(condition)))
+		ctx := WithCurrentUser(context.Background(), "u1")
+		key := RecordResourceForKey(record.NewKeyWithID("notes", "n1"))
+		if decision := policy.Decide(ctx, Request{Operation: Truncate, Resources: []Resource{key}}); decision.Allowed {
+			t.Errorf("%s: truncate must not be authorised by a conditional rule", operations)
+		}
+		decision := policy.Decide(ctx, Request{Operation: Delete, Resources: []Resource{key}})
+		mustDecideAllowed(t, decision)
+		if decision.Residuals == nil || decision.Residuals[0] == nil {
+			t.Errorf("%s: delete must carry a residual", operations)
+		}
+	}
+	// A generated name mentions the condition.
+	policy := MustPolicy("p", Scope("notes", AnyID, Allow(Get).Where(condition)))
+	decision := policy.Decide(WithCurrentUser(context.Background(), "u1"), Request{Operation: Get, Resources: []Resource{RecordResourceForKey(record.NewKeyWithID("notes", "n1"))}})
+	if !strings.Contains(decision.Rule, "where assignedTo = $currentUser") {
+		t.Errorf("generated rule name = %q", decision.Rule)
+	}
+	// Explanations and condition text carry parameter names, never values.
+	if strings.Contains(decision.Explanation, "u1") || strings.Contains(decision.Condition, "u1") {
+		t.Errorf("decision leaks a resolved value: %+v", decision)
+	}
+}
+
+func TestConditionalDecisions(t *testing.T) {
+	policy := customersPolicy(t)
+	c1 := RecordResourceForKey(record.NewKeyWithID("customers", "c1"))
+	ctx := WithCurrentUser(context.Background(), "u1")
+
+	get := policy.Decide(ctx, Request{Operation: Get, Resources: []Resource{c1}})
+	mustDecideAllowed(t, get)
+	if get.Residuals != nil || get.Rule != "read-all" {
+		t.Errorf("read must be unconditional: %+v", get)
+	}
+
+	edit := policy.Decide(ctx, Request{Operation: Update, Resources: []Resource{c1}})
+	mustDecideAllowed(t, edit)
+	if edit.Rule != "edit-assigned" || edit.Condition != "assignedTo = $currentUser" || len(edit.Residuals) != 1 || edit.Residuals[0] == nil {
+		t.Errorf("edit decision = %+v", edit)
+	}
+	if got := edit.Residuals[0].String(); got != "assignedTo = 'u1'" {
+		t.Errorf("residual = %q", got)
+	}
+
+	missing := policy.Decide(context.Background(), Request{Operation: Update, Resources: []Resource{c1}})
+	if missing.Allowed || !strings.Contains(missing.Explanation, "$currentUser") || missing.Condition == "" {
+		t.Errorf("missing variable must deny and name the parameter: %+v", missing)
+	}
+	if err := policy.Authorize(context.Background(), Request{Operation: Update, Resources: []Resource{c1}}); !errors.Is(err, ErrAccessDenied) || !strings.Contains(err.Error(), "$currentUser") {
+		t.Errorf("Authorize error = %v", err)
+	}
+
+	// A conditional allow deeper than an unconditional deny yields a residual.
+	deeper := MustPolicy("deeper", Root(Deny(Get, "deny-root")), Scope("docs", AnyID, Allow(Get, "own").Where(dal.WhereField("owner", dal.Equal, dal.NewParam("currentUser")))))
+	doc := RecordResourceForKey(record.NewKeyWithID("docs", "d1"))
+	decision := deeper.Decide(ctx, Request{Operation: Get, Resources: []Resource{doc}})
+	mustDecideAllowed(t, decision)
+	if decision.Residuals[0] == nil {
+		t.Errorf("expected residual: %+v", decision)
+	}
+	// An unconditional deny at equal specificity wins over a conditional allow.
+	tie := MustPolicy("tie", Scope("docs", AnyID, Deny(Get, "no"), Allow(Get, "own").Where(dal.WhereField("owner", dal.Equal, dal.NewParam("currentUser")))))
+	if decision := tie.Decide(ctx, Request{Operation: Get, Resources: []Resource{doc}}); decision.Allowed {
+		t.Errorf("deny must win the tie: %+v", decision)
+	}
+	// An unconditional allow makes a deeper condition moot.
+	moot := MustPolicy("moot", Root(Allow(Get, "all")), Scope("docs", AnyID, Allow(Get, "own").Where(dal.WhereField("owner", dal.Equal, dal.NewParam("currentUser")))))
+	decision = moot.Decide(ctx, Request{Operation: Get, Resources: []Resource{doc}})
+	mustDecideAllowed(t, decision)
+	if decision.Residuals != nil || decision.Rule != "all" {
+		t.Errorf("unconditional allow must make the condition moot: %+v", decision)
+	}
+	// Two conditional allows at one specificity combine with OR.
+	two := MustPolicy("two", Scope("docs", AnyID,
+		Allow(Get, "a").Where(dal.WhereField("owner", dal.Equal, dal.NewParam("currentUser"))),
+		Allow(Get, "b").Where(dal.WhereField("public", dal.Equal, dal.Constant{Value: true})),
+	))
+	decision = two.Decide(ctx, Request{Operation: Get, Resources: []Resource{doc}})
+	mustDecideAllowed(t, decision)
+	if decision.Rule != "a, b" || decision.Condition != "(owner = $currentUser OR public = true)" {
+		t.Errorf("combined decision = %+v", decision)
+	}
+	if got := decision.Residuals[0].String(); got != "(owner = 'u1' OR public = true)" {
+		t.Errorf("combined residual = %q", got)
+	}
+	// One unresolved parameter among several conditional rules denies.
+	if decision := two.Decide(context.Background(), Request{Operation: Get, Resources: []Resource{doc}}); decision.Allowed {
+		t.Errorf("unresolved parameter must deny: %+v", decision)
+	}
+	// Multi-resource requests carry residuals per resource.
+	mixed := MustPolicy("mixed", Scope("docs", AnyID, Allow(Get, "own").Where(dal.WhereField("owner", dal.Equal, dal.NewParam("currentUser")))), Scope("docs", "shared", Allow(Get, "shared")))
+	resources := []Resource{RecordResourceForKey(record.NewKeyWithID("docs", "shared")), doc}
+	decision = mixed.Decide(ctx, Request{Operation: Get, Resources: resources})
+	mustDecideAllowed(t, decision)
+	if len(decision.Residuals) != 2 || decision.Residuals[0] != nil || decision.Residuals[1] == nil {
+		t.Errorf("per-resource residuals = %+v", decision.Residuals)
+	}
+}
+
+func TestVariables(t *testing.T) {
+	ctx := WithVariables(context.Background(), map[string]any{"tenant": "t1", "currentUser": "u0"})
+	ctx = WithCurrentUser(ctx, "u1")
+	variables := variablesFromContext(ctx)
+	if variables["tenant"] != "t1" || variables["currentUser"] != "u1" {
+		t.Errorf("variables = %v", variables)
+	}
+	var nilContext context.Context
+	if got := variablesFromContext(nilContext); len(got) != 0 {
+		t.Errorf("nil context variables = %v", got)
+	}
+	for _, bad := range []func(){
+		func() { WithVariables(nilContext, nil) },
+		func() { WithVariables(context.Background(), map[string]any{"not valid": 1}) },
+	} {
+		func() {
+			defer func() {
+				if recover() == nil {
+					t.Error("expected panic")
+				}
+			}()
+			bad()
+		}()
+	}
+	resolver := newVariableResolver(WithVariables(context.Background(), map[string]any{"now": "fixed"}))
+	if value, ok := resolver.resolve("now"); !ok || value != "fixed" {
+		t.Errorf("explicit now = %v, %v", value, ok)
+	}
+	resolver = newVariableResolver(context.Background())
+	if value, ok := resolver.resolve("now"); !ok || value.(time.Time).IsZero() {
+		t.Errorf("built-in now = %v, %v", value, ok)
+	}
+	if _, ok := resolver.resolve("missing"); ok {
+		t.Error("missing variable must not resolve")
+	}
+}
+
+// stubReadSession records how the secured wrapper talks to an adapter.
+type stubReadSession struct {
+	exists      bool
+	load        map[string]any
+	getErr      error
+	queryErr    error
+	gets        int
+	existsCalls int
+	queries     []dal.Query
+}
+
+func (s *stubReadSession) Exists(context.Context, *record.Key) (bool, error) {
+	s.existsCalls++
+	return s.exists, nil
+}
+
+func (s *stubReadSession) Get(_ context.Context, rec record.Record) error {
+	s.gets++
+	if s.getErr != nil {
+		return s.getErr
+	}
+	if !s.exists {
+		rec.SetError(record.ErrRecordNotFound)
+		return nil
+	}
+	if s.load != nil && rec.Data() != nil {
+		encoded, _ := json.Marshal(s.load)
+		_ = json.Unmarshal(encoded, rec.Data())
+	}
+	rec.SetError(nil)
+	return nil
+}
+
+func (s *stubReadSession) GetMulti(ctx context.Context, records []record.Record) error {
+	for _, rec := range records {
+		if err := s.Get(ctx, rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *stubReadSession) ExecuteQueryToRecordsReader(_ context.Context, query dal.Query) (dal.RecordsReader, error) {
+	s.queries = append(s.queries, query)
+	return nil, s.queryErr
+}
+
+func (s *stubReadSession) ExecuteQueryToRecordsetReader(_ context.Context, query dal.Query, _ ...recordset.Option) (dal.RecordsetReader, error) {
+	s.queries = append(s.queries, query)
+	return nil, s.queryErr
+}
+
+func ownGetPolicy() *AccessPolicy {
+	return MustPolicy("own", Scope("customers", AnyID, Allow(Read, "own").Where(assignedToCurrentUser())))
+}
+
+func TestConditionalPointReadsThroughStub(t *testing.T) {
+	ctx := WithCurrentUser(context.Background(), "u1")
+	key := record.NewKeyWithID("customers", "c2")
+
+	// Get: the adapter loads the record, the wrapper denies and clears it.
+	stub := &stubReadSession{exists: true, load: map[string]any{"name": "Bob", "assignedTo": "u2"}}
+	session := SecureReadSession(stub, ownGetPolicy())
+	data := &customer{}
+	rec := record.NewRecordWithData(key, data)
+	err := session.Get(ctx, rec)
+	var denied *DeniedError
+	if !errors.As(err, &denied) || !strings.Contains(err.Error(), "own") || strings.Contains(err.Error(), "u1") || strings.Contains(err.Error(), "Bob") {
+		t.Fatalf("Get error = %v", err)
+	}
+	if *data != (customer{}) || !errors.Is(rec.Error(), ErrAccessDenied) {
+		t.Errorf("denied record must be cleared: data=%+v err=%v", *data, rec.Error())
+	}
+	if denied.Decision.Condition != "assignedTo = $currentUser" {
+		t.Errorf("Condition = %q", denied.Decision.Condition)
+	}
+	// Get of an own record keeps the data.
+	stub.load = map[string]any{"name": "Ann", "assignedTo": "u1"}
+	rec = record.NewRecordWithData(key, data)
+	if err := session.Get(ctx, rec); err != nil || data.Name != "Ann" {
+		t.Errorf("own record: err=%v data=%+v", err, *data)
+	}
+	// A missing record needs no evaluation.
+	stub.exists = false
+	rec = record.NewRecordWithData(key, &customer{})
+	if err := session.Get(ctx, rec); err != nil || rec.Exists() {
+		t.Errorf("missing record: err=%v exists=%v", err, rec.Exists())
+	}
+	// Adapter errors propagate.
+	stub.getErr = errors.New("boom")
+	if err := session.Get(ctx, record.NewRecordWithData(key, &customer{})); err == nil || err.Error() != "boom" {
+		t.Errorf("adapter error = %v", err)
+	}
+	if err := session.GetMulti(ctx, []record.Record{record.NewRecordWithData(key, &customer{})}); err == nil {
+		t.Error("GetMulti must propagate adapter errors")
+	}
+	stub.getErr = nil
+	stub.exists = true
+
+	// Exists is upgraded to a read; the adapter's Exists is never called.
+	stub.load = map[string]any{"assignedTo": "u2"}
+	if ok, err := session.Exists(ctx, key); ok || !errors.Is(err, ErrAccessDenied) {
+		t.Errorf("Exists(other's) = %v, %v", ok, err)
+	}
+	stub.load = map[string]any{"assignedTo": "u1"}
+	if ok, err := session.Exists(ctx, key); !ok || err != nil {
+		t.Errorf("Exists(own) = %v, %v", ok, err)
+	}
+	stub.exists = false
+	if ok, err := session.Exists(ctx, key); ok || err != nil {
+		t.Errorf("Exists(missing) = %v, %v", ok, err)
+	}
+	stub.exists = true
+	if stub.existsCalls != 0 {
+		t.Errorf("adapter Exists called %d times under a conditional rule", stub.existsCalls)
+	}
+	stub.getErr = errors.New("boom")
+	if _, err := session.Exists(ctx, key); err == nil || err.Error() != "boom" {
+		t.Errorf("Exists adapter error = %v", err)
+	}
+	stub.getErr = nil
+	// Without a conditional rule the adapter's Exists is used.
+	plain := SecureReadSession(stub, MustPolicy("plain", Root(Allow(Read, "all"))))
+	if _, err := plain.Exists(ctx, key); err != nil || stub.existsCalls != 1 {
+		t.Errorf("plain Exists: err=%v calls=%d", err, stub.existsCalls)
+	}
+	// A denied authorization short-circuits before any read.
+	if _, err := SecureReadSession(stub, MustPolicy("none", Root(Deny(Read, "no")))).Exists(ctx, key); !errors.Is(err, ErrAccessDenied) {
+		t.Errorf("denied Exists = %v", err)
+	}
+
+	// GetMulti: one denied record clears the whole batch.
+	stub.load = map[string]any{"assignedTo": "u2"}
+	first := &customer{}
+	second := &customer{}
+	records := []record.Record{record.NewRecordWithData(record.NewKeyWithID("customers", "c1"), first), record.NewRecordWithData(key, second)}
+	if err := session.GetMulti(ctx, records); !errors.Is(err, ErrAccessDenied) {
+		t.Errorf("GetMulti = %v", err)
+	}
+	if *first != (customer{}) || *second != (customer{}) {
+		t.Errorf("batch must be cleared: %+v %+v", *first, *second)
+	}
+	stub.load = map[string]any{"assignedTo": "u1"}
+	records = []record.Record{record.NewRecordWithData(record.NewKeyWithID("customers", "c1"), first), record.NewRecordWithData(key, second)}
+	if err := session.GetMulti(ctx, records); err != nil || first.AssignedTo != "u1" {
+		t.Errorf("own batch: err=%v first=%+v", err, *first)
+	}
+	records = []record.Record{record.NewRecordWithData(record.NewKeyWithID("customers", "c1"), first)}
+	if err := plain.GetMulti(ctx, records); err != nil {
+		t.Errorf("plain GetMulti = %v", err)
+	}
+}
+
+func TestConditionalQueriesThroughStub(t *testing.T) {
+	ctx := WithVariables(context.Background(), map[string]any{"tenant": "t1"})
+	policy := MustPolicy("tenant", Collection("orders", Allow(Query, "tenant-slice").Where(dal.WhereField("tenantID", dal.Equal, dal.NewParam("tenant")))))
+	stub := &stubReadSession{}
+	session := SecureReadSession(stub, policy)
+	query := dal.NewQueryBuilder(dal.From(dal.NewRootCollectionRef("orders", ""))).
+		WhereField("status", dal.Equal, "open").Limit(10).OrderBy(dal.Ascending(dal.Field("createdAt"))).
+		SelectIntoRecord(func() record.Record {
+			return record.NewRecordWithData(record.NewKeyWithID("orders", ""), &map[string]any{})
+		})
+	if _, err := session.ExecuteQueryToRecordsReader(ctx, query); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if _, err := session.ExecuteQueryToRecordsetReader(ctx, query); err != nil {
+		t.Fatalf("recordset query: %v", err)
+	}
+	if len(stub.queries) != 2 {
+		t.Fatalf("adapter saw %d queries", len(stub.queries))
+	}
+	for _, delegated := range stub.queries {
+		structured, ok := delegated.(dal.StructuredQuery)
+		if !ok {
+			t.Fatalf("delegated query is %T", delegated)
+		}
+		where := structured.Where().String()
+		if where != "(status = 'open' AND tenantID = 't1')" {
+			t.Errorf("delegated where = %q", where)
+		}
+		if strings.Contains(where, "$") {
+			t.Errorf("a parameter reached the adapter: %q", where)
+		}
+		if structured.Limit() != 10 || len(structured.OrderBy()) != 1 || !strings.Contains(delegated.String(), "access: WHERE") {
+			t.Errorf("wrapper lost query parts: limit=%d order=%d string=%q", structured.Limit(), len(structured.OrderBy()), delegated.String())
+		}
+	}
+	// The wrapper hands itself to an executor.
+	wrapped := stub.queries[0]
+	stub.queries = nil
+	if _, err := wrapped.GetRecordsReader(ctx, stub); err != nil {
+		t.Errorf("GetRecordsReader: %v", err)
+	}
+	if _, err := wrapped.GetRecordsetReader(ctx, stub); err != nil {
+		t.Errorf("GetRecordsetReader: %v", err)
+	}
+	for i, delegated := range stub.queries {
+		if _, ok := delegated.(conditionalQuery); !ok {
+			t.Errorf("executor call %d received %T, want the wrapper", i, delegated)
+		}
+	}
+	// Without a caller condition the residual stands alone.
+	bare := dal.NewQueryBuilder(dal.From(dal.NewRootCollectionRef("orders", ""))).SelectKeysOnly(reflect.String)
+	stub.queries = nil
+	if _, err := session.ExecuteQueryToRecordsReader(ctx, bare); err != nil {
+		t.Fatalf("bare query: %v", err)
+	}
+	if got := stub.queries[0].(dal.StructuredQuery).Where().String(); got != "tenantID = 't1'" {
+		t.Errorf("bare where = %q", got)
+	}
+	// Missing variable denies before the adapter is called.
+	stub.queries = nil
+	if _, err := session.ExecuteQueryToRecordsReader(context.Background(), bare); !errors.Is(err, ErrAccessDenied) || !strings.Contains(err.Error(), "$tenant") {
+		t.Errorf("missing variable = %v", err)
+	}
+	if len(stub.queries) != 0 {
+		t.Error("adapter must not be called on denial")
+	}
+	// Residuals from two policies conjoin.
+	ctx2 := WithPolicy(ctx, MustPolicy("status", Collection("orders", Allow(Query, "open-only").Where(dal.WhereField("status", dal.Equal, dal.Constant{Value: "open"})))))
+	stub.queries = nil
+	if _, err := session.ExecuteQueryToRecordsReader(ctx2, bare); err != nil {
+		t.Fatalf("two policies: %v", err)
+	}
+	if got := stub.queries[0].(dal.StructuredQuery).Where().String(); got != "(tenantID = 't1' AND status = 'open')" {
+		t.Errorf("conjoined where = %q", got)
+	}
+	// A residual on a joined source is refused.
+	joined := MustPolicy("join", Collection("orders", Allow(Query, "all")), Collection("users", Allow(Query, "own").Where(assignedToCurrentUser())))
+	joinQuery := dal.NewQueryBuilder(dal.From(dal.NewRootCollectionRef("orders", "o")).Join(dal.NewJoinedSource(dal.NewRootCollectionRef("users", "u"), dal.JoinInner))).SelectKeysOnly(reflect.String)
+	if _, err := SecureReadSession(stub, joined).ExecuteQueryToRecordsReader(WithCurrentUser(ctx, "u1"), joinQuery); !errors.Is(err, ErrAccessDenied) || !strings.Contains(err.Error(), "joined source") {
+		t.Errorf("joined residual = %v", err)
+	}
+	// Adapter errors propagate through the rewrite.
+	stub.queryErr = errors.New("boom")
+	if _, err := session.ExecuteQueryToRecordsReader(ctx, bare); err == nil || err.Error() != "boom" {
+		t.Errorf("adapter query error = %v", err)
+	}
+}
+
+func TestRewriteQueryEdges(t *testing.T) {
+	bare := dal.NewQueryBuilder(dal.From(dal.NewRootCollectionRef("orders", ""))).SelectKeysOnly(reflect.String)
+	if q, err := rewriteQuery(bare, [][]residual{{}}); err != nil {
+		t.Errorf("empty base residuals: %v", err)
+	} else if _, wrapped := q.(conditionalQuery); wrapped {
+		t.Error("empty base residuals must return the caller's query unchanged")
+	}
+	r := residual{rule: "r", text: "x = $y", condition: dal.WhereField("x", dal.Equal, dal.Constant{Value: 1})}
+	if _, err := rewriteQuery(opaqueQ{}, [][]residual{{r}}); !errors.Is(err, ErrAccessDenied) {
+		t.Errorf("opaque query with residual = %v", err)
+	}
+	q, err := rewriteQuery(bare, [][]residual{{r, r}})
+	if err != nil || q.(dal.StructuredQuery).Where().String() != "(x = 1 AND x = 1)" {
+		t.Errorf("two base residuals = %v, %v", q, err)
+	}
+}
+
+func TestCheckRecordEdges(t *testing.T) {
+	key := record.NewKeyWithID("customers", "c1")
+	bad := residual{rule: "bad", text: "fake", condition: fakeCond{}}
+	rec := record.NewRecordWithData(key, &customer{Name: "x"})
+	rec.SetError(nil)
+	if err := checkRecord(Get, rec, []residual{bad}); !errors.Is(err, ErrAccessDenied) || !strings.Contains(err.Error(), "could not be evaluated") {
+		t.Errorf("unevaluable condition = %v", err)
+	}
+	unserialisable := record.NewRecordWithData(key, &struct{ C chan int }{C: make(chan int)})
+	unserialisable.SetError(nil)
+	if err := checkRecord(Get, unserialisable, []residual{bad}); !errors.Is(err, ErrAccessDenied) {
+		t.Errorf("unserialisable data = %v", err)
+	}
+	// Map data is emptied on denial; nil data is left alone.
+	m := map[string]any{"assignedTo": "u2"}
+	mapRecord := record.NewRecordWithData(key, m)
+	mapRecord.SetError(nil)
+	if err := checkRecord(Get, mapRecord, []residual{{rule: "own", text: "t", condition: dal.WhereField("assignedTo", dal.Equal, dal.Constant{Value: "u1"})}}); !errors.Is(err, ErrAccessDenied) || len(m) != 0 {
+		t.Errorf("map record: err=%v map=%v", err, m)
+	}
+	nilData := record.NewRecordWithData(key, (*customer)(nil))
+	nilData.SetError(nil)
+	clearRecord(nilData, errors.New("x"))
+	if err := checkRecords(Get, nil, nil); err != nil {
+		t.Errorf("no residuals = %v", err)
+	}
+}
+
+type fakeCond struct{}
+
+func (fakeCond) String() string { return "fake" }
+
+func TestConditionalWritesFailClosed(t *testing.T) {
+	policy := customersPolicy(t)
+	ctx := WithCurrentUser(context.Background(), "u1")
+	key := record.NewKeyWithID("customers", "c1")
+	session := SecureWriteSession(&stubWriteSession{}, policy)
+	for name, op := range map[string]func() error{
+		"update":       func() error { return session.Update(ctx, key, []update.Update{update.ByFieldName("name", "x")}) },
+		"delete":       func() error { return session.Delete(ctx, key) },
+		"delete multi": func() error { return session.DeleteMulti(ctx, []*record.Key{key}) },
+	} {
+		err := op()
+		var denied *DeniedError
+		if !errors.As(err, &denied) || !strings.Contains(err.Error(), "not enforced") || denied.Decision.Condition != "assignedTo = $currentUser" {
+			t.Errorf("%s: %v", name, err)
+		}
+	}
+	if err := session.Insert(ctx, record.NewRecordWithData(key, &customer{})); !errors.Is(err, ErrAccessDenied) {
+		t.Errorf("insert without a rule = %v", err)
+	}
+}
+
+type stubWriteSession struct{ dal.WriteSession }
+
+func TestResidualsBoundedByResources(t *testing.T) {
+	// A custom policy returning more residuals than resources must not panic.
+	policy := oversizedPolicy{}
+	g := guard{databasePolicies: []Policy{policy}}
+	residuals, err := g.authorizeRequest(context.Background(), Request{Operation: Get, Resources: []Resource{RecordResourceForKey(record.NewKeyWithID("x", "1"))}})
+	if err != nil || len(residuals) != 1 || len(residuals[0]) != 1 {
+		t.Errorf("residuals = %v, %v", residuals, err)
+	}
+}
+
+type oversizedPolicy struct{}
+
+func (oversizedPolicy) Name() string { return "oversized" }
+func (oversizedPolicy) Decide(context.Context, Request) Decision {
+	condition := dal.WhereField("a", dal.Equal, dal.Constant{Value: 1})
+	return Decision{Allowed: true, Policy: "oversized", Residuals: []dal.Condition{condition, condition, condition}}
+}
+func (p oversizedPolicy) Authorize(ctx context.Context, request Request) error {
+	if d := p.Decide(ctx, request); !d.Allowed {
+		return &DeniedError{Decision: d}
+	}
+	return nil
+}
+
+func TestConditionalReadsOnMemoryDB(t *testing.T) {
+	ctx := context.Background()
+	raw := dalgo2memory.New(dalgo2memory.FirestoreProfile())
+	seed := map[string]customer{
+		"c1": {Name: "Ann", AssignedTo: "u1", TenantID: "t1"},
+		"c2": {Name: "Bob", AssignedTo: "u2", TenantID: "t1"},
+		"c3": {Name: "Cy", AssignedTo: "u1", TenantID: "t2"},
+	}
+	if err := raw.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		for id, c := range seed {
+			c := c
+			if err := tx.Set(ctx, record.NewRecordWithData(record.NewKeyWithID("customers", id), &c)); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Read all customers, edit only assigned ones: reads are unconditional.
+	db := MustSecureDB(raw, WithDatabasePolicies(customersPolicy(t)))
+	user1 := WithCurrentUser(ctx, "u1")
+	other := &customer{}
+	if err := db.Get(user1, record.NewRecordWithData(record.NewKeyWithID("customers", "c2"), other)); err != nil || other.Name != "Bob" {
+		t.Errorf("read-all get: err=%v data=%+v", err, *other)
+	}
+
+	// Tenant slice: the engine filters, paging and order intact.
+	tenantDB := MustSecureDB(raw, WithDatabasePolicies(MustPolicy("tenant", Collection("customers", Allow(Query, "tenant-slice").Where(dal.WhereField("tenantID", dal.Equal, dal.NewParam("tenant")))))))
+	query := dal.NewQueryBuilder(dal.From(dal.NewRootCollectionRef("customers", ""))).Limit(10).OrderBy(dal.Ascending(dal.Field("name"))).
+		SelectIntoRecord(func() record.Record {
+			return record.NewRecordWithData(record.NewKeyWithID("customers", ""), &customer{})
+		})
+	reader, err := tenantDB.ExecuteQueryToRecordsReader(WithVariables(ctx, map[string]any{"tenant": "t1"}), query)
+	if err != nil {
+		t.Fatalf("tenant query: %v", err)
+	}
+	var names []string
+	for {
+		rec, err := reader.Next()
+		if errors.Is(err, dal.ErrNoMoreRecords) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		c := rec.Data().(*customer)
+		if c.TenantID != "t1" {
+			t.Errorf("row outside tenant: %+v", *c)
+		}
+		names = append(names, c.Name)
+	}
+	if !reflect.DeepEqual(names, []string{"Ann", "Bob"}) {
+		t.Errorf("tenant rows = %v", names)
+	}
+
+	// Own-record reads through the memory adapter.
+	ownDB := MustSecureDB(raw, WithDatabasePolicies(ownGetPolicy()))
+	mine := &customer{}
+	if err := ownDB.Get(user1, record.NewRecordWithData(record.NewKeyWithID("customers", "c1"), mine)); err != nil || mine.Name != "Ann" {
+		t.Errorf("own get: err=%v data=%+v", err, *mine)
+	}
+	theirs := &customer{}
+	if err := ownDB.Get(user1, record.NewRecordWithData(record.NewKeyWithID("customers", "c2"), theirs)); !errors.Is(err, ErrAccessDenied) || *theirs != (customer{}) {
+		t.Errorf("other's get: err=%v data=%+v", err, *theirs)
+	}
+	if ok, err := ownDB.Exists(user1, record.NewKeyWithID("customers", "c2")); ok || !errors.Is(err, ErrAccessDenied) {
+		t.Errorf("other's exists = %v, %v", ok, err)
+	}
+	if ok, err := ownDB.Exists(user1, record.NewKeyWithID("customers", "c1")); !ok || err != nil {
+		t.Errorf("own exists = %v, %v", ok, err)
+	}
+	// Inside a read-only transaction the same rules apply.
+	if err := ownDB.RunReadonlyTransaction(user1, func(ctx context.Context, tx dal.ReadTransaction) error {
+		return tx.Get(ctx, record.NewRecordWithData(record.NewKeyWithID("customers", "c2"), &customer{}))
+	}); !errors.Is(err, ErrAccessDenied) {
+		t.Errorf("transactional get = %v", err)
+	}
+}

--- a/access/context.go
+++ b/access/context.go
@@ -3,9 +3,71 @@ package access
 import (
 	"context"
 	"fmt"
+	"time"
+
+	"github.com/dal-go/dalgo/dal"
 )
 
 type contextPoliciesKey struct{}
+
+type contextVariablesKey struct{}
+
+// WithVariables returns a child context carrying values for the parameters a
+// conditional rule may reference: a rule conditioned on ownerID == $tenant reads
+// the "tenant" entry. Variables inherited from the parent context are kept and
+// same-named entries are replaced. $now resolves to the evaluation time unless
+// a "now" variable is supplied.
+func WithVariables(ctx context.Context, variables map[string]any) context.Context {
+	if ctx == nil {
+		panic("access: nil context")
+	}
+	combined := variablesFromContext(ctx)
+	for name, value := range variables {
+		if !dal.ValidParamName(name) {
+			panic(fmt.Sprintf("access: invalid variable name %q", name))
+		}
+		combined[name] = value
+	}
+	return context.WithValue(ctx, contextVariablesKey{}, combined)
+}
+
+// WithCurrentUser sets the $currentUser variable.
+func WithCurrentUser(ctx context.Context, userID any) context.Context {
+	return WithVariables(ctx, map[string]any{"currentUser": userID})
+}
+
+func variablesFromContext(ctx context.Context) map[string]any {
+	combined := map[string]any{}
+	if ctx == nil {
+		return combined
+	}
+	variables, _ := ctx.Value(contextVariablesKey{}).(map[string]any)
+	for name, value := range variables {
+		combined[name] = value
+	}
+	return combined
+}
+
+// variableResolver is one consistent snapshot of the variables for a request,
+// so every condition of the request sees the same values and the same $now.
+type variableResolver struct {
+	variables map[string]any
+	now       time.Time
+}
+
+func newVariableResolver(ctx context.Context) variableResolver {
+	return variableResolver{variables: variablesFromContext(ctx), now: time.Now().UTC()}
+}
+
+func (r variableResolver) resolve(name string) (any, bool) {
+	if value, ok := r.variables[name]; ok {
+		return value, true
+	}
+	if name == "now" {
+		return r.now, true
+	}
+	return nil, false
+}
 
 // WithPolicy returns a child context carrying additional restrictive policies.
 // Policies inherited from the parent context are preserved.
@@ -42,26 +104,69 @@ func (g guard) bind(ctx context.Context) guard {
 	return g
 }
 
+// authorize settles an operation that cannot carry a residual condition. In
+// this version that is every write: a conditional rule on a write operation is
+// refused rather than silently granted, until pre-image and post-image checks
+// exist.
 func (g guard) authorize(ctx context.Context, operation Operations, resources ...Resource) error {
-	return g.authorizeRequest(ctx, Request{Operation: operation, Resources: resources})
+	residuals, err := g.authorizeRequest(ctx, Request{Operation: operation, Resources: resources})
+	if err != nil {
+		return err
+	}
+	for _, perResource := range residuals {
+		for _, residual := range perResource {
+			return &DeniedError{Decision: Decision{
+				Operation:    operation,
+				Resource:     residual.resource,
+				Policy:       residual.policy,
+				PolicySource: residual.policySource,
+				Rule:         residual.rule,
+				Effect:       effectDeny.String(),
+				Condition:    residual.text,
+				Explanation:  fmt.Sprintf("conditional rule %q is not enforced for %s in this version (where: %s)", residual.rule, operation, residual.text),
+			}}
+		}
+	}
+	return nil
 }
 
-func (g guard) authorizeRequest(ctx context.Context, request Request) error {
+// authorizeRequest evaluates every applicable policy and returns, per request
+// resource, the residual conditions the caller must still enforce. A denial by
+// any policy is returned immediately.
+func (g guard) authorizeRequest(ctx context.Context, request Request) ([][]residual, error) {
 	dynamicPolicies := policiesFromContext(ctx)
 	contextPolicyCount := len(g.boundPolicies) + len(dynamicPolicies)
 	if err := g.requireContextPolicy(request.Operation, contextPolicyCount); err != nil {
-		return err
+		return nil, err
 	}
 	policies := make([]Policy, 0, len(g.databasePolicies)+contextPolicyCount)
 	policies = append(policies, g.databasePolicies...)
 	policies = append(policies, g.boundPolicies...)
 	policies = append(policies, dynamicPolicies...)
+	var residuals [][]residual
 	for _, policy := range policies {
-		if err := policy.Authorize(ctx, request); err != nil {
-			return err
+		decision := policy.Decide(ctx, request)
+		if !decision.Allowed {
+			return nil, &DeniedError{Decision: decision}
+		}
+		for i, condition := range decision.Residuals {
+			if condition == nil || i >= len(request.Resources) {
+				continue
+			}
+			if residuals == nil {
+				residuals = make([][]residual, len(request.Resources))
+			}
+			residuals[i] = append(residuals[i], residual{
+				policy:       decision.Policy,
+				policySource: decision.PolicySource,
+				rule:         decision.Rule,
+				text:         decision.Condition,
+				resource:     request.Resources[i],
+				condition:    condition,
+			})
 		}
 	}
-	return nil
+	return residuals, nil
 }
 
 func (g guard) checkContext(ctx context.Context) error {

--- a/access/document.go
+++ b/access/document.go
@@ -47,6 +47,9 @@ type DocumentRule struct {
 	ID         string   `json:"id" yaml:"id"`
 	Effect     string   `json:"effect" yaml:"effect"`
 	Operations []string `json:"operations" yaml:"operations"`
+	// Where is an optional row condition on an allow rule, written in the
+	// DTQL condition syntax with a `param` expression for runtime variables.
+	Where *DocumentCondition `json:"where,omitempty" yaml:"where,omitempty"`
 }
 
 // Codec decouples policy loading from both its syntax and its storage. A
@@ -348,7 +351,15 @@ func ruleFromDocumentRule(documentRule DocumentRule, allowedEffects map[effect]b
 	if !allowedEffects[ruleEffect] {
 		return Rule{}, fmt.Errorf("effect %q is not valid for policy kind %s", ruleEffect, documentRule.Effect)
 	}
-	return directive(ruleEffect, operations, []string{id}), nil
+	rule := directive(ruleEffect, operations, []string{id})
+	if documentRule.Where != nil {
+		condition, err := conditionFromDocument(*documentRule.Where)
+		if err != nil {
+			return Rule{}, fmt.Errorf("where: %w", err)
+		}
+		rule = rule.Where(condition)
+	}
+	return rule, nil
 }
 
 func parseEffect(value string) (effect, error) {
@@ -464,7 +475,15 @@ func documentRuleFromRule(rule Rule) (DocumentRule, error) {
 	if err != nil {
 		return DocumentRule{}, fmt.Errorf("%w: %v", ErrNotSerializable, err)
 	}
-	return DocumentRule{ID: rule.name, Effect: rule.effect.String(), Operations: operations}, nil
+	documentRule := DocumentRule{ID: rule.name, Effect: rule.effect.String(), Operations: operations}
+	if rule.where != nil {
+		where, err := documentFromCondition(rule.where)
+		if err != nil {
+			return DocumentRule{}, fmt.Errorf("%w: rule %q: %v", ErrNotSerializable, rule.name, err)
+		}
+		documentRule.Where = where
+	}
+	return documentRule, nil
 }
 
 func documentPath(pattern PathPattern) (string, error) {

--- a/access/document_condition.go
+++ b/access/document_condition.go
@@ -1,0 +1,167 @@
+package access
+
+import (
+	"fmt"
+
+	"github.com/dal-go/dalgo/dal"
+)
+
+// DocumentCondition is a row condition in a portable policy document. It uses
+// the DTQL condition syntax so a policy and a saved query are written alike: a
+// comparison sets op/left/right; a group sets and or or.
+type DocumentCondition struct {
+	Op    string              `json:"op,omitempty" yaml:"op,omitempty"`
+	Left  *DocumentExpression `json:"left,omitempty" yaml:"left,omitempty"`
+	Right *DocumentExpression `json:"right,omitempty" yaml:"right,omitempty"`
+	And   []DocumentCondition `json:"and,omitempty" yaml:"and,omitempty"`
+	Or    []DocumentCondition `json:"or,omitempty" yaml:"or,omitempty"`
+}
+
+// DocumentExpression is one operand: exactly one of field, value, values or
+// param is set.
+type DocumentExpression struct {
+	Field  string `json:"field,omitempty" yaml:"field,omitempty"`
+	Value  any    `json:"value,omitempty" yaml:"value,omitempty"`
+	Values any    `json:"values,omitempty" yaml:"values,omitempty"`
+	Param  string `json:"param,omitempty" yaml:"param,omitempty"`
+}
+
+var documentOperators = map[string]dal.Operator{
+	string(dal.Equal):          dal.Equal,
+	string(dal.In):             dal.In,
+	string(dal.GreaterThen):    dal.GreaterThen,
+	string(dal.GreaterOrEqual): dal.GreaterOrEqual,
+	string(dal.LessThen):       dal.LessThen,
+	string(dal.LessOrEqual):    dal.LessOrEqual,
+}
+
+func conditionFromDocument(condition DocumentCondition) (dal.Condition, error) {
+	isComparison := condition.Op != "" || condition.Left != nil || condition.Right != nil
+	forms := 0
+	if isComparison {
+		forms++
+	}
+	if condition.And != nil {
+		forms++
+	}
+	if condition.Or != nil {
+		forms++
+	}
+	switch {
+	case forms == 0:
+		return nil, fmt.Errorf("condition must be a comparison (op/left/right) or a group (and/or)")
+	case forms > 1:
+		return nil, fmt.Errorf("condition mixes comparison and group forms")
+	}
+	if isComparison {
+		operator, ok := documentOperators[condition.Op]
+		if !ok {
+			return nil, fmt.Errorf("unknown comparison operator %q", condition.Op)
+		}
+		if condition.Left == nil || condition.Right == nil {
+			return nil, fmt.Errorf("comparison requires both left and right")
+		}
+		left, err := expressionFromDocument(*condition.Left)
+		if err != nil {
+			return nil, fmt.Errorf("comparison left: %w", err)
+		}
+		right, err := expressionFromDocument(*condition.Right)
+		if err != nil {
+			return nil, fmt.Errorf("comparison right: %w", err)
+		}
+		return dal.NewComparison(left, operator, right), nil
+	}
+	operator, members := dal.Operator(dal.And), condition.And
+	if condition.Or != nil {
+		operator, members = dal.Or, condition.Or
+	}
+	if len(members) == 0 {
+		return nil, fmt.Errorf("%s group must have at least one condition", operator)
+	}
+	conditions := make([]dal.Condition, 0, len(members))
+	for i, member := range members {
+		sub, err := conditionFromDocument(member)
+		if err != nil {
+			return nil, fmt.Errorf("group condition #%d: %w", i, err)
+		}
+		conditions = append(conditions, sub)
+	}
+	return dal.NewGroupCondition(operator, conditions...), nil
+}
+
+func expressionFromDocument(expression DocumentExpression) (dal.Expression, error) {
+	set := 0
+	for _, present := range []bool{expression.Field != "", expression.Value != nil, expression.Values != nil, expression.Param != ""} {
+		if present {
+			set++
+		}
+	}
+	if set != 1 {
+		return nil, fmt.Errorf("expression must set exactly one of field, value, values or param")
+	}
+	switch {
+	case expression.Field != "":
+		return dal.NewFieldRef("", expression.Field), nil
+	case expression.Value != nil:
+		return dal.Constant{Value: expression.Value}, nil
+	case expression.Param != "":
+		if !dal.ValidParamName(expression.Param) {
+			return nil, fmt.Errorf("invalid parameter name %q", expression.Param)
+		}
+		return dal.Param{Name: expression.Param}, nil
+	default:
+		return dal.Array{Value: expression.Values}, nil
+	}
+}
+
+func documentFromCondition(condition dal.Condition) (*DocumentCondition, error) {
+	switch c := condition.(type) {
+	case dal.Comparison:
+		if _, ok := documentOperators[string(c.Operator)]; !ok {
+			return nil, fmt.Errorf("unsupported comparison operator %q", c.Operator)
+		}
+		left, err := documentFromExpression(c.Left)
+		if err != nil {
+			return nil, fmt.Errorf("comparison left: %w", err)
+		}
+		right, err := documentFromExpression(c.Right)
+		if err != nil {
+			return nil, fmt.Errorf("comparison right: %w", err)
+		}
+		return &DocumentCondition{Op: string(c.Operator), Left: left, Right: right}, nil
+	case dal.GroupCondition:
+		members := make([]DocumentCondition, 0, len(c.Conditions()))
+		for i, sub := range c.Conditions() {
+			member, err := documentFromCondition(sub)
+			if err != nil {
+				return nil, fmt.Errorf("group condition #%d: %w", i, err)
+			}
+			members = append(members, *member)
+		}
+		switch c.Operator() {
+		case dal.And:
+			return &DocumentCondition{And: members}, nil
+		case dal.Or:
+			return &DocumentCondition{Or: members}, nil
+		default:
+			return nil, fmt.Errorf("unsupported group operator %q", c.Operator())
+		}
+	default:
+		return nil, fmt.Errorf("unsupported condition %T", condition)
+	}
+}
+
+func documentFromExpression(expression dal.Expression) (*DocumentExpression, error) {
+	switch e := expression.(type) {
+	case dal.FieldRef:
+		return &DocumentExpression{Field: e.Name()}, nil
+	case dal.Constant:
+		return &DocumentExpression{Value: e.Value}, nil
+	case dal.Array:
+		return &DocumentExpression{Values: e.Value}, nil
+	case dal.Param:
+		return &DocumentExpression{Param: e.Name}, nil
+	default:
+		return nil, fmt.Errorf("unsupported expression %T", expression)
+	}
+}

--- a/access/document_condition_test.go
+++ b/access/document_condition_test.go
@@ -1,0 +1,150 @@
+package access
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/record"
+)
+
+const conditionalPolicyYAML = `apiVersion: dalgo.io/access/v1
+kind: AccessPolicy
+metadata:
+  name: customers
+default: deny
+scopes:
+  - path: /customers/*
+    rules:
+      - id: read-all
+        effect: allow
+        operations: [read]
+      - id: edit-assigned
+        effect: allow
+        operations: [update, delete]
+        where:
+          op: "=="
+          left: { field: assignedTo }
+          right: { param: currentUser }
+  - path: /customers
+    rules:
+      - id: query-open-or-mine
+        effect: allow
+        operations: [query]
+        where:
+          or:
+            - op: "=="
+              left: { field: status }
+              right: { value: open }
+            - and:
+                - op: In
+                  left: { field: region }
+                  right: { values: [eu, uk] }
+                - op: ">="
+                  left: { field: score }
+                  right: { value: 10 }
+`
+
+func TestConditionalDocumentRoundTrip(t *testing.T) {
+	policy, err := UnmarshalAccessPolicyYAML([]byte(conditionalPolicyYAML))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	ctx := WithCurrentUser(context.Background(), "u1")
+	resource := RecordResourceForKey(record.NewKeyWithID("customers", "c1"))
+	decision := policy.Decide(ctx, Request{Operation: Update, Resources: []Resource{resource}})
+	if !decision.Allowed || decision.Condition != "assignedTo = $currentUser" {
+		t.Fatalf("decoded conditional rule = %+v", decision)
+	}
+	collection := CollectionResourceFor(nil, "customers")
+	decision = policy.Decide(ctx, Request{Operation: Query, Resources: []Resource{collection}})
+	if !decision.Allowed || decision.Residuals[0].String() != "(status = 'open' OR (region In (eu,uk) AND score >= 10))" {
+		t.Fatalf("decoded group rule = %+v", decision)
+	}
+	for name, marshal := range map[string]func(*AccessPolicy) ([]byte, error){"yaml": MarshalAccessPolicyYAML, "json": MarshalAccessPolicyJSON} {
+		encoded, err := marshal(policy)
+		if err != nil {
+			t.Fatalf("%s encode: %v", name, err)
+		}
+		if !strings.Contains(string(encoded), "currentUser") {
+			t.Errorf("%s encoding lost the parameter: %s", name, encoded)
+		}
+		var again *AccessPolicy
+		if name == "yaml" {
+			again, err = UnmarshalAccessPolicyYAML(encoded)
+		} else {
+			again, err = UnmarshalAccessPolicyJSON(encoded)
+		}
+		if err != nil {
+			t.Fatalf("%s decode again: %v", name, err)
+		}
+		for _, request := range []Request{
+			{Operation: Update, Resources: []Resource{resource}},
+			{Operation: Query, Resources: []Resource{collection}},
+			{Operation: Get, Resources: []Resource{resource}},
+		} {
+			first, second := policy.Decide(ctx, request), again.Decide(ctx, request)
+			if first.Allowed != second.Allowed || first.Condition != second.Condition || first.Rule != second.Rule {
+				t.Errorf("%s: decisions differ for %s: %+v vs %+v", name, request.Operation, first, second)
+			}
+		}
+	}
+	// A document with no conditions still round-trips unchanged.
+	plain := MustPolicy("plain", Root(Allow(Read, "all")))
+	encoded, err := MarshalAccessPolicyYAML(plain)
+	if err != nil || strings.Contains(string(encoded), "where") {
+		t.Errorf("plain policy: err=%v encoded=%s", err, encoded)
+	}
+}
+
+func TestDocumentConditionErrors(t *testing.T) {
+	field := func(name string) *DocumentExpression { return &DocumentExpression{Field: name} }
+	value := func(v any) *DocumentExpression { return &DocumentExpression{Value: v} }
+	for name, condition := range map[string]DocumentCondition{
+		"empty":            {},
+		"mixed forms":      {Op: "==", Left: field("a"), Right: value(1), And: []DocumentCondition{{Op: "==", Left: field("a"), Right: value(1)}}},
+		"unknown operator": {Op: "!=", Left: field("a"), Right: value(1)},
+		"missing right":    {Op: "==", Left: field("a")},
+		"bad left":         {Op: "==", Left: &DocumentExpression{}, Right: value(1)},
+		"bad right":        {Op: "==", Left: field("a"), Right: &DocumentExpression{Field: "b", Value: 1}},
+		"bad param":        {Op: "==", Left: field("a"), Right: &DocumentExpression{Param: "1x"}},
+		"empty and":        {And: []DocumentCondition{}},
+		"empty or":         {Or: []DocumentCondition{}},
+		"nested error":     {Or: []DocumentCondition{{}}},
+		"deny condition":   {Op: "==", Left: field("a"), Right: value(1)}, // valid condition on a deny rule below
+	} {
+		effect := "allow"
+		if name == "deny condition" {
+			effect = "deny"
+		}
+		document := Document{APIVersion: DocumentAPIVersion, Kind: AccessPolicyKind, Metadata: DocumentMetadata{Name: "x"}, Default: "deny",
+			Scopes: []DocumentScope{{Path: "/x/*", Rules: []DocumentRule{{ID: "r", Effect: effect, Operations: []string{"get"}, Where: &condition}}}}}
+		if _, err := DecodeAccessPolicy(strings.NewReader(""), staticCodec{d: document}); err == nil {
+			t.Errorf("%s: expected an error", name)
+		}
+	}
+	// Encoding rejects conditions outside the portable subset.
+	for name, condition := range map[string]dal.Condition{
+		"fake":           fakeCond{},
+		"operator":       dal.Comparison{Operator: dal.Operator("!="), Left: dal.Field("a"), Right: dal.Constant{Value: 1}},
+		"left":           dal.Comparison{Operator: dal.Equal, Left: fakeExpr{}, Right: dal.Constant{Value: 1}},
+		"right":          dal.Comparison{Operator: dal.Equal, Left: dal.Field("a"), Right: fakeExpr{}},
+		"group operator": dal.NewGroupCondition(dal.Operator("XOR"), dal.WhereField("a", dal.Equal, dal.Constant{Value: 1})),
+		"group member":   dal.NewGroupCondition(dal.And, fakeCond{}),
+	} {
+		if _, err := documentFromCondition(condition); err == nil {
+			t.Errorf("encode %s: expected an error", name)
+		}
+	}
+	// A rule whose condition cannot be encoded is reported as not serializable.
+	policy := &AccessPolicy{name: "p", rules: []Rule{Root(Rule{kind: directiveRule, effect: effectAllow, operations: Get, name: "r", where: fakeCond{}})}}
+	if _, err := MarshalAccessPolicyYAML(policy); !errors.Is(err, ErrNotSerializable) {
+		t.Errorf("unserialisable condition = %v", err)
+	}
+}
+
+type fakeExpr struct{}
+
+func (fakeExpr) String() string { return "fake" }

--- a/access/policy.go
+++ b/access/policy.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
+	"github.com/dal-go/dalgo/condeval"
 	"github.com/dal-go/dalgo/dal"
 )
 
@@ -37,6 +39,15 @@ type Decision struct {
 	Rule         string
 	Effect       string
 	Explanation  string
+	// Condition is the source text of the row condition behind a conditional
+	// decision, with parameter names rather than resolved values.
+	Condition string
+	// Residuals holds, per request resource (same index as Request.Resources),
+	// the resolved row condition the caller must still enforce before the
+	// operation is complete: after the read for point operations, by query
+	// rewrite for Query. A nil entry means the resource is allowed outright.
+	// Residuals is nil for an unconditional decision.
+	Residuals []dal.Condition
 }
 
 // DeniedError is returned when a policy rejects an operation.
@@ -102,7 +113,7 @@ func (p *AccessPolicy) Name() string { return p.name }
 // a policy document, such as an object key, URL, database key, or file path.
 func (p *AccessPolicy) Source() string { return p.source }
 
-func (p *AccessPolicy) Decide(_ context.Context, request Request) Decision {
+func (p *AccessPolicy) Decide(ctx context.Context, request Request) Decision {
 	if !request.Operation.validLeaf() {
 		return Decision{
 			Operation:    request.Operation,
@@ -122,16 +133,25 @@ func (p *AccessPolicy) Decide(_ context.Context, request Request) Decision {
 		}
 	}
 	var last Decision
-	for _, resource := range request.Resources {
-		last = p.decideResource(request.Operation, resource)
+	var residuals []dal.Condition
+	resolver := newVariableResolver(ctx)
+	for i, resource := range request.Resources {
+		last = p.decideResource(resolver, request.Operation, resource)
 		if !last.Allowed {
 			return last
 		}
+		if last.Residuals != nil {
+			if residuals == nil {
+				residuals = make([]dal.Condition, len(request.Resources))
+			}
+			residuals[i] = last.Residuals[0]
+		}
 	}
+	last.Residuals = residuals
 	return last
 }
 
-func (p *AccessPolicy) decideResource(operation Operations, resource Resource) Decision {
+func (p *AccessPolicy) decideResource(resolver variableResolver, operation Operations, resource Resource) Decision {
 	matching := matchingRules(p.compiled, operation, resource)
 	if len(matching) == 0 {
 		return Decision{
@@ -143,19 +163,79 @@ func (p *AccessPolicy) decideResource(operation Operations, resource Resource) D
 			Explanation:  "no matching allow rule",
 		}
 	}
-	winner := matching[0]
-	allowed := winner.effect == effectAllow
-	explanation := fmt.Sprintf("matched rule %q (%s)", winner.name, winner.effect)
+	// Walk matches in precedence order: conditional allows met before the first
+	// unconditional rule apply to the rows their conditions select; the first
+	// unconditional rule settles everything else. An unconditional allow makes
+	// the collected conditions moot; a deny (or no unconditional rule at all)
+	// leaves their disjunction as the residual the caller must enforce.
+	var conditional []compiledRule
+	var terminal *compiledRule
+	for i := range matching {
+		if matching[i].where == nil {
+			terminal = &matching[i]
+			break
+		}
+		conditional = append(conditional, matching[i])
+	}
+	if terminal != nil && (len(conditional) == 0 || terminal.effect == effectAllow) {
+		allowed := terminal.effect == effectAllow
+		return Decision{
+			Allowed:      allowed,
+			Operation:    operation,
+			Resource:     resource,
+			Policy:       p.name,
+			PolicySource: p.source,
+			Rule:         terminal.name,
+			Effect:       terminal.effect.String(),
+			Explanation:  fmt.Sprintf("matched rule %q (%s)", terminal.name, terminal.effect),
+		}
+	}
+	parts := make([]dal.Condition, 0, len(conditional))
+	names := make([]string, 0, len(conditional))
+	texts := make([]string, 0, len(conditional))
+	for _, rule := range conditional {
+		resolved, err := condeval.Substitute(rule.where, resolver.resolve)
+		if err != nil {
+			return Decision{
+				Operation:    operation,
+				Resource:     resource,
+				Policy:       p.name,
+				PolicySource: p.source,
+				Rule:         rule.name,
+				Effect:       effectDeny.String(),
+				Condition:    rule.where.String(),
+				Explanation:  fmt.Sprintf("cannot evaluate rule %q: %v", rule.name, err),
+			}
+		}
+		parts = append(parts, resolved)
+		names = append(names, rule.name)
+		texts = append(texts, rule.where.String())
+	}
+	residual, text := parts[0], texts[0]
+	if len(parts) > 1 {
+		residual = dal.NewGroupCondition(dal.Or, parts...)
+		text = "(" + strings.Join(texts, " OR ") + ")"
+	}
 	return Decision{
-		Allowed:      allowed,
+		Allowed:      true,
 		Operation:    operation,
 		Resource:     resource,
 		Policy:       p.name,
 		PolicySource: p.source,
-		Rule:         winner.name,
-		Effect:       winner.effect.String(),
-		Explanation:  explanation,
+		Rule:         strings.Join(names, ", "),
+		Effect:       effectAllow.String(),
+		Condition:    text,
+		Explanation:  fmt.Sprintf("matched conditional rule(s) %s (where: %s)", quoteAll(names), text),
+		Residuals:    []dal.Condition{residual},
 	}
+}
+
+func quoteAll(names []string) string {
+	quoted := make([]string, len(names))
+	for i, name := range names {
+		quoted[i] = fmt.Sprintf("%q", name)
+	}
+	return strings.Join(quoted, ", ")
 }
 
 func (p *AccessPolicy) Authorize(ctx context.Context, request Request) error {

--- a/access/rule.go
+++ b/access/rule.go
@@ -3,6 +3,9 @@ package access
 import (
 	"fmt"
 	"strings"
+
+	"github.com/dal-go/dalgo/condeval"
+	"github.com/dal-go/dalgo/dal"
 )
 
 type effect uint8
@@ -48,6 +51,21 @@ type Rule struct {
 	effect     effect
 	resource   string
 	children   []Rule
+	where      dal.Condition
+}
+
+// Where attaches a row condition to an allow rule: the rule applies only to
+// records whose values satisfy condition. The condition is a dal.Condition over
+// the record's fields (comparisons, In, And/Or groups) whose right-hand values
+// may be parameters such as dal.NewParam("currentUser"), resolved from the
+// operation context (see WithVariables and WithCurrentUser).
+//
+// Conditions are valid on allow rules under path scopes only. A conditional
+// rule never authorises Truncate: naming it explicitly fails compilation, while
+// the write and readwrite groups simply drop it.
+func (r Rule) Where(condition dal.Condition) Rule {
+	r.where = condition
+	return r
 }
 
 // Allow permits operations at the containing scope. The optional name appears
@@ -120,6 +138,8 @@ type compiledRule struct {
 	effect     effect
 	depth      int
 	literals   int
+	where      dal.Condition
+	params     []string
 }
 
 func compileRules(rules []Rule, allowedEffects map[effect]bool) ([]compiledRule, error) {
@@ -147,6 +167,9 @@ func compileRule(
 	allowedEffects map[effect]bool,
 	compiled *[]compiledRule,
 ) error {
+	if rule.where != nil && rule.kind != directiveRule {
+		return fmt.Errorf("access: conditions are only valid on allow rules, not on scopes")
+	}
 	switch rule.kind {
 	case directiveRule:
 		if !allowedEffects[rule.effect] {
@@ -155,19 +178,45 @@ func compileRule(
 		if !rule.operations.validSet() {
 			return fmt.Errorf("access: rule %q has an invalid operation set", rule.name)
 		}
+		operations := rule.operations
+		var params []string
+		if rule.where != nil {
+			if rule.effect != effectAllow {
+				return fmt.Errorf("access: rule %q: conditional %s rules are not supported; conditions apply to allow rules only", rule.name, rule.effect)
+			}
+			if resourceKind != PathResource {
+				return fmt.Errorf("access: rule %q: conditions are not valid on %s rules", rule.name, resourceKind)
+			}
+			if operations&Truncate != 0 {
+				if operations != Write && operations != ReadWrite {
+					return fmt.Errorf("access: rule %q: a conditional rule cannot authorise truncate", rule.name)
+				}
+				operations &^= Truncate
+			}
+			info, err := condeval.Validate(rule.where)
+			if err != nil {
+				return fmt.Errorf("access: rule %q: invalid condition: %w", rule.name, err)
+			}
+			params = info.Params
+		}
 		name := rule.name
 		if name == "" {
-			name = fmt.Sprintf("%s %s at %s", rule.effect, rule.operations, resourceDescription(resourceKind, resourceName, prefix))
+			name = fmt.Sprintf("%s %s at %s", rule.effect, operations, resourceDescription(resourceKind, resourceName, prefix))
+			if rule.where != nil {
+				name += " where " + rule.where.String()
+			}
 		}
 		*compiled = append(*compiled, compiledRule{
 			kind:       resourceKind,
 			pattern:    prefix,
 			resource:   resourceName,
 			name:       name,
-			operations: rule.operations,
+			operations: operations,
 			effect:     rule.effect,
 			depth:      len(prefix.segments),
 			literals:   literalCount(prefix),
+			where:      rule.where,
+			params:     params,
 		})
 		return nil
 	case scopeRule:

--- a/access/session.go
+++ b/access/session.go
@@ -16,41 +16,68 @@ type securedReadSession struct {
 }
 
 func (s securedReadSession) Exists(ctx context.Context, key *record.Key) (bool, error) {
-	if err := s.guard.authorize(ctx, Exists, RecordResourceForKey(key)); err != nil {
+	residuals, err := s.guard.authorizeRequest(ctx, Request{Operation: Exists, Resources: []Resource{RecordResourceForKey(key)}})
+	if err != nil {
 		return false, err
 	}
-	return s.session.Exists(ctx, key)
+	if len(residuals) == 0 {
+		return s.session.Exists(ctx, key)
+	}
+	return existsThroughRead(ctx, s.session, key, residuals[0])
 }
 
 func (s securedReadSession) Get(ctx context.Context, record record.Record) error {
-	if err := s.guard.authorize(ctx, Get, RecordResourceForKey(record.Key())); err != nil {
+	residuals, err := s.guard.authorizeRequest(ctx, Request{Operation: Get, Resources: []Resource{RecordResourceForKey(record.Key())}})
+	if err != nil {
 		return err
 	}
-	return s.session.Get(ctx, record)
+	if err := s.session.Get(ctx, record); err != nil {
+		return err
+	}
+	if len(residuals) == 0 {
+		return nil
+	}
+	return checkRecord(Get, record, residuals[0])
 }
 
 func (s securedReadSession) GetMulti(ctx context.Context, records []record.Record) error {
 	resources := resourcesForRecords(records)
-	if err := s.guard.authorize(ctx, Get, resources...); err != nil {
+	residuals, err := s.guard.authorizeRequest(ctx, Request{Operation: Get, Resources: resources})
+	if err != nil {
 		return err
 	}
-	return s.session.GetMulti(ctx, records)
+	if err := s.session.GetMulti(ctx, records); err != nil {
+		return err
+	}
+	return checkRecords(Get, records, residuals)
 }
 
 func (s securedReadSession) ExecuteQueryToRecordsReader(ctx context.Context, query dal.Query) (dal.RecordsReader, error) {
-	resources := resourcesForQuery(query)
-	if err := s.guard.authorizeRequest(ctx, Request{Operation: Query, Resources: resources, Query: query}); err != nil {
+	query, err := s.authorizeQuery(ctx, query)
+	if err != nil {
 		return nil, err
 	}
 	return s.session.ExecuteQueryToRecordsReader(ctx, query)
 }
 
 func (s securedReadSession) ExecuteQueryToRecordsetReader(ctx context.Context, query dal.Query, options ...recordset.Option) (dal.RecordsetReader, error) {
-	resources := resourcesForQuery(query)
-	if err := s.guard.authorizeRequest(ctx, Request{Operation: Query, Resources: resources, Query: query}); err != nil {
+	query, err := s.authorizeQuery(ctx, query)
+	if err != nil {
 		return nil, err
 	}
 	return s.session.ExecuteQueryToRecordsetReader(ctx, query, options...)
+}
+
+// authorizeQuery authorizes every source of a query and returns the query to
+// execute: the caller's own when no residual applies, otherwise a copy whose
+// Where carries the residual row condition.
+func (s securedReadSession) authorizeQuery(ctx context.Context, query dal.Query) (dal.Query, error) {
+	resources := resourcesForQuery(query)
+	residuals, err := s.guard.authorizeRequest(ctx, Request{Operation: Query, Resources: resources, Query: query})
+	if err != nil {
+		return nil, err
+	}
+	return rewriteQuery(query, residuals)
 }
 
 type securedWriteSession struct {

--- a/condeval/condeval.go
+++ b/condeval/condeval.go
@@ -1,0 +1,375 @@
+// Package condeval evaluates dal.Condition trees against record values.
+//
+// It is the shared, adapter-independent evaluator behind row-level access
+// conditions: a condition is validated once when a policy is compiled
+// (Validate), its parameters are substituted from runtime values
+// (Substitute), and the resolved condition is matched against a record's data
+// (Match). Record data is normalised through a JSON round trip (ToMap), so
+// struct fields are addressed by their JSON names, numbers compare as float64,
+// and times compare as RFC 3339 strings — the same shape the in-memory adapter
+// stores and queries.
+//
+// The supported subset mirrors the core query model: comparisons of a field
+// reference with a constant, an array (for In) or a parameter, combined with
+// And/Or groups. Anything else is rejected by Validate and reported as an error
+// by Match, never silently treated as a match.
+package condeval
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/dal-go/dalgo/dal"
+)
+
+// Info describes the field and parameter names a condition references.
+type Info struct {
+	Fields []string
+	Params []string
+}
+
+var comparisonOperators = map[dal.Operator]bool{
+	dal.Equal:          true,
+	dal.In:             true,
+	dal.GreaterThen:    true,
+	dal.GreaterOrEqual: true,
+	dal.LessThen:       true,
+	dal.LessOrEqual:    true,
+}
+
+// Validate checks that condition uses only the supported subset and returns
+// the field and parameter names it references, each sorted and de-duplicated.
+func Validate(condition dal.Condition) (Info, error) {
+	if condition == nil {
+		return Info{}, fmt.Errorf("condeval: condition is required")
+	}
+	fields := map[string]struct{}{}
+	params := map[string]struct{}{}
+	if err := validate(condition, fields, params); err != nil {
+		return Info{}, err
+	}
+	return Info{Fields: sortedKeys(fields), Params: sortedKeys(params)}, nil
+}
+
+func validate(condition dal.Condition, fields, params map[string]struct{}) error {
+	switch c := condition.(type) {
+	case dal.GroupCondition:
+		if c.Operator() != dal.And && c.Operator() != dal.Or {
+			return fmt.Errorf("condeval: unsupported group operator %q", c.Operator())
+		}
+		if len(c.Conditions()) == 0 {
+			return fmt.Errorf("condeval: %s group must have at least one condition", c.Operator())
+		}
+		for _, sub := range c.Conditions() {
+			if sub == nil {
+				return fmt.Errorf("condeval: %s group contains a nil condition", c.Operator())
+			}
+			if err := validate(sub, fields, params); err != nil {
+				return err
+			}
+		}
+		return nil
+	case dal.Comparison:
+		if !comparisonOperators[c.Operator] {
+			return fmt.Errorf("condeval: unsupported comparison operator %q", c.Operator)
+		}
+		field, ok := c.Left.(dal.FieldRef)
+		if !ok {
+			return fmt.Errorf("condeval: comparison left operand must be a field reference, got %T", c.Left)
+		}
+		if field.Source() != "" {
+			return fmt.Errorf("condeval: field reference %q must not be source-qualified", field)
+		}
+		if field.Name() == "" {
+			return fmt.Errorf("condeval: field reference has an empty name")
+		}
+		fields[field.Name()] = struct{}{}
+		switch right := c.Right.(type) {
+		case dal.Constant:
+			if c.Operator == dal.In {
+				return fmt.Errorf("condeval: In requires an array or a parameter on the right, got a constant")
+			}
+		case dal.Array:
+			if c.Operator != dal.In {
+				return fmt.Errorf("condeval: an array on the right requires the In operator, got %q", c.Operator)
+			}
+			if !isSlice(right.Value) {
+				return fmt.Errorf("condeval: array value must be a slice or array, got %T", right.Value)
+			}
+		case dal.Param:
+			if !dal.ValidParamName(right.Name) {
+				return fmt.Errorf("condeval: invalid parameter name %q", right.Name)
+			}
+			params[right.Name] = struct{}{}
+		default:
+			return fmt.Errorf("condeval: comparison right operand must be a constant, an array or a parameter, got %T", c.Right)
+		}
+		return nil
+	default:
+		return fmt.Errorf("condeval: unsupported condition %T", condition)
+	}
+}
+
+// Substitute returns a copy of condition with every parameter replaced by the
+// value resolve returns for its name: a slice or array becomes a dal.Array,
+// anything else a dal.Constant. An unresolved parameter is an error that names
+// it, so callers can fail closed and explain why.
+func Substitute(condition dal.Condition, resolve func(name string) (any, bool)) (dal.Condition, error) {
+	switch c := condition.(type) {
+	case dal.GroupCondition:
+		subs := make([]dal.Condition, 0, len(c.Conditions()))
+		for _, sub := range c.Conditions() {
+			resolved, err := Substitute(sub, resolve)
+			if err != nil {
+				return nil, err
+			}
+			subs = append(subs, resolved)
+		}
+		return dal.NewGroupCondition(c.Operator(), subs...), nil
+	case dal.Comparison:
+		param, ok := c.Right.(dal.Param)
+		if !ok {
+			return c, nil
+		}
+		value, found := resolve(param.Name)
+		if !found {
+			return nil, fmt.Errorf("condeval: unresolved parameter $%s", param.Name)
+		}
+		var right dal.Expression = dal.Constant{Value: value}
+		if isSlice(value) {
+			right = dal.Array{Value: value}
+		}
+		return dal.Comparison{Operator: c.Operator, Left: c.Left, Right: right}, nil
+	default:
+		return nil, fmt.Errorf("condeval: unsupported condition %T", condition)
+	}
+}
+
+// Match reports whether data satisfies condition. A nil condition matches. A
+// field the record lacks never satisfies a comparison. A condition outside the
+// supported subset, or one still carrying a parameter, is an error.
+func Match(data map[string]any, condition dal.Condition) (bool, error) {
+	switch c := condition.(type) {
+	case nil:
+		return true, nil
+	case dal.GroupCondition:
+		switch c.Operator() {
+		case dal.And:
+			for _, sub := range c.Conditions() {
+				ok, err := Match(data, sub)
+				if err != nil || !ok {
+					return false, err
+				}
+			}
+			return true, nil
+		case dal.Or:
+			for _, sub := range c.Conditions() {
+				ok, err := Match(data, sub)
+				if err != nil || ok {
+					return ok, err
+				}
+			}
+			return false, nil
+		default:
+			return false, fmt.Errorf("condeval: unsupported group operator %q", c.Operator())
+		}
+	case dal.Comparison:
+		return matchComparison(data, c)
+	default:
+		return false, fmt.Errorf("condeval: unsupported condition %T", condition)
+	}
+}
+
+func matchComparison(data map[string]any, c dal.Comparison) (bool, error) {
+	field, ok := c.Left.(dal.FieldRef)
+	if !ok {
+		return false, fmt.Errorf("condeval: comparison left operand must be a field reference, got %T", c.Left)
+	}
+	var rightValue any
+	switch right := c.Right.(type) {
+	case dal.Constant:
+		rightValue = right.Value
+	case dal.Array:
+		rightValue = right.Value
+	case dal.Param:
+		return false, fmt.Errorf("condeval: unresolved parameter $%s", right.Name)
+	default:
+		return false, fmt.Errorf("condeval: comparison right operand must be a constant or an array, got %T", c.Right)
+	}
+	fieldValue, found := Lookup(data, field.Name())
+	if !found {
+		return false, nil
+	}
+	switch c.Operator {
+	case dal.Equal:
+		return equal(fieldValue, rightValue), nil
+	case dal.In:
+		if !isSlice(rightValue) {
+			return false, fmt.Errorf("condeval: In requires an array on the right, got %T", rightValue)
+		}
+		return contains(fieldValue, rightValue), nil
+	case dal.GreaterThen, dal.GreaterOrEqual, dal.LessThen, dal.LessOrEqual:
+		return ordered(c.Operator, fieldValue, rightValue), nil
+	default:
+		return false, fmt.Errorf("condeval: unsupported comparison operator %q", c.Operator)
+	}
+}
+
+// Lookup resolves a dotted field path ("address.city") in nested maps.
+func Lookup(data map[string]any, path string) (any, bool) {
+	current := any(data)
+	for _, part := range strings.Split(path, ".") {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = m[part]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+// ToMap renders record data as the JSON-normalised map Match evaluates: struct
+// fields under their JSON names, numbers as float64, times as RFC 3339 strings.
+// Nil data is an empty map.
+func ToMap(data any) (map[string]any, error) {
+	if data == nil {
+		return map[string]any{}, nil
+	}
+	if pointer, ok := data.(*map[string]any); ok {
+		if pointer == nil {
+			return map[string]any{}, nil
+		}
+		data = *pointer
+	}
+	encoded, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("condeval: record data is not JSON-serialisable: %w", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(encoded, &out); err != nil {
+		return nil, fmt.Errorf("condeval: record data is not an object: %w", err)
+	}
+	if out == nil {
+		out = map[string]any{}
+	}
+	return out, nil
+}
+
+// normalize renders a value the way ToMap renders record data, so a constant
+// written as int or time.Time compares against stored float64 or string.
+func normalize(value any) (any, bool) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return nil, false
+	}
+	var out any
+	_ = json.Unmarshal(encoded, &out)
+	return out, true
+}
+
+func equal(a, b any) bool {
+	na, ok := normalize(a)
+	if !ok {
+		return false
+	}
+	nb, ok := normalize(b)
+	if !ok {
+		return false
+	}
+	return reflect.DeepEqual(na, nb)
+}
+
+// contains implements In: a scalar field value must be one of values; an
+// array field value must share at least one element with values.
+func contains(fieldValue, values any) bool {
+	candidates := reflect.ValueOf(values)
+	if isSlice(fieldValue) {
+		elements := reflect.ValueOf(fieldValue)
+		for i := 0; i < elements.Len(); i++ {
+			for j := 0; j < candidates.Len(); j++ {
+				if equal(elements.Index(i).Interface(), candidates.Index(j).Interface()) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	for j := 0; j < candidates.Len(); j++ {
+		if equal(fieldValue, candidates.Index(j).Interface()) {
+			return true
+		}
+	}
+	return false
+}
+
+func ordered(operator dal.Operator, a, b any) bool {
+	na, ok := normalize(a)
+	if !ok {
+		return false
+	}
+	nb, ok := normalize(b)
+	if !ok {
+		return false
+	}
+	var cmp int
+	switch left := na.(type) {
+	case float64:
+		right, ok := nb.(float64)
+		if !ok {
+			return false
+		}
+		cmp = compareFloats(left, right)
+	case string:
+		right, ok := nb.(string)
+		if !ok {
+			return false
+		}
+		cmp = strings.Compare(left, right)
+	default:
+		return false
+	}
+	switch operator {
+	case dal.GreaterThen:
+		return cmp > 0
+	case dal.GreaterOrEqual:
+		return cmp >= 0
+	case dal.LessThen:
+		return cmp < 0
+	default: // dal.LessOrEqual
+		return cmp <= 0
+	}
+}
+
+func compareFloats(a, b float64) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func isSlice(value any) bool {
+	if value == nil {
+		return false
+	}
+	kind := reflect.TypeOf(value).Kind()
+	return kind == reflect.Slice || kind == reflect.Array
+}
+
+func sortedKeys(set map[string]struct{}) []string {
+	keys := make([]string, 0, len(set))
+	for key := range set {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/condeval/condeval_test.go
+++ b/condeval/condeval_test.go
@@ -1,0 +1,222 @@
+package condeval
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dal-go/dalgo/dal"
+)
+
+func field(name string) dal.FieldRef { return dal.Field(name) }
+
+func cmp(name string, op dal.Operator, right dal.Expression) dal.Comparison {
+	return dal.Comparison{Operator: op, Left: field(name), Right: right}
+}
+
+func TestValidate(t *testing.T) {
+	good := dal.NewGroupCondition(dal.And,
+		cmp("createdBy", dal.Equal, dal.NewParam("currentUser")),
+		dal.NewGroupCondition(dal.Or,
+			cmp("status", dal.In, dal.Array{Value: []string{"draft", "review"}}),
+			cmp("age", dal.GreaterOrEqual, dal.Constant{Value: 18}),
+			cmp("role", dal.In, dal.NewParam("principal.roles")),
+		),
+	)
+	info, err := Validate(good)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if want := []string{"age", "createdBy", "role", "status"}; !reflect.DeepEqual(info.Fields, want) {
+		t.Errorf("Fields = %v, want %v", info.Fields, want)
+	}
+	if want := []string{"currentUser", "principal.roles"}; !reflect.DeepEqual(info.Params, want) {
+		t.Errorf("Params = %v, want %v", info.Params, want)
+	}
+	for name, bad := range map[string]dal.Condition{
+		"nil":               nil,
+		"unknown node":      fakeCondition{},
+		"group operator":    dal.NewGroupCondition(dal.Operator("XOR"), cmp("a", dal.Equal, dal.Constant{Value: 1})),
+		"empty group":       dal.NewGroupCondition(dal.And),
+		"nil in group":      dal.NewGroupCondition(dal.And, nil),
+		"bad nested":        dal.NewGroupCondition(dal.And, fakeCondition{}),
+		"operator":          cmp("a", dal.Operator("!="), dal.Constant{Value: 1}),
+		"left constant":     dal.Comparison{Operator: dal.Equal, Left: dal.Constant{Value: 1}, Right: field("a")},
+		"left qualified":    dal.Comparison{Operator: dal.Equal, Left: dal.NewFieldRef("t", "a"), Right: dal.Constant{Value: 1}},
+		"left empty":        dal.Comparison{Operator: dal.Equal, Left: dal.NewFieldRef("", ""), Right: dal.Constant{Value: 1}},
+		"in with constant":  cmp("a", dal.In, dal.Constant{Value: 1}),
+		"array without in":  cmp("a", dal.Equal, dal.Array{Value: []int{1}}),
+		"array not a slice": cmp("a", dal.In, dal.Array{Value: 1}),
+		"array nil":         cmp("a", dal.In, dal.Array{Value: nil}),
+		"bad param name":    cmp("a", dal.Equal, dal.Param{Name: "1x"}),
+		"right unknown":     dal.Comparison{Operator: dal.Equal, Left: field("a"), Right: field("b")},
+	} {
+		if _, err := Validate(bad); err == nil {
+			t.Errorf("Validate(%s) = nil error, want error", name)
+		}
+	}
+}
+
+type fakeCondition struct{}
+
+func (fakeCondition) String() string { return "fake" }
+
+func TestSubstitute(t *testing.T) {
+	resolve := func(name string) (any, bool) {
+		switch name {
+		case "currentUser":
+			return "u1", true
+		case "principal.roles":
+			return []string{"admin", "member"}, true
+		}
+		return nil, false
+	}
+	condition := dal.NewGroupCondition(dal.And,
+		cmp("createdBy", dal.Equal, dal.NewParam("currentUser")),
+		cmp("role", dal.In, dal.NewParam("principal.roles")),
+		cmp("status", dal.Equal, dal.Constant{Value: "active"}),
+	)
+	resolved, err := Substitute(condition, resolve)
+	if err != nil {
+		t.Fatalf("Substitute: %v", err)
+	}
+	if got := resolved.String(); got != "(createdBy = 'u1' AND role In ('admin','member') AND status = 'active')" {
+		t.Errorf("String() = %q", got)
+	}
+	if _, err := Substitute(cmp("a", dal.Equal, dal.NewParam("missing")), resolve); err == nil || !strings.Contains(err.Error(), "$missing") {
+		t.Errorf("unresolved parameter error = %v", err)
+	}
+	if _, err := Substitute(dal.NewGroupCondition(dal.And, cmp("a", dal.Equal, dal.NewParam("missing"))), resolve); err == nil {
+		t.Error("unresolved parameter inside a group must fail")
+	}
+	if _, err := Substitute(fakeCondition{}, resolve); err == nil {
+		t.Error("unknown condition must fail")
+	}
+}
+
+func TestMatch(t *testing.T) {
+	now := time.Date(2026, 9, 3, 10, 0, 0, 0, time.UTC)
+	data, err := ToMap(map[string]any{
+		"ownerID": "u1",
+		"age":     42,
+		"tags":    []string{"a", "b"},
+		"when":    now,
+		"address": map[string]any{"city": "Limerick"},
+		"flag":    true,
+	})
+	if err != nil {
+		t.Fatalf("ToMap: %v", err)
+	}
+	for name, tc := range map[string]struct {
+		condition dal.Condition
+		want      bool
+	}{
+		"nil":                      {nil, true},
+		"equal string":             {cmp("ownerID", dal.Equal, dal.Constant{Value: "u1"}), true},
+		"equal mismatch":           {cmp("ownerID", dal.Equal, dal.Constant{Value: "u2"}), false},
+		"equal int vs float":       {cmp("age", dal.Equal, dal.Constant{Value: 42}), true},
+		"equal bool":               {cmp("flag", dal.Equal, dal.Constant{Value: true}), true},
+		"equal time":               {cmp("when", dal.Equal, dal.Constant{Value: now}), true},
+		"missing field":            {cmp("nope", dal.Equal, dal.Constant{Value: "u1"}), false},
+		"nested":                   {cmp("address.city", dal.Equal, dal.Constant{Value: "Limerick"}), true},
+		"nested missing":           {cmp("address.zip", dal.Equal, dal.Constant{Value: "x"}), false},
+		"nested not a map":         {cmp("ownerID.x", dal.Equal, dal.Constant{Value: "x"}), false},
+		"in scalar":                {cmp("ownerID", dal.In, dal.Array{Value: []string{"u2", "u1"}}), true},
+		"in scalar miss":           {cmp("ownerID", dal.In, dal.Array{Value: []string{"u2"}}), false},
+		"in array overlap":         {cmp("tags", dal.In, dal.Array{Value: []string{"z", "b"}}), true},
+		"in array miss":            {cmp("tags", dal.In, dal.Array{Value: []string{"z"}}), false},
+		"gt":                       {cmp("age", dal.GreaterThen, dal.Constant{Value: 41}), true},
+		"ge":                       {cmp("age", dal.GreaterOrEqual, dal.Constant{Value: 42}), true},
+		"lt":                       {cmp("age", dal.LessThen, dal.Constant{Value: 42}), false},
+		"le":                       {cmp("age", dal.LessOrEqual, dal.Constant{Value: 42}), true},
+		"time before":              {cmp("when", dal.LessThen, dal.Constant{Value: now.Add(time.Hour)}), true},
+		"ordered mixed":            {cmp("age", dal.GreaterThen, dal.Constant{Value: "x"}), false},
+		"ordered string vs number": {cmp("ownerID", dal.GreaterThen, dal.Constant{Value: 1}), false},
+		"ordered unsupported type": {cmp("flag", dal.GreaterThen, dal.Constant{Value: true}), false},
+		"and": {dal.NewGroupCondition(dal.And,
+			cmp("ownerID", dal.Equal, dal.Constant{Value: "u1"}),
+			cmp("age", dal.GreaterThen, dal.Constant{Value: 40})), true},
+		"and short-circuit": {dal.NewGroupCondition(dal.And,
+			cmp("ownerID", dal.Equal, dal.Constant{Value: "u2"}),
+			cmp("age", dal.GreaterThen, dal.Constant{Value: 40})), false},
+		"or": {dal.NewGroupCondition(dal.Or,
+			cmp("ownerID", dal.Equal, dal.Constant{Value: "u2"}),
+			cmp("age", dal.GreaterThen, dal.Constant{Value: 40})), true},
+		"or none": {dal.NewGroupCondition(dal.Or,
+			cmp("ownerID", dal.Equal, dal.Constant{Value: "u2"}),
+			cmp("age", dal.GreaterThen, dal.Constant{Value: 50})), false},
+	} {
+		got, err := Match(data, tc.condition)
+		if err != nil {
+			t.Errorf("Match(%s): %v", name, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("Match(%s) = %v, want %v", name, got, tc.want)
+		}
+	}
+	for name, bad := range map[string]dal.Condition{
+		"unknown node":     fakeCondition{},
+		"group operator":   dal.NewGroupCondition(dal.Operator("XOR"), cmp("a", dal.Equal, dal.Constant{Value: 1})),
+		"and nested error": dal.NewGroupCondition(dal.And, fakeCondition{}),
+		"or nested error":  dal.NewGroupCondition(dal.Or, fakeCondition{}),
+		"left not a field": dal.Comparison{Operator: dal.Equal, Left: dal.Constant{Value: 1}, Right: dal.Constant{Value: 1}},
+		"unresolved param": cmp("ownerID", dal.Equal, dal.NewParam("currentUser")),
+		"right unknown":    dal.Comparison{Operator: dal.Equal, Left: field("ownerID"), Right: field("x")},
+		"in without array": cmp("ownerID", dal.In, dal.Constant{Value: "u1"}),
+		"unknown operator": cmp("ownerID", dal.Operator("!="), dal.Constant{Value: "u1"}),
+	} {
+		if _, err := Match(data, bad); err == nil {
+			t.Errorf("Match(%s) = nil error, want error", name)
+		}
+	}
+}
+
+func TestMatchNonSerialisableValues(t *testing.T) {
+	data := map[string]any{"ch": make(chan int), "n": 1.0}
+	if ok, _ := Match(data, cmp("ch", dal.Equal, dal.Constant{Value: 1})); ok {
+		t.Error("a non-serialisable field value must not equal anything")
+	}
+	if ok, _ := Match(data, cmp("n", dal.Equal, dal.Constant{Value: make(chan int)})); ok {
+		t.Error("a non-serialisable constant must not equal anything")
+	}
+	if ok, _ := Match(data, cmp("ch", dal.GreaterThen, dal.Constant{Value: 1})); ok {
+		t.Error("a non-serialisable field value must not be ordered")
+	}
+	if ok, _ := Match(data, cmp("n", dal.GreaterThen, dal.Constant{Value: make(chan int)})); ok {
+		t.Error("a non-serialisable constant must not be ordered")
+	}
+}
+
+func TestToMap(t *testing.T) {
+	type user struct {
+		Name  string `json:"name"`
+		Email string `json:"email,omitempty"`
+	}
+	if m, err := ToMap(nil); err != nil || len(m) != 0 {
+		t.Errorf("ToMap(nil) = %v, %v", m, err)
+	}
+	if m, err := ToMap((*map[string]any)(nil)); err != nil || len(m) != 0 {
+		t.Errorf("ToMap(nil pointer) = %v, %v", m, err)
+	}
+	source := map[string]any{"a": 1}
+	if m, err := ToMap(&source); err != nil || m["a"] != 1.0 {
+		t.Errorf("ToMap(*map) = %v, %v", m, err)
+	}
+	if m, err := ToMap(user{Name: "Ada"}); err != nil || m["name"] != "Ada" || len(m) != 1 {
+		t.Errorf("ToMap(struct) = %v, %v", m, err)
+	}
+	if m, err := ToMap(&user{Name: "Ada"}); err != nil || m["name"] != "Ada" {
+		t.Errorf("ToMap(*struct) = %v, %v", m, err)
+	}
+	if _, err := ToMap(make(chan int)); err == nil {
+		t.Error("ToMap(chan) must fail")
+	}
+	if _, err := ToMap([]int{1}); err == nil {
+		t.Error("ToMap(slice) must fail: not an object")
+	}
+	if m, err := ToMap((*user)(nil)); err != nil || len(m) != 0 {
+		t.Errorf("ToMap(nil struct pointer) = %v, %v", m, err)
+	}
+}

--- a/dal/q_field_ref.go
+++ b/dal/q_field_ref.go
@@ -75,6 +75,8 @@ func WhereField(name string, operator Operator, v any) Condition {
 		val = v
 	case FieldRef:
 		val = v
+	case Param:
+		val = v
 	case Array:
 		if operator != In {
 			panic("arrays must use with `In` operator")

--- a/dal/q_param.go
+++ b/dal/q_param.go
@@ -1,0 +1,44 @@
+package dal
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var _ Expression = Param{}
+
+// Param is a named parameter expression, written "$<name>" in query text and
+// DTQL. It stands for a runtime value that is substituted before a query or a
+// policy condition is executed: access policies resolve it from the operation
+// context ($currentUser, $now, named variables), and a saved DTQL query can
+// carry it until execution time. Adapters never receive a Param; the layer that
+// owns the values replaces it with a Constant (scalar) or an Array (slice).
+type Param struct {
+	Name string
+}
+
+var reParamName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$`)
+
+// ValidParamName reports whether name is a legal parameter name: an
+// identifier, optionally dotted (for example "currentUser" or "principal.roles").
+func ValidParamName(name string) bool {
+	return reParamName.MatchString(name)
+}
+
+// NewParam creates a parameter expression and panics on an invalid name.
+func NewParam(name string) Param {
+	if !ValidParamName(name) {
+		panic(fmt.Errorf("dal: invalid parameter name %q", name))
+	}
+	return Param{Name: name}
+}
+
+// String returns the parameter in its "$name" form.
+func (p Param) String() string {
+	return "$" + p.Name
+}
+
+// Equal reports whether two parameters have the same name.
+func (p Param) Equal(b Param) bool {
+	return p.Name == b.Name
+}

--- a/dal/q_param_test.go
+++ b/dal/q_param_test.go
@@ -1,0 +1,47 @@
+package dal
+
+import (
+	"testing"
+)
+
+func TestParam(t *testing.T) {
+	for _, name := range []string{"currentUser", "now", "principal.roles", "_x", "a1.b2.c3"} {
+		if !ValidParamName(name) {
+			t.Errorf("ValidParamName(%q) = false, want true", name)
+		}
+		p := NewParam(name)
+		if p.Name != name || p.String() != "$"+name {
+			t.Errorf("NewParam(%q) = %+v, String()=%q", name, p, p.String())
+		}
+	}
+	for _, name := range []string{"", "1abc", "a-b", "a.", ".a", "a..b", "a b", "$a"} {
+		if ValidParamName(name) {
+			t.Errorf("ValidParamName(%q) = true, want false", name)
+		}
+	}
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Error("NewParam with an invalid name must panic")
+			}
+		}()
+		NewParam("not valid")
+	}()
+	if !(Param{Name: "a"}).Equal(Param{Name: "a"}) || (Param{Name: "a"}).Equal(Param{Name: "b"}) {
+		t.Error("Equal")
+	}
+}
+
+func TestWhereFieldAcceptsParam(t *testing.T) {
+	condition := WhereField("ownerID", Equal, NewParam("currentUser"))
+	comparison, ok := condition.(Comparison)
+	if !ok {
+		t.Fatalf("expected Comparison, got %T", condition)
+	}
+	if _, ok := comparison.Right.(Param); !ok {
+		t.Fatalf("expected Param on the right, got %T", comparison.Right)
+	}
+	if got := comparison.String(); got != "ownerID = $currentUser" {
+		t.Errorf("String() = %q", got)
+	}
+}

--- a/dtql/README.md
+++ b/dtql/README.md
@@ -38,11 +38,12 @@ by `Serialize` with a descriptive error rather than silently dropped.
 | `FieldRef` | `{ field: <name> }` |
 | `Constant` | `{ value: <scalar> }` (inline string, bool, int or float) |
 | `Array` | `{ values: [ <scalar>, ... ] }` (inline, for `In` membership) |
+| `Param` | `{ param: <name> }` — a runtime parameter (`$name` in query text), substituted with a constant or array before execution; names are dotted identifiers such as `currentUser` or `principal.roles` |
 | `Operator` | the `dal.Operator` string itself: `==`, `In`, `>`, `>=`, `<`, `<=` |
 | `Limit` / `Offset` | `limit: <int>` / `offset: <int>` (omitted when zero) |
 
-An expression node sets **exactly one** of `field`, `value` or `values`, which
-discriminates a `FieldRef`, a `Constant` or an `Array`.
+An expression node sets **exactly one** of `field`, `value`, `values` or
+`param`, which discriminates a `FieldRef`, a `Constant`, an `Array` or a `Param`.
 
 ## Document shape
 

--- a/dtql/deserialize.go
+++ b/dtql/deserialize.go
@@ -101,17 +101,25 @@ func exprFromYAML(e exprYAML) (dal.Expression, error) {
 	if e.Values != nil {
 		set++
 	}
+	if e.Param != "" {
+		set++
+	}
 	if set == 0 {
-		return nil, fmt.Errorf("expression must set exactly one of field, value or values")
+		return nil, fmt.Errorf("expression must set exactly one of field, value, values or param")
 	}
 	if set > 1 {
-		return nil, fmt.Errorf("expression must set exactly one of field, value or values, but several are set")
+		return nil, fmt.Errorf("expression must set exactly one of field, value, values or param, but several are set")
 	}
 	switch {
 	case e.Field != "":
 		return dal.NewFieldRef("", e.Field), nil
 	case e.Value != nil:
 		return dal.Constant{Value: e.Value}, nil
+	case e.Param != "":
+		if !dal.ValidParamName(e.Param) {
+			return nil, fmt.Errorf("invalid parameter name %q", e.Param)
+		}
+		return dal.Param{Name: e.Param}, nil
 	default: // e.Values != nil
 		return dal.Array{Value: e.Values}, nil
 	}

--- a/dtql/deserialize_test.go
+++ b/dtql/deserialize_test.go
@@ -75,7 +75,7 @@ func TestDeserialize_invalidInputRejected(t *testing.T) {
 		{
 			name:    "expression with no field/value/values",
 			yaml:    "from:\n  name: users\ncolumns:\n  - as: x\n",
-			wantErr: "exactly one of field, value or values",
+			wantErr: "exactly one of field, value, values or param",
 		},
 	}
 	for _, tt := range tests {

--- a/dtql/param_test.go
+++ b/dtql/param_test.go
@@ -1,0 +1,50 @@
+package dtql
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+)
+
+func TestParamRoundTrip(t *testing.T) {
+	source := "from:\n  name: orders\nwhere:\n  op: ==\n  left:\n    field: tenantID\n  right:\n    param: tenant\n"
+	query, err := Deserialize([]byte(source))
+	if err != nil {
+		t.Fatalf("Deserialize: %v", err)
+	}
+	comparison, ok := query.Where().(dal.Comparison)
+	if !ok {
+		t.Fatalf("Where() is %T", query.Where())
+	}
+	if param, ok := comparison.Right.(dal.Param); !ok || param.Name != "tenant" {
+		t.Fatalf("right operand = %#v", comparison.Right)
+	}
+	encoded, err := Serialize(query)
+	if err != nil {
+		t.Fatalf("Serialize: %v", err)
+	}
+	if string(encoded) != source {
+		t.Errorf("canonical form differs:\n%s\nwant:\n%s", encoded, source)
+	}
+	if !strings.Contains(query.Where().String(), "$tenant") {
+		t.Errorf("String() = %q", query.Where().String())
+	}
+}
+
+func TestParamRejections(t *testing.T) {
+	for name, source := range map[string]string{
+		"invalid name":    "from:\n  name: orders\nwhere:\n  op: ==\n  left:\n    field: a\n  right:\n    param: 1x\n",
+		"param and value": "from:\n  name: orders\nwhere:\n  op: ==\n  left:\n    field: a\n  right:\n    param: x\n    value: 1\n",
+	} {
+		if _, err := Deserialize([]byte(source)); err == nil {
+			t.Errorf("%s: expected an error", name)
+		}
+	}
+}
+
+func TestSchemaMentionsParam(t *testing.T) {
+	if !strings.Contains(string(SchemaJSON()), `"param"`) {
+		t.Error("schema must describe the param expression")
+	}
+}

--- a/dtql/schema.go
+++ b/dtql/schema.go
@@ -22,11 +22,13 @@ func schemaDocument() map[string]any {
 		"field":  map[string]any{"type": "string"},
 		"value":  scalar,
 		"values": map[string]any{"type": "array", "items": scalar},
+		"param":  map[string]any{"type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$"},
 	}
 	exprOneOf := []any{
 		map[string]any{"required": []any{"field"}},
 		map[string]any{"required": []any{"value"}},
 		map[string]any{"required": []any{"values"}},
+		map[string]any{"required": []any{"param"}},
 	}
 	// A column/order is an expression plus one extra key (as / desc).
 	columnProps := mergeProps(exprProps, map[string]any{"as": map[string]any{"type": "string"}})

--- a/dtql/schema/schema.json
+++ b/dtql/schema/schema.json
@@ -17,6 +17,11 @@
           "required": [
             "values"
           ]
+        },
+        {
+          "required": [
+            "param"
+          ]
         }
       ],
       "properties": {
@@ -24,6 +29,10 @@
           "type": "string"
         },
         "field": {
+          "type": "string"
+        },
+        "param": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$",
           "type": "string"
         },
         "value": {
@@ -100,10 +109,19 @@
           "required": [
             "values"
           ]
+        },
+        {
+          "required": [
+            "param"
+          ]
         }
       ],
       "properties": {
         "field": {
+          "type": "string"
+        },
+        "param": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$",
           "type": "string"
         },
         "value": {
@@ -189,6 +207,11 @@
           "required": [
             "values"
           ]
+        },
+        {
+          "required": [
+            "param"
+          ]
         }
       ],
       "properties": {
@@ -196,6 +219,10 @@
           "type": "boolean"
         },
         "field": {
+          "type": "string"
+        },
+        "param": {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$",
           "type": "string"
         },
         "value": {

--- a/dtql/schema/schema.yaml
+++ b/dtql/schema/schema.yaml
@@ -8,10 +8,15 @@ $defs:
           - value
       - required:
           - values
+      - required:
+          - param
     properties:
       as:
         type: string
       field:
+        type: string
+      param:
+        pattern: ^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$
         type: string
       value:
         type:
@@ -59,8 +64,13 @@ $defs:
           - value
       - required:
           - values
+      - required:
+          - param
     properties:
       field:
+        type: string
+      param:
+        pattern: ^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$
         type: string
       value:
         type:
@@ -112,10 +122,15 @@ $defs:
           - value
       - required:
           - values
+      - required:
+          - param
     properties:
       desc:
         type: boolean
       field:
+        type: string
+      param:
+        pattern: ^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$
         type: string
       value:
         type:

--- a/dtql/serialize.go
+++ b/dtql/serialize.go
@@ -111,8 +111,10 @@ func exprToYAML(expr dal.Expression) (exprYAML, error) {
 		return exprYAML{Value: e.Value}, nil
 	case dal.Array:
 		return exprYAML{Values: e.Value}, nil
+	case dal.Param:
+		return exprYAML{Param: e.Name}, nil
 	default:
-		return exprYAML{}, fmt.Errorf("unsupported expression %T (only field references, constants and arrays are supported)", expr)
+		return exprYAML{}, fmt.Errorf("unsupported expression %T (only field references, constants, arrays and parameters are supported)", expr)
 	}
 }
 

--- a/dtql/shapes.go
+++ b/dtql/shapes.go
@@ -18,12 +18,13 @@ type fromYAML struct {
 }
 
 // exprYAML is the YAML representation of an in-scope dal.Expression.
-// Exactly one of Field / Value / Values is set, which discriminates a
-// FieldRef, a Constant or an Array respectively.
+// Exactly one of Field / Value / Values / Param is set, which discriminates a
+// FieldRef, a Constant, an Array or a Param respectively.
 type exprYAML struct {
 	Field  string `yaml:"field,omitempty"`  // dal.FieldRef
 	Value  any    `yaml:"value,omitempty"`  // dal.Constant (inline scalar)
 	Values any    `yaml:"values,omitempty"` // dal.Array (inline sequence)
+	Param  string `yaml:"param,omitempty"`  // dal.Param (runtime parameter, "$name")
 }
 
 // columnYAML is the YAML representation of a dal.Column.

--- a/spec/features/access-policies/row-level-conditions/README.md
+++ b/spec/features/access-policies/row-level-conditions/README.md
@@ -1,12 +1,12 @@
 ---
 format: https://specscore.md/feature-specification
-status: Draft
+status: Implementing
 ---
 
 # Feature: Row-level access conditions with runtime variables
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/row-level-conditions?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/row-level-conditions?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/row-level-conditions?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/row-level-conditions?op=request-change) |
-**Status:** Draft
+**Status:** Implementing
 **Date:** 2026-09-02
 **Owner:** alex
 **Source Ideas:** row-level-access-conditions

--- a/spec/ideas/README.md
+++ b/spec/ideas/README.md
@@ -27,7 +27,7 @@ The Idea format follows [SpecScore](https://specscore.md/idea-specification).
 | [query-group-by-aggregation](query-group-by-aggregation.md) | Implemented | 2026-06-05 | alex | query-group-by-aggregation |
 | [recordops](recordops.md) | Approved | 2026-05-15 | alex | — |
 | [recordset-computed-columns](recordset-computed-columns.md) | Specified | 2026-06-02 | alex | recordset-computed-columns |
-| [row-level-access-conditions](row-level-access-conditions.md) | Specifying | 2026-09-02 | alex | access-policies/row-level-conditions, access-policies/principal-bindings, access-policies/field-patterns |
+| [row-level-access-conditions](row-level-access-conditions.md) | Implementing | 2026-09-02 | alex | access-policies/field-patterns, access-policies/principal-bindings, access-policies/row-level-conditions |
 | [transaction-message](transaction-message.md) | Approved | 2026-06-02 | alex | — |
 | [triggers-and-webhooks](triggers-and-webhooks.md) | Draft | 2026-09-02 | alex | — |
 

--- a/spec/ideas/row-level-access-conditions.md
+++ b/spec/ideas/row-level-access-conditions.md
@@ -1,13 +1,13 @@
 ---
 format: https://specscore.md/idea-specification
-status: Specifying
+status: Implementing
 ---
 # Idea: Declarative per-principal policies with row-level conditions, path captures and field patterns
 
-**Status:** Specifying
+**Status:** Implementing
 **Date:** 2026-09-02
 **Owner:** alex
-**Promotes To:** access-policies/row-level-conditions, access-policies/principal-bindings, access-policies/field-patterns
+**Promotes To:** access-policies/field-patterns, access-policies/principal-bindings, access-policies/row-level-conditions
 **Supersedes:** —
 **Related Ideas:** extends:access-policies
 

--- a/spec/plans/row-level-conditions-mvp.md
+++ b/spec/plans/row-level-conditions-mvp.md
@@ -1,0 +1,120 @@
+---
+format: https://specscore.md/plan-specification
+status: Approved
+---
+# Plan: Implement row-level access conditions (read-side MVP)
+
+**Status:** Approved
+**Source Feature:** access-policies/row-level-conditions
+**Date:** 2026-09-03
+**Owner:** alex
+**Supersedes:** —
+
+## Summary
+
+Implement the read side of `access-policies/row-level-conditions`: a parameter
+expression in `dal`, a shared record-condition evaluator, `where` conditions on
+allow rules with runtime variables, enforcement for `Get`, `Exists` and `Query`
+(AND-rewrite), portable documents in DTQL condition syntax with a `param` node,
+and the DTQL `param` node itself. Conditions are evaluated against record values
+only; no lookups into other collections. The write side (`check`, pre-image and
+post-image checks) and path captures are deliberately left to a second plan.
+
+## Approach
+
+Bottom-up, each task independently testable at 100% statement coverage (the
+CI gate). Pure pieces first (`dal.Param`, the evaluator), then the policy engine
+(rules, precedence-aware residual conditions, variables), then the secured
+wrappers, then documents and DTQL, then integration against `dalgo2memory`.
+
+Precedence keeps the parent feature's order: matching rules are walked in
+order; conditional allows encountered before the first unconditional rule
+combine with OR; an unconditional allow makes the residual moot; an unconditional
+deny or default deny leaves the OR as the residual. Residuals from several
+policies intersect with AND. The residual is what the wrapper enforces: after
+the read for point operations, by query rewrite for `Query`.
+
+Founder decisions applied: a denied conditional `Get` returns `DeniedError`
+(the hide option is a follow-up); `dal.Condition` inside, DTQL outside;
+read and write levels differ by declaring two rules on one path.
+
+## Tasks
+
+### Task 1: Parameter expression in dal
+
+**Id:** task-1
+**Verifies:** access-policies/row-level-conditions#ac:comparison-and-groups
+**Depends-On:** —
+**Status:** planning
+
+Add `dal.Param` (string form `$<name>`, validated name) as a `FieldRef`/`Constant`
+sibling, accepted by `WhereField`, so queries and policy conditions share one
+parameter node.
+
+### Task 2: Shared record-condition evaluator
+
+**Id:** task-2
+**Verifies:** access-policies/row-level-conditions#ac:comparison-and-groups
+**Depends-On:** 1
+**Status:** planning
+
+New `condeval` package: `Match` over JSON-normalised record data (comparisons,
+`In` incl. array-field overlap, And/Or, dotted field paths, missing field is
+false), `Validate` (structural rules, referenced fields and params),
+`Substitute` (params to constants/arrays; unresolved is an error), `ToMap`.
+
+### Task 3: Conditional allow rules, variables and residual decisions
+
+**Id:** task-3
+**Verifies:** access-policies/row-level-conditions#ac:conditional-deny-rejected, access-policies/row-level-conditions#ac:write-group-excludes-truncate, access-policies/row-level-conditions#ac:missing-variable-denies, access-policies/row-level-conditions#ac:unconditional-suite-unchanged, access-policies/row-level-conditions#ac:no-leak
+**Depends-On:** 2
+**Status:** planning
+
+`Rule.Where(cond)`; compile validation (allow only, path rules only, explicit
+`Truncate` rejected, `write`/`readwrite` drop it); `WithVariables`,
+`WithCurrentUser`, built-in `$now`; `Decide` resolves parameters from the context
+and returns a residual condition; explanations name rule, slot and condition text
+without values.
+
+### Task 4: Read-side enforcement in the secured wrappers
+
+**Id:** task-4
+**Verifies:** access-policies/row-level-conditions#ac:get-other-users-record, access-policies/row-level-conditions#ac:tenant-slice, access-policies/row-level-conditions#ac:no-leak
+**Depends-On:** 3
+**Status:** planning
+
+`Get`/`GetMulti` evaluate the residual after the read and zero the data on
+denial; `Exists` upgrades to a read; `Query` is wrapped with the residual ANDed
+into `Where()`; residuals from several policies conjoin; queries with joins under
+a conditional rule are denied in this slice.
+
+### Task 5: Portable documents and the DTQL param node
+
+**Id:** task-5
+**Verifies:** access-policies/row-level-conditions#ac:yaml-roundtrip
+**Depends-On:** 3
+**Status:** planning
+
+`where` on `DocumentRule` in DTQL condition syntax with `param`; encode and
+decode both directions in YAML and JSON; DTQL gains the `param` expression and
+its generated schema is refreshed.
+
+### Task 6: Integration against dalgo2memory and coverage gate
+
+**Id:** task-6
+**Verifies:** access-policies/row-level-conditions#ac:read-all-edit-assigned, access-policies/row-level-conditions#ac:tenant-slice
+**Depends-On:** 4, 5
+**Status:** planning
+
+Secured `dalgo2memory` round trips: tenant slice with limit and order, read all
+customers, get another user's record denied, exists upgraded; whole module at
+100% statement coverage; existing suites unchanged.
+
+## Open Questions
+
+- Path captures (`{name}` segments to `$path.<name>`) and the write side
+  (`check`, pre-image reads) are the next plan; the hide-as-not-found option
+  and strict post-verification of query results ride with it.
+
+---
+*This document follows the https://specscore.md/plan-specification*

--- a/spec/plans/row-level-conditions-mvp.md
+++ b/spec/plans/row-level-conditions-mvp.md
@@ -1,10 +1,10 @@
 ---
 format: https://specscore.md/plan-specification
-status: Approved
+status: Implemented
 ---
 # Plan: Implement row-level access conditions (read-side MVP)
 
-**Status:** Approved
+**Status:** Implemented
 **Source Feature:** access-policies/row-level-conditions
 **Date:** 2026-09-03
 **Owner:** alex
@@ -45,7 +45,7 @@ read and write levels differ by declaring two rules on one path.
 **Id:** task-1
 **Verifies:** access-policies/row-level-conditions#ac:comparison-and-groups
 **Depends-On:** —
-**Status:** planning
+**Status:** complete
 
 Add `dal.Param` (string form `$<name>`, validated name) as a `FieldRef`/`Constant`
 sibling, accepted by `WhereField`, so queries and policy conditions share one
@@ -56,7 +56,7 @@ parameter node.
 **Id:** task-2
 **Verifies:** access-policies/row-level-conditions#ac:comparison-and-groups
 **Depends-On:** 1
-**Status:** planning
+**Status:** complete
 
 New `condeval` package: `Match` over JSON-normalised record data (comparisons,
 `In` incl. array-field overlap, And/Or, dotted field paths, missing field is
@@ -68,7 +68,7 @@ false), `Validate` (structural rules, referenced fields and params),
 **Id:** task-3
 **Verifies:** access-policies/row-level-conditions#ac:conditional-deny-rejected, access-policies/row-level-conditions#ac:write-group-excludes-truncate, access-policies/row-level-conditions#ac:missing-variable-denies, access-policies/row-level-conditions#ac:unconditional-suite-unchanged, access-policies/row-level-conditions#ac:no-leak
 **Depends-On:** 2
-**Status:** planning
+**Status:** complete
 
 `Rule.Where(cond)`; compile validation (allow only, path rules only, explicit
 `Truncate` rejected, `write`/`readwrite` drop it); `WithVariables`,
@@ -81,7 +81,7 @@ without values.
 **Id:** task-4
 **Verifies:** access-policies/row-level-conditions#ac:get-other-users-record, access-policies/row-level-conditions#ac:tenant-slice, access-policies/row-level-conditions#ac:no-leak
 **Depends-On:** 3
-**Status:** planning
+**Status:** complete
 
 `Get`/`GetMulti` evaluate the residual after the read and zero the data on
 denial; `Exists` upgrades to a read; `Query` is wrapped with the residual ANDed
@@ -93,7 +93,7 @@ a conditional rule are denied in this slice.
 **Id:** task-5
 **Verifies:** access-policies/row-level-conditions#ac:yaml-roundtrip
 **Depends-On:** 3
-**Status:** planning
+**Status:** complete
 
 `where` on `DocumentRule` in DTQL condition syntax with `param`; encode and
 decode both directions in YAML and JSON; DTQL gains the `param` expression and
@@ -102,13 +102,25 @@ its generated schema is refreshed.
 ### Task 6: Integration against dalgo2memory and coverage gate
 
 **Id:** task-6
-**Verifies:** access-policies/row-level-conditions#ac:read-all-edit-assigned, access-policies/row-level-conditions#ac:tenant-slice
+**Verifies:** access-policies/row-level-conditions#ac:tenant-slice
 **Depends-On:** 4, 5
-**Status:** planning
+**Status:** complete
 
 Secured `dalgo2memory` round trips: tenant slice with limit and order, read all
 customers, get another user's record denied, exists upgraded; whole module at
 100% statement coverage; existing suites unchanged.
+
+## Deferred AC Coverage
+
+- access-policies/row-level-conditions#ac:cannot-take-ownership — write-side
+  enforcement (pre-image `where`, post-image `check`) is the next plan; in this
+  slice a conditional rule on a write operation denies fail-closed with an
+  explanation, so no write is ever granted by an unenforced condition.
+- access-policies/row-level-conditions#ac:read-all-edit-assigned — the read
+  half (query returns every customer, get succeeds) is exercised by task 6; the
+  edit half needs the write side and is deferred with it.
+- access-policies/row-level-conditions#ac:capture-in-condition — path captures
+  (`{name}` segments bound to `$path.<name>`) are the next plan.
 
 ## Open Questions
 


### PR DESCRIPTION
Implements the read side of `access-policies/row-level-conditions` (tracks #133; plan `spec/plans/row-level-conditions-mvp.md`).

**What lands**
- `dal.Param` (`$name`) usable in queries and policy conditions; `WhereField` accepts it.
- New `condeval` package: evaluate `dal.Condition` against record values (JSON-normalised, dotted paths, `In` incl. array overlap, And/Or), validate, substitute parameters.
- `access`: `Allow(...).Where(cond)`. Conditions on allow rules under path scopes only; explicit `Truncate` rejected, `write`/`readwrite` drop it. `WithVariables`, `WithCurrentUser`, built-in `$now`. Precedence keeps the parent feature's order: conditional allows met before the first unconditional rule OR together; an unconditional allow makes them moot; a deny (or default deny) leaves the OR as the residual; residuals from several policies AND.
- Enforcement: `Get`/`GetMulti` evaluate after the read and clear the record on denial; `Exists` upgrades to a read; `Query` is delegated as a wrapper whose `Where()` conjoins the residual, so the engine filters and paging stays intact. Adapters never see a parameter.
- Fail-closed boundaries of this slice: a conditional rule on a **write** operation denies with an explicit explanation (write-side checks are the next plan); a residual on a **joined** source denies.
- Portable documents: `where` on a rule in DTQL condition syntax with `param`, YAML and JSON both directions.
- DTQL gains the `param` node; schema regenerated.

**Verification**: 100% statement coverage in `access`, `condeval`, `dal`, `dtql`; `go test ./...` green; `golangci-lint run ./...` 0 issues; `specscore spec lint` 0 violations. Feature moved Draft → Approved → Implementing; plan tasks complete with a Deferred AC Coverage section (write side, path captures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEVhqasFJJ3iAcARe7Wts6