### PR TITLE
feat(access): path captures — {name} segments bound to $path.<name> in row conditions

### DIFF
--- a/access/captures_test.go
+++ b/access/captures_test.go
@@ -1,0 +1,196 @@
+package access
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/dal-go/dalgo/adapters/dalgo2memory"
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/record"
+	"github.com/dal-go/record/update"
+)
+
+func spaceOfPath() dal.Condition {
+	return dal.WhereField("spaceID", dal.Equal, dal.NewParam("path.spaceID"))
+}
+
+func trackusKeyIn(space string) *record.Key {
+	return record.NewKeyWithParentAndID(record.NewKeyWithID("spaces", space), "ext", "trackus")
+}
+
+func itemKeyIn(space, id string) *record.Key {
+	return record.NewKeyWithParentAndID(trackusKeyIn(space), "items", id)
+}
+
+func TestCapturePatterns(t *testing.T) {
+	pattern := Path("spaces", Capture("spaceID"), "ext", "trackus", "items", AnyID)
+	if got := pattern.String(); got != "/spaces/{spaceID}/ext/trackus/items/*" {
+		t.Errorf("String() = %q", got)
+	}
+	if got := pattern.captures(); !reflect.DeepEqual(got, []string{"spaceID"}) {
+		t.Errorf("captures() = %v", got)
+	}
+	for name, parts := range map[string][]any{
+		"invalid name":   {"spaces", Capture("1x")},
+		"dotted name":    {"spaces", Capture("a.b")},
+		"duplicate name": {"spaces", Capture("id"), "ext", Capture("id")},
+	} {
+		if _, err := NewPath(parts...); err == nil {
+			t.Errorf("%s: expected an error", name)
+		}
+	}
+	// A record and a collection resource both bind the capture.
+	item := RecordResourceForKey(itemKeyIn("s1", "i1"))
+	if !patternsMatch(pattern, item) {
+		t.Fatalf("pattern must match %s", item)
+	}
+	if got := captureValues(pattern, item); !reflect.DeepEqual(got, map[string]any{"path.spaceID": "s1"}) {
+		t.Errorf("captureValues(record) = %v", got)
+	}
+	shorter := CollectionResourceFor(nil, "spaces")
+	if got := captureValues(pattern, shorter); got != nil {
+		t.Errorf("captureValues(too short) = %v, want nil", got)
+	}
+	if got := captureValues(Path("spaces", AnyID), item); got != nil {
+		t.Errorf("captureValues(no captures) = %v, want nil", got)
+	}
+}
+
+func TestCaptureDocuments(t *testing.T) {
+	policy := MustPolicy("spaces", Under(Path("spaces", Capture("spaceID"), "ext", "trackus"),
+		Allow(Read, "own-space").Where(spaceOfPath())))
+	encoded, err := MarshalAccessPolicyYAML(policy)
+	if err != nil || !strings.Contains(string(encoded), "path: /spaces/{spaceID}/ext/trackus") || !strings.Contains(string(encoded), "param: path.spaceID") {
+		t.Fatalf("encode: err=%v\n%s", err, encoded)
+	}
+	again, err := UnmarshalAccessPolicyYAML(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if again.compiled[0].pattern.String() != "/spaces/{spaceID}/ext/trackus" {
+		t.Errorf("decoded pattern = %q", again.compiled[0].pattern)
+	}
+	for name, path := range map[string]string{
+		"capture as collection": "/{spaces}/*",
+		"bad capture name":      "/spaces/{1x}",
+	} {
+		document := Document{APIVersion: DocumentAPIVersion, Kind: AccessPolicyKind, Metadata: DocumentMetadata{Name: "x"}, Default: "deny",
+			Scopes: []DocumentScope{{Path: path, Rules: []DocumentRule{{ID: "r", Effect: "allow", Operations: []string{"get"}}}}}}
+		if _, err := DecodeAccessPolicy(strings.NewReader(""), staticCodec{d: document}); err == nil {
+			t.Errorf("%s: expected an error", name)
+		}
+	}
+}
+
+func TestCaptureCompilation(t *testing.T) {
+	if _, err := NewPolicy("p", Scope("spaces", AnyID, Allow(Get, "no-capture").Where(spaceOfPath()))); err == nil || !strings.Contains(err.Error(), "captures no such segment") {
+		t.Errorf("unknown capture must fail compilation: %v", err)
+	}
+	if _, err := NewPolicy("p", Scope("spaces", Capture("spaceID"), Allow(Get, "ok").Where(spaceOfPath()))); err != nil {
+		t.Errorf("declared capture must compile: %v", err)
+	}
+	// A capture declared by a parent scope is visible to nested scopes.
+	if _, err := NewPolicy("p", Scope("spaces", Capture("spaceID"), Scope("ext", "trackus", Allow(Get, "nested").Where(spaceOfPath())))); err != nil {
+		t.Errorf("parent capture must be visible: %v", err)
+	}
+}
+
+func TestCaptureDecisions(t *testing.T) {
+	policy := MustPolicy("spaces", Under(Path("spaces", Capture("spaceID"), "ext", "trackus"),
+		Allow(Read|Write, "own-space").Where(spaceOfPath())))
+	ctx := context.Background()
+	item := RecordResourceForKey(itemKeyIn("s1", "i1"))
+	decision := policy.Decide(ctx, Request{Operation: Get, Resources: []Resource{item}})
+	mustDecideAllowed(t, decision)
+	if got := decision.Residuals[0].String(); got != "spaceID = 's1'" {
+		t.Errorf("residual = %q", got)
+	}
+	if decision.Condition != "spaceID = $path.spaceID" || strings.Contains(decision.Explanation, "s1") {
+		t.Errorf("decision leaks or mislabels: %+v", decision)
+	}
+	collection := CollectionResourceFor(trackusKeyIn("s2"), "items")
+	decision = policy.Decide(ctx, Request{Operation: Query, Resources: []Resource{collection}})
+	mustDecideAllowed(t, decision)
+	if got := decision.Residuals[0].String(); got != "spaceID = 's2'" {
+		t.Errorf("collection residual = %q", got)
+	}
+	if got := decision.Writes[0].Alternatives[0].Where.String(); got != "spaceID = 's2'" {
+		t.Errorf("write alternative = %q", got)
+	}
+	// A capture also feeds a terminal allow's check.
+	checked := MustPolicy("checked", Under(Path("spaces", Capture("spaceID")), Allow(Write, "stay-in-space").Check(spaceOfPath())))
+	decision = checked.Decide(ctx, Request{Operation: Set, Resources: []Resource{item}})
+	mustDecideAllowed(t, decision)
+	if got := decision.Writes[0].Terminal.Check.String(); got != "spaceID = 's1'" {
+		t.Errorf("terminal check = %q", got)
+	}
+	// A capture takes precedence over a same-named variable.
+	decision = policy.Decide(WithVariables(ctx, map[string]any{"path.spaceID": "other"}), Request{Operation: Get, Resources: []Resource{item}})
+	mustDecideAllowed(t, decision)
+	if got := decision.Residuals[0].String(); got != "spaceID = 's1'" {
+		t.Errorf("capture precedence: %q", got)
+	}
+}
+
+func TestCapturesOnMemoryDB(t *testing.T) {
+	ctx := context.Background()
+	raw := dalgo2memory.New(dalgo2memory.FirestoreProfile())
+	itemKey := itemKeyIn
+	type item struct {
+		SpaceID string `json:"spaceID"`
+		Title   string `json:"title"`
+	}
+	if err := raw.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		for _, seed := range []struct {
+			space, id string
+			data      item
+		}{
+			{"s1", "i1", item{SpaceID: "s1", Title: "own"}},
+			{"s1", "i2", item{SpaceID: "s2", Title: "misfiled"}},
+			{"s2", "i3", item{SpaceID: "s2", Title: "other"}},
+		} {
+			seed := seed
+			if err := tx.Set(ctx, record.NewRecordWithData(itemKey(seed.space, seed.id), &seed.data)); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	db := MustSecureDB(raw, WithDatabasePolicies(MustPolicy("spaces", Under(Path("spaces", Capture("spaceID"), "ext", "trackus"),
+		Allow(Read|Write, "own-space").Where(spaceOfPath())))))
+
+	own := &item{}
+	if err := db.Get(ctx, record.NewRecordWithData(itemKey("s1", "i1"), own)); err != nil || own.Title != "own" {
+		t.Errorf("own item: err=%v data=%+v", err, *own)
+	}
+	misfiled := &item{}
+	if err := db.Get(ctx, record.NewRecordWithData(itemKey("s1", "i2"), misfiled)); !errors.Is(err, ErrAccessDenied) || *misfiled != (item{}) {
+		t.Errorf("misfiled item must be denied: err=%v data=%+v", err, *misfiled)
+	}
+	// A query under space s1 returns only rows whose spaceID is s1.
+	query := dal.NewQueryBuilder(dal.From(dal.NewCollectionRef("items", "", trackusKeyIn("s1")))).
+		SelectIntoRecord(func() record.Record { return record.NewRecordWithData(itemKey("s1", ""), &item{}) })
+	records, err := dal.ExecuteQueryAndReadAllToRecords(ctx, query, db)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(records) != 1 || records[0].Data().(*item).Title != "own" {
+		t.Errorf("query rows = %d", len(records))
+	}
+	// Writes: an update that moves the row out of its space is refused.
+	if err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Update(ctx, itemKey("s1", "i1"), []update.Update{update.ByFieldName("spaceID", "s2")})
+	}); !errors.Is(err, ErrAccessDenied) {
+		t.Errorf("moving out of the space = %v", err)
+	}
+	if err := db.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		return tx.Update(ctx, itemKey("s1", "i1"), []update.Update{update.ByFieldName("title", "renamed")})
+	}); err != nil {
+		t.Errorf("edit within the space: %v", err)
+	}
+}

--- a/access/context.go
+++ b/access/context.go
@@ -59,6 +59,23 @@ func newVariableResolver(ctx context.Context) variableResolver {
 	return variableResolver{variables: variablesFromContext(ctx), now: time.Now().UTC()}
 }
 
+// withCaptures returns a resolver that also knows the values a matched path
+// pattern bound to its captures; captures take precedence over variables of
+// the same name.
+func (r variableResolver) withCaptures(captures map[string]any) variableResolver {
+	if len(captures) == 0 {
+		return r
+	}
+	merged := make(map[string]any, len(r.variables)+len(captures))
+	for name, value := range r.variables {
+		merged[name] = value
+	}
+	for name, value := range captures {
+		merged[name] = value
+	}
+	return variableResolver{variables: merged, now: r.now}
+}
+
 func (r variableResolver) resolve(name string) (any, bool) {
 	if value, ok := r.variables[name]; ok {
 		return value, true

--- a/access/document.go
+++ b/access/document.go
@@ -410,6 +410,13 @@ func parseDocumentPath(value string) (PathPattern, error) {
 			patternParts[i] = AnyID
 			continue
 		}
+		if strings.HasPrefix(decoded, "{") && strings.HasSuffix(decoded, "}") {
+			if i%2 == 0 {
+				return PathPattern{}, fmt.Errorf("path %q uses a capture where a collection name is required", value)
+			}
+			patternParts[i] = Capture(strings.TrimSuffix(strings.TrimPrefix(decoded, "{"), "}"))
+			continue
+		}
 		if decoded == "*" {
 			return PathPattern{}, fmt.Errorf("path %q uses * where a collection name is required", value)
 		}
@@ -509,6 +516,10 @@ func documentPath(pattern PathPattern) (string, error) {
 	}
 	parts := make([]string, len(pattern.segments))
 	for i, segment := range pattern.segments {
+		if segment.capture != "" {
+			parts[i] = "{" + segment.capture + "}"
+			continue
+		}
 		if segment.anyID {
 			parts[i] = "*"
 			continue

--- a/access/policy.go
+++ b/access/policy.go
@@ -229,14 +229,14 @@ func (p *AccessPolicy) decideResource(resolver variableResolver, operation Opera
 	// Resolve every alternative once; an unresolved parameter denies.
 	write := &WriteResidual{}
 	for _, rule := range conditional {
-		alternative, err := p.resolveAlternative(resolver, rule)
+		alternative, err := p.resolveAlternative(resolver.withCaptures(captureValues(rule.pattern, resource)), rule)
 		if err != nil {
 			return p.denyUnresolved(operation, resource, rule, err)
 		}
 		write.Alternatives = append(write.Alternatives, alternative)
 	}
 	if terminal != nil && terminal.effect == effectAllow {
-		alternative, err := p.resolveAlternative(resolver, *terminal)
+		alternative, err := p.resolveAlternative(resolver.withCaptures(captureValues(terminal.pattern, resource)), *terminal)
 		if err != nil {
 			return p.denyUnresolved(operation, resource, *terminal, err)
 		}

--- a/access/resource.go
+++ b/access/resource.go
@@ -3,6 +3,7 @@ package access
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -27,9 +28,10 @@ const (
 )
 
 type pathSegment struct {
-	kind  segmentKind
-	value any
-	anyID bool
+	kind    segmentKind
+	value   any
+	anyID   bool
+	capture string // name of a captured ID segment; empty when not captured
 }
 
 // Resource is a policy target. Construct resources through RecordResource,
@@ -57,6 +59,10 @@ func (r Resource) String() string {
 		}
 		parts := make([]string, len(r.path))
 		for i, segment := range r.path {
+			if segment.capture != "" {
+				parts[i] = "{" + segment.capture + "}"
+				continue
+			}
 			if segment.anyID {
 				parts[i] = "*"
 				continue
@@ -119,6 +125,16 @@ type anyIDValue struct{}
 // not assigned yet.
 var AnyID = anyIDValue{}
 
+type captureValue struct{ name string }
+
+// Capture matches any record ID like AnyID and binds the matched value to the
+// variable $path.<name> for the conditions of rules under this pattern, so a
+// rule on /spaces/{spaceID}/ext/trackus/** can say `spaceID == $path.spaceID`.
+// The name is a plain identifier; it must be unique within one pattern.
+func Capture(name string) any {
+	return captureValue{name: name}
+}
+
 // PathPattern is a structural path prefix. Arguments alternate between a
 // collection name and an ID matcher; a terminal collection name is valid.
 type PathPattern struct {
@@ -150,6 +166,18 @@ func NewPath(parts ...any) (PathPattern, error) {
 			segments[i] = pathSegment{kind: idSegment, anyID: true}
 			continue
 		}
+		if capture, ok := part.(captureValue); ok {
+			if !validCaptureName(capture.name) {
+				return PathPattern{}, fmt.Errorf("access: path part %d: invalid capture name %q", i, capture.name)
+			}
+			for _, previous := range segments[:i] {
+				if previous.capture == capture.name {
+					return PathPattern{}, fmt.Errorf("access: path part %d: duplicate capture name %q", i, capture.name)
+				}
+			}
+			segments[i] = pathSegment{kind: idSegment, anyID: true, capture: capture.name}
+			continue
+		}
 		if part == nil {
 			return PathPattern{}, fmt.Errorf("access: path ID part %d is nil; use AnyID for a wildcard", i)
 		}
@@ -168,6 +196,37 @@ func (p PathPattern) append(other PathPattern) PathPattern {
 	segments = append(segments, other.segments...)
 	return PathPattern{segments: segments}
 }
+
+// captures lists the capture names a pattern declares, in path order.
+func (p PathPattern) captures() []string {
+	var names []string
+	for _, segment := range p.segments {
+		if segment.capture != "" {
+			names = append(names, segment.capture)
+		}
+	}
+	return names
+}
+
+// captureValues returns the values a matched resource binds to the pattern's
+// captures, keyed "path.<name>". It assumes patternsMatch already held.
+func captureValues(pattern PathPattern, resource Resource) map[string]any {
+	var values map[string]any
+	for i, segment := range pattern.segments {
+		if segment.capture == "" || i >= len(resource.path) {
+			continue
+		}
+		if values == nil {
+			values = map[string]any{}
+		}
+		values["path."+segment.capture] = resource.path[i].value
+	}
+	return values
+}
+
+var reCaptureName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+func validCaptureName(name string) bool { return reCaptureName.MatchString(name) }
 
 func patternsMatch(pattern PathPattern, resource Resource) bool {
 	if resource.kind != PathResource || len(pattern.segments) > len(resource.path) {

--- a/access/rule.go
+++ b/access/rule.go
@@ -2,6 +2,7 @@ package access
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -224,6 +225,15 @@ func compileRule(
 				}
 			}
 			sort.Strings(params)
+			declared := prefix.captures()
+			for _, param := range params {
+				if !strings.HasPrefix(param, "path.") {
+					continue
+				}
+				if !slices.Contains(declared, strings.TrimPrefix(param, "path.")) {
+					return fmt.Errorf("access: rule %q references $%s but its path %s captures no such segment", rule.name, param, prefix)
+				}
+			}
 		}
 		name := rule.name
 		if name == "" {

--- a/spec/features/access-policies/row-level-conditions/README.md
+++ b/spec/features/access-policies/row-level-conditions/README.md
@@ -381,6 +381,12 @@ field value of the record.
 **When** a record under `/spaces/s1/ext/trackus/items/i1` whose `spaceID` is `s1` is read, and one whose `spaceID` is `s2`
 **Then** the first read is allowed and the second is denied.
 
+### AC: unknown-capture-rejected (verifies REQ:path-captures)
+
+**Given** a rule on `/spaces/*/ext/trackus/**` conditioned on `$path.spaceID`
+**When** the policy is constructed
+**Then** construction fails naming the missing capture.
+
 ### AC: get-other-users-record (verifies REQ:point-read-enforcement)
 
 **Given** an allow rule `Get where ownerID == $currentUser` and a record owned by someone else

--- a/spec/plans/row-level-conditions-mvp.md
+++ b/spec/plans/row-level-conditions-mvp.md
@@ -121,6 +121,8 @@ customers, get another user's record denied, exists upgraded; whole module at
   edit half needs the write side and is deferred with it.
 - access-policies/row-level-conditions#ac:capture-in-condition — path captures
   (`{name}` segments bound to `$path.<name>`) are the next plan.
+- access-policies/row-level-conditions#ac:unknown-capture-rejected — path captures,
+  verified by [`row-level-conditions-path-captures`](row-level-conditions-path-captures.md).
 - access-policies/row-level-conditions#ac:check-defaults-to-where — write side,
   verified by [`row-level-conditions-write-side`](row-level-conditions-write-side.md).
 - access-policies/row-level-conditions#ac:update-post-image — write side,

--- a/spec/plans/row-level-conditions-path-captures.md
+++ b/spec/plans/row-level-conditions-path-captures.md
@@ -1,0 +1,78 @@
+---
+format: https://specscore.md/plan-specification
+status: Implemented
+---
+# Plan: Row-level access conditions — path captures
+
+**Status:** Implemented
+**Source Feature:** access-policies/row-level-conditions
+**Date:** 2026-09-03
+**Owner:** alex
+**Supersedes:** —
+
+## Summary
+
+Third slice of `access-policies/row-level-conditions`: a path pattern may name a
+wildcard ID segment — `access.Capture("spaceID")` in Go, `{spaceID}` in a
+document path — and the matched value is bound to `$path.spaceID` for the
+conditions of rules under that pattern. This is the shape most Sneat extension
+policies need: `/spaces/{spaceID}/ext/trackus/**` with
+`spaceID == $path.spaceID`, so a record filed under one Space cannot claim
+another.
+
+## Approach
+
+Captures are ordinary wildcard segments with a name. A rule's conditions may
+reference `$path.<name>` only for captures its (joined) path declares; anything
+else fails compilation. When a rule matches a resource, the capture values are
+merged into the request's variable resolver for that rule (captures win over
+same-named variables), so substitution, query rewrite, point-read checks and
+write residuals need no new machinery.
+
+## Tasks
+
+### Task 1: Captures in path patterns
+
+**Id:** task-1
+**Verifies:** access-policies/row-level-conditions#ac:unknown-capture-rejected
+**Depends-On:** —
+**Status:** complete
+
+`Capture(name)` for `Path`/`Scope`/`Under`; validated, unique names; `{name}` in
+`String()` and in portable document paths, both directions; compile-time
+rejection of `$path.<name>` without a matching capture.
+
+### Task 2: Binding captures in decisions
+
+**Id:** task-2
+**Verifies:** access-policies/row-level-conditions#ac:capture-in-condition
+**Depends-On:** 1
+**Status:** complete
+
+Matched capture values feed the resolver for the matched rule's `where` and
+`check`, for record and collection resources, reads and writes; verified on
+`dalgo2memory` with a Space-scoped policy.
+
+## Deferred AC Coverage
+
+- access-policies/row-level-conditions#ac:comparison-and-groups — unchanged; verified by [`row-level-conditions-mvp`](row-level-conditions-mvp.md).
+- access-policies/row-level-conditions#ac:conditional-deny-rejected — unchanged; verified by [`row-level-conditions-mvp`](row-level-conditions-mvp.md).
+- access-policies/row-level-conditions#ac:write-group-excludes-truncate — unchanged; verified by [`row-level-conditions-mvp`](row-level-conditions-mvp.md).
+- access-policies/row-level-conditions#ac:missing-variable-denies — unchanged; verified by [`row-level-conditions-mvp`](row-level-conditions-mvp.md).
+- access-policies/row-level-conditions#ac:get-other-users-record — unchanged; verified by [`row-level-conditions-mvp`](row-level-conditions-mvp.md).
+- access-policies/row-level-conditions#ac:tenant-slice — unchanged; verified by [`row-level-conditions-mvp`](row-level-conditions-mvp.md).
+- access-policies/row-level-conditions#ac:unconditional-suite-unchanged — unchanged; verified by [`row-level-conditions-mvp`](row-level-conditions-mvp.md).
+- access-policies/row-level-conditions#ac:yaml-roundtrip — unchanged; verified by [`row-level-conditions-mvp`](row-level-conditions-mvp.md).
+- access-policies/row-level-conditions#ac:no-leak — unchanged; verified by [`row-level-conditions-mvp`](row-level-conditions-mvp.md).
+- access-policies/row-level-conditions#ac:check-defaults-to-where — unchanged; verified by [`row-level-conditions-write-side`](row-level-conditions-write-side.md).
+- access-policies/row-level-conditions#ac:cannot-take-ownership — unchanged; verified by [`row-level-conditions-write-side`](row-level-conditions-write-side.md).
+- access-policies/row-level-conditions#ac:update-post-image — unchanged; verified by [`row-level-conditions-write-side`](row-level-conditions-write-side.md).
+- access-policies/row-level-conditions#ac:batch-all-or-nothing — unchanged; verified by [`row-level-conditions-write-side`](row-level-conditions-write-side.md).
+- access-policies/row-level-conditions#ac:read-all-edit-assigned — unchanged; verified by [`row-level-conditions-write-side`](row-level-conditions-write-side.md).
+
+## Open Questions
+
+None at this time.
+
+---
+*This document follows the https://specscore.md/plan-specification*

--- a/spec/plans/row-level-conditions-write-side.md
+++ b/spec/plans/row-level-conditions-write-side.md
@@ -98,6 +98,8 @@ sub-tests for adapters; 100% statement coverage.
 
 - access-policies/row-level-conditions#ac:capture-in-condition — path captures
   are the next plan.
+- access-policies/row-level-conditions#ac:unknown-capture-rejected — path captures,
+  verified by [`row-level-conditions-path-captures`](row-level-conditions-path-captures.md).
 - access-policies/row-level-conditions#ac:comparison-and-groups — read-side criterion
   already verified by [`row-level-conditions-mvp`](row-level-conditions-mvp.md);
   behaviour unchanged here, suites re-run green.


### PR DESCRIPTION
Third slice of `access-policies/row-level-conditions` (tracks #133; plan `spec/plans/row-level-conditions-path-captures.md`).

- `access.Capture("spaceID")` in Go patterns and `{spaceID}` in document paths mark a named wildcard ID segment (validated, unique per pattern).
- A rule's conditions may reference `$path.<name>` only for captures its path declares; otherwise compilation fails naming the missing capture.
- When a rule matches, the captured values feed its `where`/`check` — record and collection resources, reads and writes — so `/spaces/{spaceID}/ext/trackus/**` with `spaceID == $path.spaceID` keeps a record filed under one Space from claiming another. Captures take precedence over same-named variables.

Verified on `dalgo2memory` (own item readable, misfiled item denied, query narrowed by the space in its path, moving a row out of its space refused). 100% coverage in `access`; `go test ./...` green; golangci 0; spec lint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEVhqasFJJ3iAcARe7Wts6