### PR TITLE
feat(access): row-level conditions on writes — check, pre-image where, post-image check

### DIFF
--- a/access/conditions_test.go
+++ b/access/conditions_test.go
@@ -493,7 +493,7 @@ type fakeCond struct{}
 
 func (fakeCond) String() string { return "fake" }
 
-func TestConditionalWritesFailClosed(t *testing.T) {
+func TestConditionalWriteNeedsReadCapability(t *testing.T) {
 	policy := customersPolicy(t)
 	ctx := WithCurrentUser(context.Background(), "u1")
 	key := record.NewKeyWithID("customers", "c1")
@@ -504,8 +504,7 @@ func TestConditionalWritesFailClosed(t *testing.T) {
 		"delete multi": func() error { return session.DeleteMulti(ctx, []*record.Key{key}) },
 	} {
 		err := op()
-		var denied *DeniedError
-		if !errors.As(err, &denied) || !strings.Contains(err.Error(), "not enforced") || denied.Decision.Condition != "assignedTo = $currentUser" {
+		if !errors.Is(err, ErrAccessDenied) || !strings.Contains(err.Error(), "pre-image") {
 			t.Errorf("%s: %v", name, err)
 		}
 	}
@@ -520,9 +519,9 @@ func TestResidualsBoundedByResources(t *testing.T) {
 	// A custom policy returning more residuals than resources must not panic.
 	policy := oversizedPolicy{}
 	g := guard{databasePolicies: []Policy{policy}}
-	residuals, err := g.authorizeRequest(context.Background(), Request{Operation: Get, Resources: []Resource{RecordResourceForKey(record.NewKeyWithID("x", "1"))}})
-	if err != nil || len(residuals) != 1 || len(residuals[0]) != 1 {
-		t.Errorf("residuals = %v, %v", residuals, err)
+	residuals, writes, err := g.authorizeRequest(context.Background(), Request{Operation: Get, Resources: []Resource{RecordResourceForKey(record.NewKeyWithID("x", "1"))}})
+	if err != nil || len(residuals) != 1 || len(residuals[0]) != 1 || len(writes) != 1 || len(writes[0]) != 1 {
+		t.Errorf("residuals = %v, writes = %v, %v", residuals, writes, err)
 	}
 }
 
@@ -531,7 +530,8 @@ type oversizedPolicy struct{}
 func (oversizedPolicy) Name() string { return "oversized" }
 func (oversizedPolicy) Decide(context.Context, Request) Decision {
 	condition := dal.WhereField("a", dal.Equal, dal.Constant{Value: 1})
-	return Decision{Allowed: true, Policy: "oversized", Residuals: []dal.Condition{condition, condition, condition}}
+	write := &WriteResidual{Terminal: &WriteAlternative{Rule: "t"}}
+	return Decision{Allowed: true, Policy: "oversized", Residuals: []dal.Condition{condition, condition, condition}, Writes: []*WriteResidual{write, write, write}}
 }
 func (p oversizedPolicy) Authorize(ctx context.Context, request Request) error {
 	if d := p.Decide(ctx, request); !d.Allowed {

--- a/access/context.go
+++ b/access/context.go
@@ -104,50 +104,40 @@ func (g guard) bind(ctx context.Context) guard {
 	return g
 }
 
-// authorize settles an operation that cannot carry a residual condition. In
-// this version that is every write: a conditional rule on a write operation is
-// refused rather than silently granted, until pre-image and post-image checks
-// exist.
+// authorize settles an operation by policy decision alone; residual row
+// conditions, if any, are ignored. Reads use authorizeRequest and writes use
+// authorizeWrite so residuals are enforced.
 func (g guard) authorize(ctx context.Context, operation Operations, resources ...Resource) error {
-	residuals, err := g.authorizeRequest(ctx, Request{Operation: operation, Resources: resources})
-	if err != nil {
-		return err
-	}
-	for _, perResource := range residuals {
-		for _, residual := range perResource {
-			return &DeniedError{Decision: Decision{
-				Operation:    operation,
-				Resource:     residual.resource,
-				Policy:       residual.policy,
-				PolicySource: residual.policySource,
-				Rule:         residual.rule,
-				Effect:       effectDeny.String(),
-				Condition:    residual.text,
-				Explanation:  fmt.Sprintf("conditional rule %q is not enforced for %s in this version (where: %s)", residual.rule, operation, residual.text),
-			}}
-		}
-	}
-	return nil
+	_, _, err := g.authorizeRequest(ctx, Request{Operation: operation, Resources: resources})
+	return err
+}
+
+// authorizeWrite returns, per resource, the write residuals every applicable
+// policy requires the caller to enforce before delegating the write.
+func (g guard) authorizeWrite(ctx context.Context, operation Operations, resources ...Resource) ([][]writeResidual, error) {
+	_, writes, err := g.authorizeRequest(ctx, Request{Operation: operation, Resources: resources})
+	return writes, err
 }
 
 // authorizeRequest evaluates every applicable policy and returns, per request
-// resource, the residual conditions the caller must still enforce. A denial by
-// any policy is returned immediately.
-func (g guard) authorizeRequest(ctx context.Context, request Request) ([][]residual, error) {
+// resource, the read residuals and the write residuals the caller must still
+// enforce. A denial by any policy is returned immediately.
+func (g guard) authorizeRequest(ctx context.Context, request Request) ([][]residual, [][]writeResidual, error) {
 	dynamicPolicies := policiesFromContext(ctx)
 	contextPolicyCount := len(g.boundPolicies) + len(dynamicPolicies)
 	if err := g.requireContextPolicy(request.Operation, contextPolicyCount); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	policies := make([]Policy, 0, len(g.databasePolicies)+contextPolicyCount)
 	policies = append(policies, g.databasePolicies...)
 	policies = append(policies, g.boundPolicies...)
 	policies = append(policies, dynamicPolicies...)
 	var residuals [][]residual
+	var writes [][]writeResidual
 	for _, policy := range policies {
 		decision := policy.Decide(ctx, request)
 		if !decision.Allowed {
-			return nil, &DeniedError{Decision: decision}
+			return nil, nil, &DeniedError{Decision: decision}
 		}
 		for i, condition := range decision.Residuals {
 			if condition == nil || i >= len(request.Resources) {
@@ -165,8 +155,22 @@ func (g guard) authorizeRequest(ctx context.Context, request Request) ([][]resid
 				condition:    condition,
 			})
 		}
+		for i, write := range decision.Writes {
+			if write == nil || i >= len(request.Resources) {
+				continue
+			}
+			if writes == nil {
+				writes = make([][]writeResidual, len(request.Resources))
+			}
+			writes[i] = append(writes[i], writeResidual{
+				policy:       decision.Policy,
+				policySource: decision.PolicySource,
+				resource:     request.Resources[i],
+				residual:     write,
+			})
+		}
 	}
-	return residuals, nil
+	return residuals, writes, nil
 }
 
 func (g guard) checkContext(ctx context.Context) error {

--- a/access/document.go
+++ b/access/document.go
@@ -50,6 +50,9 @@ type DocumentRule struct {
 	// Where is an optional row condition on an allow rule, written in the
 	// DTQL condition syntax with a `param` expression for runtime variables.
 	Where *DocumentCondition `json:"where,omitempty" yaml:"where,omitempty"`
+	// Check is an optional post-image condition on an allow rule: what a row
+	// written under the rule must satisfy afterwards. Defaults to Where.
+	Check *DocumentCondition `json:"check,omitempty" yaml:"check,omitempty"`
 }
 
 // Codec decouples policy loading from both its syntax and its storage. A
@@ -359,6 +362,13 @@ func ruleFromDocumentRule(documentRule DocumentRule, allowedEffects map[effect]b
 		}
 		rule = rule.Where(condition)
 	}
+	if documentRule.Check != nil {
+		condition, err := conditionFromDocument(*documentRule.Check)
+		if err != nil {
+			return Rule{}, fmt.Errorf("check: %w", err)
+		}
+		rule = rule.Check(condition)
+	}
 	return rule, nil
 }
 
@@ -482,6 +492,13 @@ func documentRuleFromRule(rule Rule) (DocumentRule, error) {
 			return DocumentRule{}, fmt.Errorf("%w: rule %q: %v", ErrNotSerializable, rule.name, err)
 		}
 		documentRule.Where = where
+	}
+	if rule.check != nil {
+		check, err := documentFromCondition(rule.check)
+		if err != nil {
+			return DocumentRule{}, fmt.Errorf("%w: rule %q: %v", ErrNotSerializable, rule.name, err)
+		}
+		documentRule.Check = check
 	}
 	return documentRule, nil
 }

--- a/access/policy.go
+++ b/access/policy.go
@@ -48,6 +48,34 @@ type Decision struct {
 	// rewrite for Query. A nil entry means the resource is allowed outright.
 	// Residuals is nil for an unconditional decision.
 	Residuals []dal.Condition
+	// Writes holds, per request resource, the ordered alternatives that decide
+	// a write on that resource (see WriteResidual). A nil entry means the write
+	// is allowed outright, with no row or post-image constraint.
+	Writes []*WriteResidual
+}
+
+// WriteAlternative is one allow rule as it applies to a write. Where selects
+// the rows (by pre-image) the rule applies to; nil means every row. Check is
+// what the row must satisfy after the write; nil means no constraint. Both are
+// resolved conditions; the Text fields keep the source form with parameter
+// names for explanations.
+type WriteAlternative struct {
+	Rule      string
+	Where     dal.Condition
+	Check     dal.Condition
+	WhereText string
+	CheckText string
+}
+
+// WriteResidual is what the secured wrapper enforces on a write: the
+// conditional alternatives in precedence order, then Terminal — the first
+// unconditional rule when it is an allow (possibly with a Check) — or nil when
+// the walk ends in a deny or in no rule at all. The first alternative whose
+// Where holds on the pre-image decides the write; a new row (Insert, or Set of
+// a missing row) is admitted by the first alternative whose Check it satisfies.
+type WriteResidual struct {
+	Alternatives []WriteAlternative
+	Terminal     *WriteAlternative
 }
 
 // DeniedError is returned when a policy rejects an operation.
@@ -134,6 +162,7 @@ func (p *AccessPolicy) Decide(ctx context.Context, request Request) Decision {
 	}
 	var last Decision
 	var residuals []dal.Condition
+	var writes []*WriteResidual
 	resolver := newVariableResolver(ctx)
 	for i, resource := range request.Resources {
 		last = p.decideResource(resolver, request.Operation, resource)
@@ -146,8 +175,15 @@ func (p *AccessPolicy) Decide(ctx context.Context, request Request) Decision {
 			}
 			residuals[i] = last.Residuals[0]
 		}
+		if last.Writes != nil {
+			if writes == nil {
+				writes = make([]*WriteResidual, len(request.Resources))
+			}
+			writes[i] = last.Writes[0]
+		}
 	}
 	last.Residuals = residuals
+	last.Writes = writes
 	return last
 }
 
@@ -177,7 +213,7 @@ func (p *AccessPolicy) decideResource(resolver variableResolver, operation Opera
 		}
 		conditional = append(conditional, matching[i])
 	}
-	if terminal != nil && (len(conditional) == 0 || terminal.effect == effectAllow) {
+	if len(conditional) == 0 && (terminal.effect != effectAllow || terminal.check == nil) {
 		allowed := terminal.effect == effectAllow
 		return Decision{
 			Allowed:      allowed,
@@ -190,43 +226,101 @@ func (p *AccessPolicy) decideResource(resolver variableResolver, operation Opera
 			Explanation:  fmt.Sprintf("matched rule %q (%s)", terminal.name, terminal.effect),
 		}
 	}
-	parts := make([]dal.Condition, 0, len(conditional))
+	// Resolve every alternative once; an unresolved parameter denies.
+	write := &WriteResidual{}
+	for _, rule := range conditional {
+		alternative, err := p.resolveAlternative(resolver, rule)
+		if err != nil {
+			return p.denyUnresolved(operation, resource, rule, err)
+		}
+		write.Alternatives = append(write.Alternatives, alternative)
+	}
+	if terminal != nil && terminal.effect == effectAllow {
+		alternative, err := p.resolveAlternative(resolver, *terminal)
+		if err != nil {
+			return p.denyUnresolved(operation, resource, *terminal, err)
+		}
+		write.Terminal = &alternative
+	}
+	decision := Decision{
+		Allowed:      true,
+		Operation:    operation,
+		Resource:     resource,
+		Policy:       p.name,
+		PolicySource: p.source,
+		Effect:       effectAllow.String(),
+		Writes:       []*WriteResidual{write},
+	}
+	if len(conditional) == 0 {
+		// A terminal allow with only a post-image check: reads are unconditional.
+		decision.Rule = terminal.name
+		decision.Condition = terminal.check.String()
+		decision.Explanation = fmt.Sprintf("matched rule %q (allow; check: %s)", terminal.name, decision.Condition)
+		return decision
+	}
 	names := make([]string, 0, len(conditional))
 	texts := make([]string, 0, len(conditional))
-	for _, rule := range conditional {
-		resolved, err := condeval.Substitute(rule.where, resolver.resolve)
-		if err != nil {
-			return Decision{
-				Operation:    operation,
-				Resource:     resource,
-				Policy:       p.name,
-				PolicySource: p.source,
-				Rule:         rule.name,
-				Effect:       effectDeny.String(),
-				Condition:    rule.where.String(),
-				Explanation:  fmt.Sprintf("cannot evaluate rule %q: %v", rule.name, err),
-			}
-		}
-		parts = append(parts, resolved)
-		names = append(names, rule.name)
-		texts = append(texts, rule.where.String())
+	parts := make([]dal.Condition, 0, len(conditional))
+	for _, alternative := range write.Alternatives {
+		names = append(names, alternative.Rule)
+		texts = append(texts, alternative.WhereText)
+		parts = append(parts, alternative.Where)
+	}
+	if write.Terminal != nil {
+		// An unconditional allow makes the row conditions moot for reads.
+		decision.Rule = write.Terminal.Rule
+		decision.Explanation = fmt.Sprintf("matched rule %q (allow)", write.Terminal.Rule)
+		return decision
 	}
 	residual, text := parts[0], texts[0]
 	if len(parts) > 1 {
 		residual = dal.NewGroupCondition(dal.Or, parts...)
 		text = "(" + strings.Join(texts, " OR ") + ")"
 	}
+	decision.Rule = strings.Join(names, ", ")
+	decision.Condition = text
+	decision.Explanation = fmt.Sprintf("matched conditional rule(s) %s (where: %s)", quoteAll(names), text)
+	decision.Residuals = []dal.Condition{residual}
+	return decision
+}
+
+func (p *AccessPolicy) resolveAlternative(resolver variableResolver, rule compiledRule) (WriteAlternative, error) {
+	alternative := WriteAlternative{Rule: rule.name}
+	if rule.where != nil {
+		resolved, err := condeval.Substitute(rule.where, resolver.resolve)
+		if err != nil {
+			return WriteAlternative{}, err
+		}
+		alternative.Where = resolved
+		alternative.WhereText = rule.where.String()
+	}
+	if rule.check != nil {
+		resolved, err := condeval.Substitute(rule.check, resolver.resolve)
+		if err != nil {
+			return WriteAlternative{}, err
+		}
+		alternative.Check = resolved
+		alternative.CheckText = rule.check.String()
+	}
+	return alternative, nil
+}
+
+func (p *AccessPolicy) denyUnresolved(operation Operations, resource Resource, rule compiledRule, err error) Decision {
+	condition := ""
+	if rule.where != nil {
+		condition = rule.where.String()
+	} else if rule.check != nil {
+		condition = rule.check.String()
+	}
 	return Decision{
-		Allowed:      true,
 		Operation:    operation,
 		Resource:     resource,
 		Policy:       p.name,
 		PolicySource: p.source,
-		Rule:         strings.Join(names, ", "),
-		Effect:       effectAllow.String(),
-		Condition:    text,
-		Explanation:  fmt.Sprintf("matched conditional rule(s) %s (where: %s)", quoteAll(names), text),
-		Residuals:    []dal.Condition{residual},
+		Rule:         rule.name,
+		Effect:       effectDeny.String(),
+		Condition:    condition,
+		Explanation:  fmt.Sprintf("cannot evaluate rule %q: %v", rule.name, err),
 	}
 }
 

--- a/access/rule.go
+++ b/access/rule.go
@@ -2,6 +2,7 @@ package access
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/dal-go/dalgo/condeval"
@@ -52,6 +53,7 @@ type Rule struct {
 	resource   string
 	children   []Rule
 	where      dal.Condition
+	check      dal.Condition
 }
 
 // Where attaches a row condition to an allow rule: the rule applies only to
@@ -65,6 +67,17 @@ type Rule struct {
 // the write and readwrite groups simply drop it.
 func (r Rule) Where(condition dal.Condition) Rule {
 	r.where = condition
+	return r
+}
+
+// Check attaches a post-image condition to an allow rule: a row written under
+// the rule must satisfy condition after the write (the new data of an Insert
+// or Set, the updated row of an Update). A rule with Where but no Check uses
+// Where as its check, so "rows where ownerID == $currentUser" also means "and
+// they must still be mine afterwards". A rule with Check but no Where applies
+// to every row on read and constrains only what a write may produce.
+func (r Rule) Check(condition dal.Condition) Rule {
+	r.check = condition
 	return r
 }
 
@@ -139,6 +152,7 @@ type compiledRule struct {
 	depth      int
 	literals   int
 	where      dal.Condition
+	check      dal.Condition
 	params     []string
 }
 
@@ -167,7 +181,7 @@ func compileRule(
 	allowedEffects map[effect]bool,
 	compiled *[]compiledRule,
 ) error {
-	if rule.where != nil && rule.kind != directiveRule {
+	if (rule.where != nil || rule.check != nil) && rule.kind != directiveRule {
 		return fmt.Errorf("access: conditions are only valid on allow rules, not on scopes")
 	}
 	switch rule.kind {
@@ -180,7 +194,7 @@ func compileRule(
 		}
 		operations := rule.operations
 		var params []string
-		if rule.where != nil {
+		if rule.where != nil || rule.check != nil {
 			if rule.effect != effectAllow {
 				return fmt.Errorf("access: rule %q: conditional %s rules are not supported; conditions apply to allow rules only", rule.name, rule.effect)
 			}
@@ -193,17 +207,32 @@ func compileRule(
 				}
 				operations &^= Truncate
 			}
-			info, err := condeval.Validate(rule.where)
-			if err != nil {
-				return fmt.Errorf("access: rule %q: invalid condition: %w", rule.name, err)
+			seen := map[string]struct{}{}
+			for slot, condition := range map[string]dal.Condition{"where": rule.where, "check": rule.check} {
+				if condition == nil {
+					continue
+				}
+				info, err := condeval.Validate(condition)
+				if err != nil {
+					return fmt.Errorf("access: rule %q: invalid %s condition: %w", rule.name, slot, err)
+				}
+				for _, param := range info.Params {
+					if _, dup := seen[param]; !dup {
+						seen[param] = struct{}{}
+						params = append(params, param)
+					}
+				}
 			}
-			params = info.Params
+			sort.Strings(params)
 		}
 		name := rule.name
 		if name == "" {
 			name = fmt.Sprintf("%s %s at %s", rule.effect, operations, resourceDescription(resourceKind, resourceName, prefix))
 			if rule.where != nil {
 				name += " where " + rule.where.String()
+			}
+			if rule.check != nil {
+				name += " check " + rule.check.String()
 			}
 		}
 		*compiled = append(*compiled, compiledRule{
@@ -216,6 +245,7 @@ func compileRule(
 			depth:      len(prefix.segments),
 			literals:   literalCount(prefix),
 			where:      rule.where,
+			check:      rule.check,
 			params:     params,
 		})
 		return nil

--- a/access/session.go
+++ b/access/session.go
@@ -16,7 +16,7 @@ type securedReadSession struct {
 }
 
 func (s securedReadSession) Exists(ctx context.Context, key *record.Key) (bool, error) {
-	residuals, err := s.guard.authorizeRequest(ctx, Request{Operation: Exists, Resources: []Resource{RecordResourceForKey(key)}})
+	residuals, _, err := s.guard.authorizeRequest(ctx, Request{Operation: Exists, Resources: []Resource{RecordResourceForKey(key)}})
 	if err != nil {
 		return false, err
 	}
@@ -27,7 +27,7 @@ func (s securedReadSession) Exists(ctx context.Context, key *record.Key) (bool, 
 }
 
 func (s securedReadSession) Get(ctx context.Context, record record.Record) error {
-	residuals, err := s.guard.authorizeRequest(ctx, Request{Operation: Get, Resources: []Resource{RecordResourceForKey(record.Key())}})
+	residuals, _, err := s.guard.authorizeRequest(ctx, Request{Operation: Get, Resources: []Resource{RecordResourceForKey(record.Key())}})
 	if err != nil {
 		return err
 	}
@@ -42,7 +42,7 @@ func (s securedReadSession) Get(ctx context.Context, record record.Record) error
 
 func (s securedReadSession) GetMulti(ctx context.Context, records []record.Record) error {
 	resources := resourcesForRecords(records)
-	residuals, err := s.guard.authorizeRequest(ctx, Request{Operation: Get, Resources: resources})
+	residuals, _, err := s.guard.authorizeRequest(ctx, Request{Operation: Get, Resources: resources})
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func (s securedReadSession) ExecuteQueryToRecordsetReader(ctx context.Context, q
 // Where carries the residual row condition.
 func (s securedReadSession) authorizeQuery(ctx context.Context, query dal.Query) (dal.Query, error) {
 	resources := resourcesForQuery(query)
-	residuals, err := s.guard.authorizeRequest(ctx, Request{Operation: Query, Resources: resources, Query: query})
+	residuals, _, err := s.guard.authorizeRequest(ctx, Request{Operation: Query, Resources: resources, Query: query})
 	if err != nil {
 		return nil, err
 	}
@@ -86,66 +86,97 @@ type securedWriteSession struct {
 }
 
 func (s securedWriteSession) Set(ctx context.Context, record record.Record) error {
-	if err := s.guard.authorize(ctx, Set, RecordResourceForKey(record.Key())); err != nil {
+	if err := s.authorizeAndEnforce(ctx, Set, []writeTarget{{key: record.Key(), data: record.Data()}}); err != nil {
 		return err
 	}
 	return s.session.Set(ctx, record)
 }
 
 func (s securedWriteSession) SetMulti(ctx context.Context, records []record.Record) error {
-	if err := s.guard.authorize(ctx, Set, resourcesForRecords(records)...); err != nil {
+	if err := s.authorizeAndEnforce(ctx, Set, targetsForRecords(records)); err != nil {
 		return err
 	}
 	return s.session.SetMulti(ctx, records)
 }
 
 func (s securedWriteSession) Insert(ctx context.Context, record record.Record, options ...dal.InsertOption) error {
-	if err := s.guard.authorize(ctx, Insert, RecordResourceForKey(record.Key())); err != nil {
+	if err := s.authorizeAndEnforce(ctx, Insert, []writeTarget{{key: record.Key(), data: record.Data()}}); err != nil {
 		return err
 	}
 	return s.session.Insert(ctx, record, options...)
 }
 
 func (s securedWriteSession) InsertMulti(ctx context.Context, records []record.Record, options ...dal.InsertOption) error {
-	if err := s.guard.authorize(ctx, Insert, resourcesForRecords(records)...); err != nil {
+	if err := s.authorizeAndEnforce(ctx, Insert, targetsForRecords(records)); err != nil {
 		return err
 	}
 	return s.session.InsertMulti(ctx, records, options...)
 }
 
 func (s securedWriteSession) Update(ctx context.Context, key *record.Key, updates []update.Update, preconditions ...dal.Precondition) error {
-	if err := s.guard.authorize(ctx, Update, RecordResourceForKey(key)); err != nil {
+	if err := s.authorizeAndEnforce(ctx, Update, []writeTarget{{key: key, updates: updates}}); err != nil {
 		return err
 	}
 	return s.session.Update(ctx, key, updates, preconditions...)
 }
 
 func (s securedWriteSession) UpdateRecord(ctx context.Context, record record.Record, updates []update.Update, preconditions ...dal.Precondition) error {
-	if err := s.guard.authorize(ctx, Update, RecordResourceForKey(record.Key())); err != nil {
+	if err := s.authorizeAndEnforce(ctx, Update, []writeTarget{{key: record.Key(), updates: updates}}); err != nil {
 		return err
 	}
 	return s.session.UpdateRecord(ctx, record, updates, preconditions...)
 }
 
 func (s securedWriteSession) UpdateMulti(ctx context.Context, keys []*record.Key, updates []update.Update, preconditions ...dal.Precondition) error {
-	if err := s.guard.authorize(ctx, Update, resourcesForKeys(keys)...); err != nil {
+	targets := make([]writeTarget, len(keys))
+	for i, key := range keys {
+		targets[i] = writeTarget{key: key, updates: updates}
+	}
+	if err := s.authorizeAndEnforce(ctx, Update, targets); err != nil {
 		return err
 	}
 	return s.session.UpdateMulti(ctx, keys, updates, preconditions...)
 }
 
 func (s securedWriteSession) Delete(ctx context.Context, key *record.Key) error {
-	if err := s.guard.authorize(ctx, Delete, RecordResourceForKey(key)); err != nil {
+	if err := s.authorizeAndEnforce(ctx, Delete, []writeTarget{{key: key}}); err != nil {
 		return err
 	}
 	return s.session.Delete(ctx, key)
 }
 
 func (s securedWriteSession) DeleteMulti(ctx context.Context, keys []*record.Key) error {
-	if err := s.guard.authorize(ctx, Delete, resourcesForKeys(keys)...); err != nil {
+	targets := make([]writeTarget, len(keys))
+	for i, key := range keys {
+		targets[i] = writeTarget{key: key}
+	}
+	if err := s.authorizeAndEnforce(ctx, Delete, targets); err != nil {
 		return err
 	}
 	return s.session.DeleteMulti(ctx, keys)
+}
+
+// authorizeAndEnforce authorizes a write on every target and then enforces
+// the write residuals — pre-image row conditions and post-image checks —
+// before anything reaches the adapter, so a batch is refused whole.
+func (s securedWriteSession) authorizeAndEnforce(ctx context.Context, operation Operations, targets []writeTarget) error {
+	resources := make([]Resource, len(targets))
+	for i, target := range targets {
+		resources[i] = RecordResourceForKey(target.key)
+	}
+	writes, err := s.guard.authorizeWrite(ctx, operation, resources...)
+	if err != nil {
+		return err
+	}
+	return s.enforceWrites(ctx, operation, writes, targets)
+}
+
+func targetsForRecords(records []record.Record) []writeTarget {
+	targets := make([]writeTarget, len(records))
+	for i, rec := range records {
+		targets[i] = writeTarget{key: rec.Key(), data: rec.Data()}
+	}
+	return targets
 }
 
 type securedReadwriteSession struct {

--- a/access/write.go
+++ b/access/write.go
@@ -1,0 +1,225 @@
+package access
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dal-go/dalgo/condeval"
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/record"
+	"github.com/dal-go/record/update"
+)
+
+// writeResidual is one policy's WriteResidual for one request resource, with
+// the attribution a denial needs.
+type writeResidual struct {
+	policy       string
+	policySource string
+	resource     Resource
+	residual     *WriteResidual
+}
+
+func (w writeResidual) deny(operation Operations, rule, condition, explanation string) *DeniedError {
+	return &DeniedError{Decision: Decision{
+		Operation:    operation,
+		Resource:     w.resource,
+		Policy:       w.policy,
+		PolicySource: w.policySource,
+		Rule:         rule,
+		Effect:       effectDeny.String(),
+		Condition:    condition,
+		Explanation:  explanation,
+	}}
+}
+
+// writeTarget is one record a write touches: its key, the new data for an
+// Insert or Set, or the updates for an Update.
+type writeTarget struct {
+	key     *record.Key
+	data    any
+	updates []update.Update
+}
+
+// writeImages holds what a write residual is evaluated against: whether the
+// row exists, its pre-image, and its post-image (nil for a Delete).
+type writeImages struct {
+	exists bool
+	pre    map[string]any
+	post   map[string]any
+}
+
+// enforceWrites evaluates every policy's write residual for every target
+// before any write is delegated, so a batch with one refused row writes
+// nothing.
+func (s securedWriteSession) enforceWrites(ctx context.Context, operation Operations, writes [][]writeResidual, targets []writeTarget) error {
+	if len(writes) == 0 {
+		return nil
+	}
+	for i, target := range targets {
+		perResource := writes[i]
+		if len(perResource) == 0 {
+			continue
+		}
+		images, err := s.writeImages(ctx, operation, target, perResource[0])
+		if err != nil {
+			return err
+		}
+		for _, w := range perResource {
+			if err := evaluateWrite(operation, images, w); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// writeImages reads the pre-image (inside the caller's transaction) and
+// computes the post-image for one target.
+func (s securedWriteSession) writeImages(ctx context.Context, operation Operations, target writeTarget, w writeResidual) (writeImages, error) {
+	var images writeImages
+	if operation != Insert {
+		reader, ok := s.session.(dal.ReadSession)
+		if !ok {
+			return images, w.deny(operation, "", "", "a conditional write needs a session that can read the row's pre-image")
+		}
+		shadow := record.NewRecordWithData(target.key, &map[string]any{})
+		if err := reader.Get(ctx, shadow); err != nil {
+			return images, err
+		}
+		if shadow.Exists() {
+			images.exists = true
+			images.pre = *shadow.Data().(*map[string]any)
+		}
+	}
+	switch operation {
+	case Insert, Set:
+		post, err := condeval.ToMap(target.data)
+		if err != nil {
+			return images, w.deny(operation, "", "", fmt.Sprintf("row data could not be evaluated: %v", err))
+		}
+		images.post = post
+	case Update:
+		if images.exists {
+			post := condeval.CloneMap(images.pre)
+			if err := condeval.ApplyUpdates(post, target.updates); err != nil {
+				return images, w.deny(operation, "", "", fmt.Sprintf("post-image could not be computed: %v", err))
+			}
+			images.post = post
+		}
+	}
+	return images, nil
+}
+
+// evaluateWrite applies one policy's write residual. The first alternative
+// whose Where holds on the pre-image decides an Update, Set of an existing row
+// or Delete; a new row is admitted by the first alternative whose Check it
+// satisfies; the Terminal allow applies when no alternative does.
+func evaluateWrite(operation Operations, images writeImages, w writeResidual) error {
+	r := w.residual
+	isNewRow := operation == Insert || (operation == Set && !images.exists)
+	if isNewRow {
+		for _, alternative := range r.Alternatives {
+			check, checkText := alternativeCheck(alternative)
+			ok, err := condeval.Match(images.post, check)
+			if err != nil {
+				return w.deny(operation, alternative.Rule, checkText, fmt.Sprintf("post-image check could not be evaluated for rule %q: %v", alternative.Rule, err))
+			}
+			if ok {
+				return nil
+			}
+		}
+		return terminalAdmits(operation, images, w, "no rule admits the new row")
+	}
+	if !images.exists {
+		// Nothing to protect: the adapter reports the missing row unless an
+		// unconditional allow applies.
+		if r.Terminal != nil {
+			return nil
+		}
+		return w.deny(operation, "", "", "row does not exist or is outside every conditional rule")
+	}
+	for _, alternative := range r.Alternatives {
+		ok, err := condeval.Match(images.pre, alternative.Where)
+		if err != nil {
+			return w.deny(operation, alternative.Rule, alternative.WhereText, fmt.Sprintf("row condition could not be evaluated for rule %q: %v", alternative.Rule, err))
+		}
+		if !ok {
+			continue
+		}
+		if operation == Delete {
+			return nil
+		}
+		check, checkText := alternativeCheck(alternative)
+		ok, err = condeval.Match(images.post, check)
+		if err != nil {
+			return w.deny(operation, alternative.Rule, checkText, fmt.Sprintf("post-image check could not be evaluated for rule %q: %v", alternative.Rule, err))
+		}
+		if !ok {
+			return w.deny(operation, alternative.Rule, checkText, fmt.Sprintf("post-image check not satisfied for rule %q (check: %s)", alternative.Rule, checkText))
+		}
+		return nil
+	}
+	return terminalAdmits(operation, images, w, "row condition not satisfied for any rule")
+}
+
+// alternativeCheck returns the post-image condition of an alternative: its
+// Check, or its Where when no Check is declared.
+func alternativeCheck(alternative WriteAlternative) (dal.Condition, string) {
+	if alternative.Check != nil {
+		return alternative.Check, alternative.CheckText
+	}
+	return alternative.Where, alternative.WhereText
+}
+
+// terminalAdmits applies the Terminal allow, if any, to a write no
+// alternative decided: a Delete needs no check; other writes must satisfy the
+// terminal's Check when it has one.
+func terminalAdmits(operation Operations, images writeImages, w writeResidual, failure string) error {
+	terminal := w.residual.Terminal
+	if terminal == nil {
+		return w.deny(operation, alternativeNames(w.residual), alternativeTexts(w.residual), failure)
+	}
+	if operation == Delete || terminal.Check == nil {
+		return nil
+	}
+	ok, err := condeval.Match(images.post, terminal.Check)
+	if err != nil {
+		return w.deny(operation, terminal.Rule, terminal.CheckText, fmt.Sprintf("post-image check could not be evaluated for rule %q: %v", terminal.Rule, err))
+	}
+	if !ok {
+		return w.deny(operation, terminal.Rule, terminal.CheckText, fmt.Sprintf("post-image check not satisfied for rule %q (check: %s)", terminal.Rule, terminal.CheckText))
+	}
+	return nil
+}
+
+func alternativeNames(r *WriteResidual) string {
+	names := make([]string, len(r.Alternatives))
+	for i, alternative := range r.Alternatives {
+		names[i] = alternative.Rule
+	}
+	return joinNames(names)
+}
+
+func alternativeTexts(r *WriteResidual) string {
+	texts := make([]string, len(r.Alternatives))
+	for i, alternative := range r.Alternatives {
+		texts[i] = alternative.WhereText
+	}
+	if len(texts) == 1 {
+		return texts[0]
+	}
+	return "(" + joinWith(texts, " OR ") + ")"
+}
+
+func joinNames(names []string) string { return joinWith(names, ", ") }
+
+func joinWith(parts []string, separator string) string {
+	out := ""
+	for i, part := range parts {
+		if i > 0 {
+			out += separator
+		}
+		out += part
+	}
+	return out
+}

--- a/access/writes_test.go
+++ b/access/writes_test.go
@@ -1,0 +1,385 @@
+package access
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dal-go/dalgo/adapters/dalgo2memory"
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/record"
+	"github.com/dal-go/record/update"
+)
+
+// stubReadwriteSession records writes the wrapper lets through and serves
+// pre-images from a map keyed by record ID.
+type stubReadwriteSession struct {
+	stubReadSession
+	rows   map[string]map[string]any
+	writes []string
+}
+
+func (s *stubReadwriteSession) Get(_ context.Context, rec record.Record) error {
+	s.gets++
+	if s.getErr != nil {
+		return s.getErr
+	}
+	row, ok := s.rows[rec.Key().ID.(string)]
+	if !ok {
+		rec.SetError(record.ErrRecordNotFound)
+		return nil
+	}
+	if target, ok := rec.Data().(*map[string]any); ok {
+		*target = row
+	}
+	rec.SetError(nil)
+	return nil
+}
+
+func (s *stubReadwriteSession) Set(context.Context, record.Record) error {
+	s.writes = append(s.writes, "set")
+	return nil
+}
+func (s *stubReadwriteSession) SetMulti(context.Context, []record.Record) error {
+	s.writes = append(s.writes, "setMulti")
+	return nil
+}
+func (s *stubReadwriteSession) Insert(context.Context, record.Record, ...dal.InsertOption) error {
+	s.writes = append(s.writes, "insert")
+	return nil
+}
+func (s *stubReadwriteSession) InsertMulti(context.Context, []record.Record, ...dal.InsertOption) error {
+	s.writes = append(s.writes, "insertMulti")
+	return nil
+}
+func (s *stubReadwriteSession) Update(context.Context, *record.Key, []update.Update, ...dal.Precondition) error {
+	s.writes = append(s.writes, "update")
+	return nil
+}
+func (s *stubReadwriteSession) UpdateRecord(context.Context, record.Record, []update.Update, ...dal.Precondition) error {
+	s.writes = append(s.writes, "updateRecord")
+	return nil
+}
+func (s *stubReadwriteSession) UpdateMulti(context.Context, []*record.Key, []update.Update, ...dal.Precondition) error {
+	s.writes = append(s.writes, "updateMulti")
+	return nil
+}
+func (s *stubReadwriteSession) Delete(context.Context, *record.Key) error {
+	s.writes = append(s.writes, "delete")
+	return nil
+}
+func (s *stubReadwriteSession) DeleteMulti(context.Context, []*record.Key) error {
+	s.writes = append(s.writes, "deleteMulti")
+	return nil
+}
+
+func ownership() dal.Condition {
+	return dal.WhereField("ownerID", dal.Equal, dal.NewParam("currentUser"))
+}
+
+func TestCheckRuleCompilation(t *testing.T) {
+	for name, rules := range map[string][]Rule{
+		"check on deny":   {Root(Deny(Get, "d").Check(ownership()))},
+		"check on scope":  {Under(Path("x"), Allow(Get)).Check(ownership())},
+		"invalid check":   {Root(Allow(Set, "s").Check(dal.NewGroupCondition(dal.And)))},
+		"check on opaque": {OpaqueQueryScope(Allow(Query, "q").Check(ownership()))},
+	} {
+		if _, err := NewPolicy("p", rules...); err == nil {
+			t.Errorf("%s: expected a compile error", name)
+		}
+	}
+	// A check-only rule compiles; the generated name mentions it; params are
+	// de-duplicated across where and check.
+	policy := MustPolicy("p", Scope("docs", AnyID, Allow(Set|Update).Where(ownership()).Check(dal.NewGroupCondition(dal.And, ownership(), dal.WhereField("status", dal.Equal, dal.Constant{Value: "draft"})))))
+	ctx := WithCurrentUser(context.Background(), "u1")
+	decision := policy.Decide(ctx, Request{Operation: Set, Resources: []Resource{RecordResourceForKey(record.NewKeyWithID("docs", "d1"))}})
+	mustDecideAllowed(t, decision)
+	if !strings.Contains(decision.Rule, "check (ownerID = $currentUser AND status = 'draft')") || len(policy.compiled[0].params) != 1 {
+		t.Errorf("decision = %+v params = %v", decision, policy.compiled[0].params)
+	}
+	if decision.Writes == nil || decision.Writes[0].Alternatives[0].Check == nil || decision.Writes[0].Alternatives[0].CheckText == "" {
+		t.Errorf("write residual = %+v", decision.Writes)
+	}
+}
+
+func TestWriteDecisions(t *testing.T) {
+	ctx := WithCurrentUser(context.Background(), "u1")
+	doc := RecordResourceForKey(record.NewKeyWithID("docs", "d1"))
+	// A terminal allow with only a check: reads unconditional, writes checked.
+	checkOnly := MustPolicy("check-only", Scope("docs", AnyID, Allow(ReadWrite, "keep-mine").Check(ownership())))
+	decision := checkOnly.Decide(ctx, Request{Operation: Get, Resources: []Resource{doc}})
+	mustDecideAllowed(t, decision)
+	if decision.Residuals != nil || decision.Writes == nil || decision.Writes[0].Terminal == nil || decision.Writes[0].Terminal.Check == nil || decision.Condition != "ownerID = $currentUser" {
+		t.Errorf("check-only decision = %+v", decision)
+	}
+	// Conditional alternatives before a terminal allow keep both.
+	both := MustPolicy("both", Root(Allow(ReadWrite, "all")), Scope("docs", AnyID, Allow(Update, "own").Where(ownership())))
+	decision = both.Decide(ctx, Request{Operation: Update, Resources: []Resource{doc}})
+	mustDecideAllowed(t, decision)
+	if decision.Residuals != nil || len(decision.Writes[0].Alternatives) != 1 || decision.Writes[0].Terminal == nil || decision.Rule != "all" {
+		t.Errorf("both decision = %+v", decision)
+	}
+	// Unresolved parameters in a check or in the terminal's check deny.
+	for name, policy := range map[string]*AccessPolicy{
+		"check-only":     checkOnly,
+		"terminal check": MustPolicy("t", Root(Allow(ReadWrite, "all").Check(ownership()))),
+	} {
+		if decision := policy.Decide(context.Background(), Request{Operation: Set, Resources: []Resource{doc}}); decision.Allowed || decision.Condition != "ownerID = $currentUser" {
+			t.Errorf("%s: unresolved parameter must deny with the condition text: %+v", name, decision)
+		}
+	}
+	// Multi-resource requests carry write residuals per resource.
+	decision = both.Decide(ctx, Request{Operation: Update, Resources: []Resource{RecordResourceForKey(record.NewKeyWithID("other", "o1")), doc}})
+	mustDecideAllowed(t, decision)
+	if len(decision.Writes) != 2 || decision.Writes[0] != nil || decision.Writes[1] == nil {
+		t.Errorf("per-resource writes = %+v", decision.Writes)
+	}
+}
+
+func newWriteFixture(t *testing.T, policies ...Policy) (*stubReadwriteSession, dal.ReadwriteSession) {
+	t.Helper()
+	stub := &stubReadwriteSession{rows: map[string]map[string]any{
+		"mine":   {"ownerID": "u1", "status": "draft", "title": "a"},
+		"theirs": {"ownerID": "u2", "status": "draft", "title": "b"},
+	}}
+	return stub, SecureReadwriteSession(stub, policies...)
+}
+
+func TestConditionalWritesThroughStub(t *testing.T) {
+	ctx := WithCurrentUser(context.Background(), "u1")
+	key := func(id string) *record.Key { return record.NewKeyWithID("docs", id) }
+	// Where-only rule: check defaults to where.
+	own := MustPolicy("own", Scope("docs", AnyID, Allow(Write, "own").Where(ownership())))
+	stub, session := newWriteFixture(t, own)
+	mustDeny := func(t *testing.T, err error, fragment string) {
+		t.Helper()
+		if !errors.Is(err, ErrAccessDenied) || !strings.Contains(err.Error(), fragment) || strings.Contains(err.Error(), "u1") {
+			t.Fatalf("expected denial containing %q without values, got %v", fragment, err)
+		}
+	}
+	// Insert: admitted by the alternative's check, refused otherwise.
+	if err := session.Insert(ctx, record.NewRecordWithData(key("new"), map[string]any{"ownerID": "u1"})); err != nil {
+		t.Fatalf("insert own: %v", err)
+	}
+	mustDeny(t, session.Insert(ctx, record.NewRecordWithData(key("new"), map[string]any{"ownerID": "u2"})), "no rule admits the new row")
+	// Set: missing row behaves like insert; existing row checks pre and post.
+	if err := session.Set(ctx, record.NewRecordWithData(key("fresh"), map[string]any{"ownerID": "u1"})); err != nil {
+		t.Fatalf("set new own: %v", err)
+	}
+	mustDeny(t, session.Set(ctx, record.NewRecordWithData(key("theirs"), map[string]any{"ownerID": "u1"})), "row condition not satisfied")
+	mustDeny(t, session.Set(ctx, record.NewRecordWithData(key("mine"), map[string]any{"ownerID": "u2"})), "post-image check not satisfied")
+	if err := session.Set(ctx, record.NewRecordWithData(key("mine"), map[string]any{"ownerID": "u1", "title": "c"})); err != nil {
+		t.Fatalf("set own: %v", err)
+	}
+	// Update: cannot take ownership, cannot give it away, may edit own.
+	mustDeny(t, session.Update(ctx, key("theirs"), []update.Update{update.ByFieldName("ownerID", "u1")}), "row condition not satisfied")
+	mustDeny(t, session.Update(ctx, key("mine"), []update.Update{update.ByFieldName("ownerID", "u2")}), "post-image check not satisfied")
+	if err := session.Update(ctx, key("mine"), []update.Update{update.ByFieldName("title", "d")}); err != nil {
+		t.Fatalf("update own: %v", err)
+	}
+	if err := session.UpdateRecord(ctx, record.NewRecordWithData(key("mine"), map[string]any{}), []update.Update{update.ByFieldName("title", "e")}); err != nil {
+		t.Fatalf("update record own: %v", err)
+	}
+	mustDeny(t, session.Update(ctx, key("missing"), []update.Update{update.ByFieldName("title", "x")}), "does not exist")
+	mustDeny(t, session.Update(ctx, key("mine"), []update.Update{update.ByFieldPath(update.FieldPath{"title", "nested"}, "x")}), "post-image could not be computed")
+	// Delete: own yes, theirs no.
+	if err := session.Delete(ctx, key("mine")); err != nil {
+		t.Fatalf("delete own: %v", err)
+	}
+	mustDeny(t, session.Delete(ctx, key("theirs")), "row condition not satisfied")
+	// Batches are refused whole and never reach the adapter.
+	before := len(stub.writes)
+	mustDeny(t, session.SetMulti(ctx, []record.Record{record.NewRecordWithData(key("mine"), map[string]any{"ownerID": "u1"}), record.NewRecordWithData(key("theirs"), map[string]any{"ownerID": "u1"})}), "row condition not satisfied")
+	mustDeny(t, session.InsertMulti(ctx, []record.Record{record.NewRecordWithData(key("a"), map[string]any{"ownerID": "u1"}), record.NewRecordWithData(key("b"), map[string]any{"ownerID": "u2"})}), "no rule admits")
+	mustDeny(t, session.UpdateMulti(ctx, []*record.Key{key("mine"), key("theirs")}, []update.Update{update.ByFieldName("title", "x")}), "row condition not satisfied")
+	mustDeny(t, session.DeleteMulti(ctx, []*record.Key{key("mine"), key("theirs")}), "row condition not satisfied")
+	if len(stub.writes) != before {
+		t.Errorf("refused batches reached the adapter: %v", stub.writes[before:])
+	}
+	if err := session.SetMulti(ctx, []record.Record{record.NewRecordWithData(key("mine"), map[string]any{"ownerID": "u1"})}); err != nil {
+		t.Fatalf("set multi own: %v", err)
+	}
+	// A batch mixing an unconditional target with a conditional one evaluates only the latter.
+	mixed := SecureReadwriteSession(stub, MustPolicy("mixed", Scope("docs", "shared", Allow(Write, "shared")), Scope("docs", AnyID, Allow(Write, "own").Where(ownership()))))
+	if err := mixed.SetMulti(ctx, []record.Record{record.NewRecordWithData(key("shared"), map[string]any{"ownerID": "u9"}), record.NewRecordWithData(key("mine"), map[string]any{"ownerID": "u1"})}); err != nil {
+		t.Fatalf("mixed batch: %v", err)
+	}
+	if err := session.InsertMulti(ctx, []record.Record{record.NewRecordWithData(key("a"), map[string]any{"ownerID": "u1"})}); err != nil {
+		t.Fatalf("insert multi own: %v", err)
+	}
+	if err := session.UpdateMulti(ctx, []*record.Key{key("mine")}, []update.Update{update.ByFieldName("title", "x")}); err != nil {
+		t.Fatalf("update multi own: %v", err)
+	}
+	if err := session.DeleteMulti(ctx, []*record.Key{key("mine")}); err != nil {
+		t.Fatalf("delete multi own: %v", err)
+	}
+	// Row data that cannot be evaluated is refused.
+	mustDeny(t, session.Insert(ctx, record.NewRecordWithData(key("chan"), &struct{ C chan int }{C: make(chan int)})), "could not be evaluated")
+	// Pre-image read errors propagate.
+	stub.getErr = errors.New("boom")
+	if err := session.Delete(ctx, key("mine")); err == nil || err.Error() != "boom" {
+		t.Errorf("pre-image error = %v", err)
+	}
+	stub.getErr = nil
+
+	// A terminal allow admits what no alternative decided; its own check
+	// still applies to non-delete writes; a missing row is left to the adapter.
+	loose := MustPolicy("loose", Root(Allow(Write, "all").Check(dal.WhereField("status", dal.Equal, dal.Constant{Value: "draft"}))), Scope("docs", AnyID, Allow(Write, "own").Where(ownership())))
+	stub, session = newWriteFixture(t, loose)
+	if err := session.Update(ctx, key("theirs"), []update.Update{update.ByFieldName("title", "x")}); err != nil {
+		t.Fatalf("terminal admits theirs: %v", err)
+	}
+	mustDeny(t, session.Update(ctx, key("theirs"), []update.Update{update.ByFieldName("status", "final")}), "post-image check not satisfied")
+	mustDeny(t, session.Insert(ctx, record.NewRecordWithData(key("n"), map[string]any{"ownerID": "u3", "status": "final"})), "post-image check not satisfied")
+	if err := session.Delete(ctx, key("theirs")); err != nil {
+		t.Fatalf("terminal delete: %v", err)
+	}
+	if err := session.Update(ctx, key("missing"), []update.Update{update.ByFieldName("title", "x")}); err != nil {
+		t.Fatalf("missing row under terminal allow: %v", err)
+	}
+	// Two policies both apply; the stricter one refuses.
+	strict := WithPolicy(ctx, MustPolicy("draft-only", Scope("docs", AnyID, Allow(Write, "drafts").Where(dal.WhereField("status", dal.Equal, dal.Constant{Value: "draft"})))))
+	stub.rows["mine"]["status"] = "final"
+	mustDeny(t, session.Update(strict, key("mine"), []update.Update{update.ByFieldName("title", "x")}), "drafts")
+}
+
+func TestEvaluateWriteErrorBranches(t *testing.T) {
+	bad := WriteAlternative{Rule: "bad", Where: fakeCond{}, Check: fakeCond{}, WhereText: "w", CheckText: "c"}
+	good := WriteAlternative{Rule: "good", Where: dal.WhereField("ownerID", dal.Equal, dal.Constant{Value: "u1"}), WhereText: "ownerID = $currentUser"}
+	images := writeImages{exists: true, pre: map[string]any{"ownerID": "u1"}, post: map[string]any{"ownerID": "u1"}}
+	for name, tc := range map[string]struct {
+		operation Operations
+		images    writeImages
+		residual  WriteResidual
+		fragment  string
+	}{
+		"new row check error":        {Insert, images, WriteResidual{Alternatives: []WriteAlternative{bad}}, "could not be evaluated"},
+		"pre-image where error":      {Update, images, WriteResidual{Alternatives: []WriteAlternative{bad}}, "could not be evaluated"},
+		"post-image check error":     {Update, images, WriteResidual{Alternatives: []WriteAlternative{{Rule: "g", Where: good.Where, Check: fakeCond{}, CheckText: "c"}}}, "could not be evaluated"},
+		"terminal check error":       {Insert, images, WriteResidual{Terminal: &WriteAlternative{Rule: "t", Check: fakeCond{}}}, "could not be evaluated"},
+		"terminal check false":       {Set, images, WriteResidual{Terminal: &WriteAlternative{Rule: "t", Check: dal.WhereField("ownerID", dal.Equal, dal.Constant{Value: "u2"}), CheckText: "ownerID = 'u2'"}}, "not satisfied"},
+		"no alternative no terminal": {Delete, images, WriteResidual{Alternatives: []WriteAlternative{{Rule: "a", Where: dal.WhereField("ownerID", dal.Equal, dal.Constant{Value: "u2"}), WhereText: "a"}, {Rule: "b", Where: dal.WhereField("ownerID", dal.Equal, dal.Constant{Value: "u3"}), WhereText: "b"}}}, "(a OR b)"},
+	} {
+		err := evaluateWrite(tc.operation, tc.images, writeResidual{policy: "p", resource: RecordResourceForKey(record.NewKeyWithID("docs", "d1")), residual: &tc.residual})
+		var denied *DeniedError
+		if !errors.As(err, &denied) || (!strings.Contains(err.Error(), tc.fragment) && denied.Decision.Condition != tc.fragment) {
+			t.Errorf("%s: %v", name, err)
+		}
+	}
+	if err := evaluateWrite(Delete, images, writeResidual{residual: &WriteResidual{Alternatives: []WriteAlternative{good}}}); err != nil {
+		t.Errorf("delete own = %v", err)
+	}
+}
+
+func TestReadAllEditAssignedOnMemoryDB(t *testing.T) {
+	ctx := context.Background()
+	raw := dalgo2memory.New(dalgo2memory.FirestoreProfile())
+	key := func(id string) *record.Key { return record.NewKeyWithID("customers", id) }
+	if err := raw.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		for id, c := range map[string]customer{"c1": {Name: "Ann", AssignedTo: "u1"}, "c2": {Name: "Bob", AssignedTo: "u2"}} {
+			c := c
+			if err := tx.Set(ctx, record.NewRecordWithData(key(id), &c)); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	db := MustSecureDB(raw, WithDatabasePolicies(customersPolicy(t)))
+	user1 := WithCurrentUser(ctx, "u1")
+	run := func(worker func(ctx context.Context, tx dal.ReadwriteTransaction) error) error {
+		return db.RunReadwriteTransaction(user1, worker)
+	}
+	// Read all: the other user's customer is readable.
+	other := &customer{}
+	if err := db.Get(user1, record.NewRecordWithData(key("c2"), other)); err != nil || other.Name != "Bob" {
+		t.Fatalf("read all: err=%v data=%+v", err, *other)
+	}
+	// Edit only assigned: own update lands, other's is refused, reassignment away is refused.
+	if err := run(func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Update(ctx, key("c1"), []update.Update{update.ByFieldName("name", "Ann B")})
+	}); err != nil {
+		t.Fatalf("update own: %v", err)
+	}
+	if err := run(func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Update(ctx, key("c2"), []update.Update{update.ByFieldName("name", "x")})
+	}); !errors.Is(err, ErrAccessDenied) {
+		t.Fatalf("update other's = %v", err)
+	}
+	if err := run(func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Update(ctx, key("c1"), []update.Update{update.ByFieldName("assignedTo", "u2")})
+	}); !errors.Is(err, ErrAccessDenied) {
+		t.Fatalf("reassign away = %v", err)
+	}
+	if err := run(func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Delete(ctx, key("c2"))
+	}); !errors.Is(err, ErrAccessDenied) {
+		t.Fatalf("delete other's = %v", err)
+	}
+	if err := run(func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Delete(ctx, key("c1"))
+	}); err != nil {
+		t.Fatalf("delete own: %v", err)
+	}
+	// The stored data reflects only the admitted writes.
+	stored := &customer{}
+	if err := raw.Get(ctx, record.NewRecordWithData(key("c2"), stored)); err != nil || stored.Name != "Bob" {
+		t.Errorf("c2 must be untouched: err=%v data=%+v", err, *stored)
+	}
+	if exists, err := raw.Exists(ctx, key("c1")); err != nil || exists {
+		t.Errorf("c1 must be deleted: exists=%v err=%v", exists, err)
+	}
+}
+
+func TestCheckDocumentRoundTrip(t *testing.T) {
+	source := `apiVersion: dalgo.io/access/v1
+kind: AccessPolicy
+metadata:
+  name: docs
+default: deny
+scopes:
+  - path: /docs/*
+    rules:
+      - id: keep-drafts
+        effect: allow
+        operations: [write]
+        where:
+          op: "=="
+          left: { field: ownerID }
+          right: { param: currentUser }
+        check:
+          and:
+            - op: "=="
+              left: { field: ownerID }
+              right: { param: currentUser }
+            - op: "=="
+              left: { field: status }
+              right: { value: draft }
+`
+	policy, err := UnmarshalAccessPolicyYAML([]byte(source))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	decision := policy.Decide(WithCurrentUser(context.Background(), "u1"), Request{Operation: Set, Resources: []Resource{RecordResourceForKey(record.NewKeyWithID("docs", "d1"))}})
+	mustDecideAllowed(t, decision)
+	if got := decision.Writes[0].Alternatives[0].CheckText; got != "(ownerID = $currentUser AND status = 'draft')" {
+		t.Errorf("check text = %q", got)
+	}
+	for name, marshal := range map[string]func(*AccessPolicy) ([]byte, error){"yaml": MarshalAccessPolicyYAML, "json": MarshalAccessPolicyJSON} {
+		encoded, err := marshal(policy)
+		if err != nil || !strings.Contains(string(encoded), "check") {
+			t.Fatalf("%s: err=%v encoded=%s", name, err, encoded)
+		}
+	}
+	bad := Document{APIVersion: DocumentAPIVersion, Kind: AccessPolicyKind, Metadata: DocumentMetadata{Name: "x"}, Default: "deny",
+		Scopes: []DocumentScope{{Path: "/x/*", Rules: []DocumentRule{{ID: "r", Effect: "allow", Operations: []string{"set"}, Check: &DocumentCondition{}}}}}}
+	if _, err := DecodeAccessPolicy(strings.NewReader(""), staticCodec{d: bad}); err == nil || !strings.Contains(err.Error(), "check:") {
+		t.Errorf("invalid check must fail with the slot named: %v", err)
+	}
+	unserialisable := &AccessPolicy{name: "p", rules: []Rule{Root(Rule{kind: directiveRule, effect: effectAllow, operations: Set, name: "r", check: fakeCond{}})}}
+	if _, err := MarshalAccessPolicyYAML(unserialisable); !errors.Is(err, ErrNotSerializable) {
+		t.Errorf("unserialisable check = %v", err)
+	}
+}

--- a/condeval/updates.go
+++ b/condeval/updates.go
@@ -1,0 +1,82 @@
+package condeval
+
+import (
+	"fmt"
+
+	"github.com/dal-go/record/update"
+)
+
+// CloneMap deep-copies JSON-shaped record data (maps, slices and scalars) so a
+// post-image can be computed without touching the pre-image.
+func CloneMap(data map[string]any) map[string]any {
+	out := make(map[string]any, len(data))
+	for key, value := range data {
+		out[key] = cloneValue(value)
+	}
+	return out
+}
+
+func cloneValue(value any) any {
+	switch v := value.(type) {
+	case map[string]any:
+		return CloneMap(v)
+	case []any:
+		out := make([]any, len(v))
+		for i, item := range v {
+			out[i] = cloneValue(item)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+// ApplyUpdates applies field updates to JSON-shaped record data, producing the
+// post-image of an Update: a field name addresses a top-level key, a field
+// path a nested key, and update.DeleteField removes the leaf. Missing
+// intermediate maps are created; an intermediate value that is not a map is an
+// error, because the write would fail or corrupt the record and the policy
+// must not guess the outcome.
+func ApplyUpdates(data map[string]any, updates []update.Update) error {
+	for _, item := range updates {
+		var path []string
+		if fieldPath := item.FieldPath(); len(fieldPath) > 0 {
+			path = fieldPath
+		} else if fieldName := item.FieldName(); fieldName != "" {
+			path = []string{fieldName}
+		} else {
+			return fmt.Errorf("condeval: update has neither a field name nor a field path")
+		}
+		if err := applyPathUpdate(data, path, item.Value()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applyPathUpdate(data map[string]any, path []string, value any) error {
+	current := data
+	for _, key := range path[:len(path)-1] {
+		switch next := current[key].(type) {
+		case map[string]any:
+			current = next
+		case nil:
+			created := make(map[string]any)
+			current[key] = created
+			current = created
+		default:
+			return fmt.Errorf("condeval: field path segment %q is not a map (got %T)", key, current[key])
+		}
+	}
+	leaf := path[len(path)-1]
+	if value == update.DeleteField {
+		delete(current, leaf)
+		return nil
+	}
+	normalized, ok := normalize(value)
+	if !ok {
+		return fmt.Errorf("condeval: update value for %q is not JSON-serialisable", leaf)
+	}
+	current[leaf] = normalized
+	return nil
+}

--- a/condeval/updates_test.go
+++ b/condeval/updates_test.go
@@ -1,0 +1,52 @@
+package condeval
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/dal-go/record/update"
+)
+
+func TestCloneMap(t *testing.T) {
+	source := map[string]any{"a": 1.0, "nested": map[string]any{"b": []any{"x", map[string]any{"c": true}}}}
+	clone := CloneMap(source)
+	if !reflect.DeepEqual(clone, source) {
+		t.Fatalf("clone = %v, want %v", clone, source)
+	}
+	clone["nested"].(map[string]any)["b"].([]any)[1].(map[string]any)["c"] = false
+	if source["nested"].(map[string]any)["b"].([]any)[1].(map[string]any)["c"] != true {
+		t.Error("clone must not share nested values with the source")
+	}
+}
+
+func TestApplyUpdates(t *testing.T) {
+	data := map[string]any{"name": "Ann", "address": map[string]any{"city": "Cork"}, "flag": "x"}
+	err := ApplyUpdates(data, []update.Update{
+		update.ByFieldName("name", "Bob"),
+		update.ByFieldPath(update.FieldPath{"address", "city"}, "Limerick"),
+		update.ByFieldPath(update.FieldPath{"meta", "created"}, 42),
+		update.DeleteByFieldName("flag"),
+	})
+	if err != nil {
+		t.Fatalf("ApplyUpdates: %v", err)
+	}
+	want := map[string]any{"name": "Bob", "address": map[string]any{"city": "Limerick"}, "meta": map[string]any{"created": 42.0}}
+	if !reflect.DeepEqual(data, want) {
+		t.Errorf("data = %v, want %v", data, want)
+	}
+	for name, bad := range map[string][]update.Update{
+		"intermediate not a map": {update.ByFieldPath(update.FieldPath{"name", "first"}, "A")},
+		"unserialisable value":   {update.ByFieldName("ch", make(chan int))},
+		"empty update":           {emptyUpdate{}},
+	} {
+		if err := ApplyUpdates(CloneMap(data), bad); err == nil {
+			t.Errorf("%s: expected an error", name)
+		}
+	}
+}
+
+type emptyUpdate struct{}
+
+func (emptyUpdate) FieldName() string           { return "" }
+func (emptyUpdate) FieldPath() update.FieldPath { return nil }
+func (emptyUpdate) Value() any                  { return nil }

--- a/end2end/test_access.go
+++ b/end2end/test_access.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dal-go/dalgo/dal"
 	"github.com/dal-go/dalgo/end2end/models"
 	"github.com/dal-go/record"
+	"github.com/dal-go/record/update"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -127,5 +128,27 @@ func accessConditionsTest(ctx context.Context, t *testing.T, db dal.DB) {
 		exists, err = secured.Exists(callerCtx, record.NewKeyWithID(models.CitiesCollection, otherCountryID))
 		assert.ErrorIs(t, err, access.ErrAccessDenied)
 		assert.False(t, exists)
+	})
+	t.Run("writes_follow_the_condition", func(t *testing.T) {
+		if !queriesRan {
+			t.Skip("adapter did not execute a narrowed query; writes are not exercised")
+		}
+		writer := access.MustSecureDB(db, access.WithDatabasePolicies(access.MustPolicy("cities-writes",
+			access.Scope(models.CitiesCollection, access.AnyID, access.Allow(access.Update|access.Delete, "edit-own-country").Where(countryOfCaller)),
+		)))
+		touch := func(id string) error {
+			return writer.RunReadwriteTransaction(callerCtx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+				return tx.Update(ctx, record.NewKeyWithID(models.CitiesCollection, id), []update.Update{update.ByFieldName("HasAirport", true)})
+			}, dal.TxWithMessage("access conditions write"))
+		}
+		require.NoError(t, touch(expected[0]), "update of an own-country city")
+		assert.ErrorIs(t, touch(otherCountryID), access.ErrAccessDenied, "update of another country's city")
+		err := writer.RunReadwriteTransaction(callerCtx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+			return tx.Delete(ctx, record.NewKeyWithID(models.CitiesCollection, otherCountryID))
+		}, dal.TxWithMessage("access conditions write"))
+		assert.ErrorIs(t, err, access.ErrAccessDenied, "delete of another country's city")
+		other := &models.City{}
+		require.NoError(t, db.Get(ctx, record.NewRecordWithData(record.NewKeyWithID(models.CitiesCollection, otherCountryID), other)))
+		assert.NotEqual(t, country, other.Country, "the other country's city must be untouched")
 	})
 }

--- a/spec/features/access-policies/row-level-conditions/README.md
+++ b/spec/features/access-policies/row-level-conditions/README.md
@@ -98,7 +98,9 @@ conditions.
 ### REQ: rule-condition-slots
 
 A rule MUST accept two optional conditions: `where` and `check`. `check` MUST
-default to `where` when absent. In this feature, conditions MUST be accepted on
+default to `where` when absent. A rule MAY declare `check` without `where`: it
+then applies to every row on read and constrains only what a write may
+produce. In this feature, conditions MUST be accepted on
 **allow** rules only; constructing a deny rule with a condition MUST fail. A
 condition MUST NOT be accepted on a collection-group resource rule or on an
 opaque-query rule. A conditional rule MUST NOT authorise `Truncate`: when its
@@ -243,8 +245,15 @@ evaluate `where` on it; evaluate `check` on the new data. `Update`: read the
 pre-image, evaluate `where` on it, compute the post-image by applying the update
 and evaluate `check` on it; if the wrapper cannot compute the post-image for the
 update's operations it MUST deny. `Delete`: read the pre-image and evaluate
-`where` on it. Multi-record writes MUST be evaluated in full before any record
-is written and denied whole if any record fails. On an adapter without
+`where` on it. Rule selection for a write follows the read-side precedence walk:
+the first conditional allow whose `where` holds on the pre-image decides the
+row and its `check` applies; a new row (`Insert`, or `Set` of a missing row) is
+admitted by the first conditional allow whose `check` it satisfies; when no
+conditional allow applies, the first unconditional allow admits the write,
+subject to its own `check` if it declares one. An `Update` or `Delete` of a
+missing row under only conditional rules MUST be denied; under an unconditional
+allow it MUST be left to the adapter. Multi-record writes MUST be evaluated in
+full before any record is written and denied whole if any record fails. On an adapter without
 transactions, a conditional write MUST be denied unless the policy sets an
 explicit best-effort option, in which case the pre-image read precedes the
 write without isolation and the decision explanation states so.
@@ -384,11 +393,29 @@ field value of the record.
 **When** the caller queries `orders` with `Limit 10` ordered by `createdAt`
 **Then** the adapter executes a query whose `Where` conjoins `tenantID == "t1"` with the caller's conditions, and the ten returned rows all belong to `t1`.
 
+### AC: check-defaults-to-where (verifies REQ:rule-condition-slots)
+
+**Given** an allow rule with only `where: ownerID == $currentUser`
+**When** an `Insert` is evaluated with data whose `ownerID` differs from the current user
+**Then** the insert is denied with the explanation naming the `check` slot.
+
 ### AC: cannot-take-ownership (verifies REQ:write-enforcement)
 
 **Given** an allow rule `Set where ownerID == $currentUser` and an existing record owned by another user
 **When** the caller sets that key with data whose `ownerID` is the caller
 **Then** the write is denied because `where` fails on the pre-image.
+
+### AC: update-post-image (verifies REQ:write-enforcement)
+
+**Given** an allow rule `Update where ownerID == $currentUser check ownerID == $currentUser`
+**When** the caller updates their own record by setting `ownerID` to someone else
+**Then** the update is denied because `check` fails on the computed post-image.
+
+### AC: batch-all-or-nothing (verifies REQ:write-enforcement)
+
+**Given** a conditional `Delete` rule and a multi-delete where one key's pre-image fails `where`
+**When** the batch is executed
+**Then** nothing is deleted.
 
 ### AC: unconditional-suite-unchanged (verifies REQ:precedence-with-conditions)
 

--- a/spec/plans/row-level-conditions-mvp.md
+++ b/spec/plans/row-level-conditions-mvp.md
@@ -121,6 +121,12 @@ customers, get another user's record denied, exists upgraded; whole module at
   edit half needs the write side and is deferred with it.
 - access-policies/row-level-conditions#ac:capture-in-condition — path captures
   (`{name}` segments bound to `$path.<name>`) are the next plan.
+- access-policies/row-level-conditions#ac:check-defaults-to-where — write side,
+  verified by [`row-level-conditions-write-side`](row-level-conditions-write-side.md).
+- access-policies/row-level-conditions#ac:update-post-image — write side,
+  verified by [`row-level-conditions-write-side`](row-level-conditions-write-side.md).
+- access-policies/row-level-conditions#ac:batch-all-or-nothing — write side,
+  verified by [`row-level-conditions-write-side`](row-level-conditions-write-side.md).
 
 ## Open Questions
 

--- a/spec/plans/row-level-conditions-write-side.md
+++ b/spec/plans/row-level-conditions-write-side.md
@@ -1,0 +1,134 @@
+---
+format: https://specscore.md/plan-specification
+status: Implemented
+---
+# Plan: Row-level access conditions — write side
+
+**Status:** Implemented
+**Source Feature:** access-policies/row-level-conditions
+**Date:** 2026-09-03
+**Owner:** alex
+**Supersedes:** —
+
+## Summary
+
+Second slice of `access-policies/row-level-conditions`, after the read-side
+MVP ([`row-level-conditions-mvp`](row-level-conditions-mvp.md)): enforce row
+conditions on writes. A rule gains `check` (the post-image condition, defaulting
+to `where`); the secured write session reads the pre-image inside the caller's
+transaction, computes the post-image (new data for Insert and Set, pre-image
+plus updates for Update), and admits or refuses each write before anything
+reaches the adapter. This lifts the read-side slice's fail-closed refusal of
+conditional writes, so "read all customers, edit only the ones assigned to me"
+works end to end.
+
+## Approach
+
+Rule selection follows the same precedence walk as reads: matching rules in
+order, conditional allows first, then the first unconditional rule. For a write
+the *first alternative whose `where` holds on the pre-image* decides the row and
+its `check` must hold on the post-image; a new row (Insert, or Set of a missing
+row) is admitted by the first alternative whose `check` it satisfies; when no
+alternative applies, the terminal unconditional allow admits the write, subject
+to its own `check` if it declares one. Deletes need only `where`. Every policy
+in the intersection is evaluated; any refusal wins. Batches are evaluated in
+full before any write is delegated.
+
+The pre-image is read into a private map through the transaction's own read
+session; a write session that cannot read refuses conditional writes. The
+post-image for Update is computed with the shared `condeval.ApplyUpdates`, the
+same field-path semantics the in-memory adapter applies.
+
+## Tasks
+
+### Task 1: Shared update applier
+
+**Id:** task-1
+**Verifies:** access-policies/row-level-conditions#ac:comparison-and-groups
+**Depends-On:** —
+**Status:** complete
+
+`condeval.ApplyUpdates` and `condeval.CloneMap`: field-name and field-path
+sets, `update.DeleteField`, intermediate maps created, non-map intermediates and
+non-serialisable values refused.
+
+### Task 2: Check on rules and write residuals in decisions
+
+**Id:** task-2
+**Verifies:** access-policies/row-level-conditions#ac:check-defaults-to-where, access-policies/row-level-conditions#ac:conditional-deny-rejected
+**Depends-On:** 1
+**Status:** complete
+
+`Rule.Check(cond)`; compile validation shared with `where`; `Decision.Writes`
+carries per-resource `WriteResidual` (ordered alternatives plus terminal allow),
+resolved once per request; unresolved parameters deny.
+
+### Task 3: Write enforcement in the secured write session
+
+**Id:** task-3
+**Verifies:** access-policies/row-level-conditions#ac:cannot-take-ownership, access-policies/row-level-conditions#ac:update-post-image, access-policies/row-level-conditions#ac:batch-all-or-nothing, access-policies/row-level-conditions#ac:read-all-edit-assigned
+**Depends-On:** 2
+**Status:** complete
+
+Pre-image read inside the transaction, post-image computation, alternative
+selection per operation (Insert, Set, Update, UpdateRecord, UpdateMulti,
+Delete, multi variants), batches refused whole, explanations without values.
+
+### Task 4: Portable documents
+
+**Id:** task-4
+**Verifies:** access-policies/row-level-conditions#ac:yaml-roundtrip
+**Depends-On:** 2
+**Status:** complete
+
+`check` on `DocumentRule`, YAML and JSON, both directions.
+
+### Task 5: Integration and conformance
+
+**Id:** task-5
+**Verifies:** access-policies/row-level-conditions#ac:read-all-edit-assigned
+**Depends-On:** 3, 4
+**Status:** complete
+
+The customers example end to end on `dalgo2memory` (read all, edit only
+assigned, cannot take ownership, cannot reassign away); end2end write
+sub-tests for adapters; 100% statement coverage.
+
+## Deferred AC Coverage
+
+- access-policies/row-level-conditions#ac:capture-in-condition — path captures
+  are the next plan.
+- access-policies/row-level-conditions#ac:comparison-and-groups — read-side criterion
+  already verified by [`row-level-conditions-mvp`](row-level-conditions-mvp.md);
+  behaviour unchanged here, suites re-run green.
+- access-policies/row-level-conditions#ac:conditional-deny-rejected — read-side criterion
+  already verified by [`row-level-conditions-mvp`](row-level-conditions-mvp.md);
+  behaviour unchanged here, suites re-run green.
+- access-policies/row-level-conditions#ac:write-group-excludes-truncate — read-side criterion
+  already verified by [`row-level-conditions-mvp`](row-level-conditions-mvp.md);
+  behaviour unchanged here, suites re-run green.
+- access-policies/row-level-conditions#ac:missing-variable-denies — read-side criterion
+  already verified by [`row-level-conditions-mvp`](row-level-conditions-mvp.md);
+  behaviour unchanged here, suites re-run green.
+- access-policies/row-level-conditions#ac:get-other-users-record — read-side criterion
+  already verified by [`row-level-conditions-mvp`](row-level-conditions-mvp.md);
+  behaviour unchanged here, suites re-run green.
+- access-policies/row-level-conditions#ac:tenant-slice — read-side criterion
+  already verified by [`row-level-conditions-mvp`](row-level-conditions-mvp.md);
+  behaviour unchanged here, suites re-run green.
+- access-policies/row-level-conditions#ac:unconditional-suite-unchanged — read-side criterion
+  already verified by [`row-level-conditions-mvp`](row-level-conditions-mvp.md);
+  behaviour unchanged here, suites re-run green.
+- access-policies/row-level-conditions#ac:yaml-roundtrip — read-side criterion
+  already verified by [`row-level-conditions-mvp`](row-level-conditions-mvp.md);
+  behaviour unchanged here, suites re-run green.
+- access-policies/row-level-conditions#ac:no-leak — read-side criterion
+  already verified by [`row-level-conditions-mvp`](row-level-conditions-mvp.md);
+  behaviour unchanged here, suites re-run green.
+
+## Open Questions
+
+None at this time.
+
+---
+*This document follows the https://specscore.md/plan-specification*


### PR DESCRIPTION
Second slice of `access-policies/row-level-conditions` (tracks #133; plan `spec/plans/row-level-conditions-write-side.md`). Lifts the read-side slice's fail-closed refusal of conditional writes.

**Model**
- `Rule.Check(cond)`: post-image condition, defaults to `where`; a check-only rule reads every row and constrains only what a write may produce.
- `Decision.Writes`: per-resource `WriteResidual` — conditional alternatives in precedence order plus the terminal unconditional allow (with its own check, if any).

**Enforcement** (inside the caller's transaction, before anything reaches the adapter)
- Pre-image read into a private map; post-image = new data (Insert/Set) or pre-image + updates (`condeval.ApplyUpdates`, same field-path semantics as the memory adapter).
- The first alternative whose `where` holds on the pre-image decides an Update/Set/Delete and its `check` must hold on the post-image; a new row is admitted by the first alternative whose `check` it satisfies; otherwise the terminal allow decides, subject to its check. Deletes need only `where`.
- Batches refused whole; a write-only session refuses conditional writes; explanations name rule and condition text, never values.

**Verified**: the customers example end to end on `dalgo2memory` (read all, edit own, cannot take or give away ownership, delete own only); `writes_follow_the_condition` added to the end2end `access_conditions` group; 100% coverage in `access`, `condeval`, `end2end`; `go test ./...` green; golangci 0 issues; spec lint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEVhqasFJJ3iAcARe7Wts6