### PR TITLE
feat(access): principal bindings — rule sets bound to roles, groups, users and everyone

### DIFF
--- a/access/context.go
+++ b/access/context.go
@@ -45,6 +45,17 @@ func variablesFromContext(ctx context.Context) map[string]any {
 	for name, value := range variables {
 		combined[name] = value
 	}
+	if principal, ok := PrincipalFrom(ctx); ok {
+		if _, set := combined["currentUser"]; !set && principal.ID != nil {
+			combined["currentUser"] = principal.ID
+		}
+		if _, set := combined["principal.roles"]; !set {
+			combined["principal.roles"] = append([]string{}, principal.Roles...)
+		}
+		if _, set := combined["principal.groups"]; !set {
+			combined["principal.groups"] = append([]string{}, principal.Groups...)
+		}
+	}
 	return combined
 }
 

--- a/access/document.go
+++ b/access/document.go
@@ -26,7 +26,21 @@ type Document struct {
 	Kind       string           `json:"kind" yaml:"kind"`
 	Metadata   DocumentMetadata `json:"metadata" yaml:"metadata"`
 	Default    string           `json:"default" yaml:"default"`
-	Scopes     []DocumentScope  `json:"scopes" yaml:"scopes"`
+	Scopes     []DocumentScope  `json:"scopes,omitempty" yaml:"scopes,omitempty"`
+	// RuleSets and Bindings describe a principal policy set: named rule sets
+	// (each a scope tree like Scopes) and the roles, groups, users and
+	// everyone they are bound to. A document has either Scopes or both
+	// RuleSets and Bindings.
+	RuleSets map[string][]DocumentScope `json:"ruleSets,omitempty" yaml:"ruleSets,omitempty"`
+	Bindings *DocumentBindings          `json:"bindings,omitempty" yaml:"bindings,omitempty"`
+}
+
+// DocumentBindings maps principals to rule-set names.
+type DocumentBindings struct {
+	Roles    map[string][]string `json:"roles,omitempty" yaml:"roles,omitempty"`
+	Groups   map[string][]string `json:"groups,omitempty" yaml:"groups,omitempty"`
+	Users    map[string][]string `json:"users,omitempty" yaml:"users,omitempty"`
+	Everyone []string            `json:"everyone,omitempty" yaml:"everyone,omitempty"`
 }
 
 type DocumentMetadata struct {
@@ -133,11 +147,18 @@ func DecodeAccessPolicy(reader io.Reader, codec Codec, options ...DecodeOption) 
 	if err != nil {
 		return nil, err
 	}
+	return accessPolicyFromDocument(document, settings)
+}
+
+func accessPolicyFromDocument(document Document, settings decodeOptions) (*AccessPolicy, error) {
 	if document.Kind != AccessPolicyKind {
 		return nil, fmt.Errorf("access: expected kind %s, got %q", AccessPolicyKind, document.Kind)
 	}
 	if document.Default != effectDeny.String() {
 		return nil, fmt.Errorf("access: AccessPolicy default must be %q", effectDeny)
+	}
+	if document.Bindings != nil || len(document.RuleSets) > 0 {
+		return nil, fmt.Errorf("access: the document declares rule sets and bindings; decode it as a principal policy set")
 	}
 	rules, err := rulesFromDocument(document, map[effect]bool{effectAllow: true, effectDeny: true})
 	if err != nil {
@@ -149,6 +170,125 @@ func DecodeAccessPolicy(reader io.Reader, codec Codec, options ...DecodeOption) 
 	}
 	policy.source = settings.source
 	return policy, nil
+}
+
+// DecodePrincipalPolicySet decodes and validates one AccessPolicy document
+// that binds named rule sets to roles, groups, users and everyone.
+func DecodePrincipalPolicySet(reader io.Reader, codec Codec, options ...DecodeOption) (*PrincipalPolicySet, error) {
+	document, settings, err := decodeDocument(reader, codec, options)
+	if err != nil {
+		return nil, err
+	}
+	return principalPolicySetFromDocument(document, settings)
+}
+
+func principalPolicySetFromDocument(document Document, settings decodeOptions) (*PrincipalPolicySet, error) {
+	if document.Kind != AccessPolicyKind {
+		return nil, fmt.Errorf("access: expected kind %s, got %q", AccessPolicyKind, document.Kind)
+	}
+	if document.Default != effectDeny.String() {
+		return nil, fmt.Errorf("access: AccessPolicy default must be %q", effectDeny)
+	}
+	if document.Bindings == nil || len(document.RuleSets) == 0 {
+		return nil, fmt.Errorf("access: a principal policy set requires ruleSets and bindings")
+	}
+	if len(document.Scopes) > 0 {
+		return nil, fmt.Errorf("access: a principal policy set must not declare top-level scopes; put them in a rule set")
+	}
+	allowed := map[effect]bool{effectAllow: true, effectDeny: true}
+	ruleSets := make(map[string][]Rule, len(document.RuleSets))
+	for setName, scopes := range document.RuleSets {
+		rules := make([]Rule, 0, len(scopes))
+		for i, scope := range scopes {
+			rule, err := ruleFromDocumentScope(scope, allowed)
+			if err != nil {
+				return nil, fmt.Errorf("access: ruleSets[%s][%d]: %w", setName, i, err)
+			}
+			rules = append(rules, rule)
+		}
+		ruleSets[setName] = rules
+	}
+	set, err := NewPrincipalPolicySet(document.Metadata.Name, ruleSets, Bindings{
+		Roles:    document.Bindings.Roles,
+		Groups:   document.Bindings.Groups,
+		Users:    document.Bindings.Users,
+		Everyone: document.Bindings.Everyone,
+	})
+	if err != nil {
+		return nil, err
+	}
+	set.source = settings.source
+	return set, nil
+}
+
+// DecodePolicy decodes one AccessPolicy document as either an AccessPolicy
+// or, when it declares rule sets and bindings, a PrincipalPolicySet.
+func DecodePolicy(reader io.Reader, codec Codec, options ...DecodeOption) (Policy, error) {
+	document, settings, err := decodeDocument(reader, codec, options)
+	if err != nil {
+		return nil, err
+	}
+	if document.Bindings != nil || len(document.RuleSets) > 0 {
+		return principalPolicySetFromDocument(document, settings)
+	}
+	return accessPolicyFromDocument(document, settings)
+}
+
+// EncodePrincipalPolicySet validates and writes one principal policy set
+// through codec.
+func EncodePrincipalPolicySet(writer io.Writer, codec Codec, set *PrincipalPolicySet) error {
+	if set == nil {
+		return fmt.Errorf("access: principal policy set is required")
+	}
+	document := Document{
+		APIVersion: DocumentAPIVersion,
+		Kind:       AccessPolicyKind,
+		Metadata:   DocumentMetadata{Name: set.name},
+		Default:    effectDeny.String(),
+		RuleSets:   make(map[string][]DocumentScope, len(set.ruleSets)),
+		Bindings: &DocumentBindings{
+			Roles:    set.bindings.Roles,
+			Groups:   set.bindings.Groups,
+			Users:    set.bindings.Users,
+			Everyone: set.bindings.Everyone,
+		},
+	}
+	for setName, rules := range set.ruleSets {
+		scopes := make([]DocumentScope, 0, len(rules))
+		for _, rule := range rules {
+			scope, err := documentScopeFromRule(rule)
+			if err != nil {
+				return fmt.Errorf("rule set %q: %w", setName, err)
+			}
+			scopes = append(scopes, scope)
+		}
+		document.RuleSets[setName] = scopes
+	}
+	return encodeDocument(writer, codec, document)
+}
+
+func MarshalPrincipalPolicySetYAML(set *PrincipalPolicySet) ([]byte, error) {
+	var data bytes.Buffer
+	if err := EncodePrincipalPolicySet(&data, YAMLCodec{}, set); err != nil {
+		return nil, err
+	}
+	return data.Bytes(), nil
+}
+
+func MarshalPrincipalPolicySetJSON(set *PrincipalPolicySet) ([]byte, error) {
+	var data bytes.Buffer
+	if err := EncodePrincipalPolicySet(&data, JSONCodec{}, set); err != nil {
+		return nil, err
+	}
+	return data.Bytes(), nil
+}
+
+func UnmarshalPrincipalPolicySetYAML(data []byte, options ...DecodeOption) (*PrincipalPolicySet, error) {
+	return DecodePrincipalPolicySet(bytes.NewReader(data), YAMLCodec{}, options...)
+}
+
+func UnmarshalPrincipalPolicySetJSON(data []byte, options ...DecodeOption) (*PrincipalPolicySet, error) {
+	return DecodePrincipalPolicySet(bytes.NewReader(data), JSONCodec{}, options...)
 }
 
 // DecodeAuditPolicy decodes and validates one AuditPolicy from any reader.
@@ -195,8 +335,8 @@ func decodeDocument(reader io.Reader, codec Codec, options []DecodeOption) (Docu
 	if strings.TrimSpace(document.Metadata.Name) == "" {
 		return Document{}, settings, fmt.Errorf("access: metadata.name is required")
 	}
-	if len(document.Scopes) == 0 {
-		return Document{}, settings, fmt.Errorf("access: at least one scope is required")
+	if len(document.Scopes) == 0 && len(document.RuleSets) == 0 && document.Bindings == nil {
+		return Document{}, settings, fmt.Errorf("access: at least one scope, or rule sets with bindings, is required")
 	}
 	return document, settings, nil
 }

--- a/access/principal.go
+++ b/access/principal.go
@@ -1,0 +1,251 @@
+package access
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// Principal identifies the caller for principal bindings and for the
+// $currentUser, $principal.roles and $principal.groups variables. Roles and
+// groups are opaque strings the host assigns; DALgo never looks them up.
+type Principal struct {
+	ID     any
+	Roles  []string
+	Groups []string
+}
+
+type contextPrincipalKey struct{}
+
+// WithPrincipal returns a child context carrying the caller's principal. It
+// replaces any principal inherited from the parent context.
+func WithPrincipal(ctx context.Context, principal Principal) context.Context {
+	if ctx == nil {
+		panic("access: nil context")
+	}
+	return context.WithValue(ctx, contextPrincipalKey{}, principal)
+}
+
+// PrincipalFrom returns the principal carried by ctx, if any.
+func PrincipalFrom(ctx context.Context) (Principal, bool) {
+	if ctx == nil {
+		return Principal{}, false
+	}
+	principal, ok := ctx.Value(contextPrincipalKey{}).(Principal)
+	return principal, ok
+}
+
+// Bindings map principals to named rule sets. A binding value is a list of
+// rule-set names; Everyone applies to every principal, including an absent one.
+type Bindings struct {
+	Roles    map[string][]string
+	Groups   map[string][]string
+	Users    map[string][]string
+	Everyone []string
+}
+
+// PrincipalPolicySet is a Policy that derives the caller's authority from
+// who they are: the rule sets bound to the principal's ID, roles and groups
+// (plus Everyone) are unioned and compiled as one AccessPolicy, so the parent
+// feature's precedence resolves overlaps between bindings; that single policy
+// then takes part in the ordinary intersection with database and context
+// policies, so a binding can never widen what another policy denies.
+type PrincipalPolicySet struct {
+	name     string
+	source   string
+	ruleSets map[string][]Rule
+	bindings Bindings
+
+	mu    sync.Mutex
+	cache map[string]*AccessPolicy
+}
+
+// NewPrincipalPolicySet validates that every binding names an existing rule
+// set and that every rule set compiles on its own.
+func NewPrincipalPolicySet(name string, ruleSets map[string][]Rule, bindings Bindings) (*PrincipalPolicySet, error) {
+	if strings.TrimSpace(name) == "" {
+		return nil, fmt.Errorf("access: principal policy set name is required")
+	}
+	if len(ruleSets) == 0 {
+		return nil, fmt.Errorf("access: principal policy set %q has no rule sets", name)
+	}
+	for setName, rules := range ruleSets {
+		if strings.TrimSpace(setName) == "" || strings.Contains(setName, "/") {
+			return nil, fmt.Errorf("access: principal policy set %q: invalid rule set name %q", name, setName)
+		}
+		if _, err := NewPolicy(name+"/"+setName, prefixRuleNames(setName, rules)...); err != nil {
+			return nil, fmt.Errorf("access: rule set %q: %w", setName, err)
+		}
+	}
+	check := func(kind string, references map[string][]string) error {
+		for subject, sets := range references {
+			for _, setName := range sets {
+				if _, ok := ruleSets[setName]; !ok {
+					return fmt.Errorf("access: principal policy set %q: %s %q references unknown rule set %q", name, kind, subject, setName)
+				}
+			}
+		}
+		return nil
+	}
+	if err := check("role", bindings.Roles); err != nil {
+		return nil, err
+	}
+	if err := check("group", bindings.Groups); err != nil {
+		return nil, err
+	}
+	if err := check("user", bindings.Users); err != nil {
+		return nil, err
+	}
+	if err := check("everyone", map[string][]string{"everyone": bindings.Everyone}); err != nil {
+		return nil, err
+	}
+	return &PrincipalPolicySet{name: name, ruleSets: ruleSets, bindings: bindings, cache: map[string]*AccessPolicy{}}, nil
+}
+
+// MustPrincipalPolicySet constructs a set and panics when it is invalid.
+func MustPrincipalPolicySet(name string, ruleSets map[string][]Rule, bindings Bindings) *PrincipalPolicySet {
+	set, err := NewPrincipalPolicySet(name, ruleSets, bindings)
+	if err != nil {
+		panic(err)
+	}
+	return set
+}
+
+func (p *PrincipalPolicySet) Name() string { return p.name }
+
+// Source returns the storage-neutral reference supplied while loading the
+// document, if any.
+func (p *PrincipalPolicySet) Source() string { return p.source }
+
+// Decide unions the rule sets bound to the principal on ctx and evaluates the
+// request against them as one policy. Without any applicable binding the
+// request is denied.
+func (p *PrincipalPolicySet) Decide(ctx context.Context, request Request) Decision {
+	principal, present := PrincipalFrom(ctx)
+	sets, attribution := p.boundSets(principal, present)
+	if len(sets) == 0 {
+		return Decision{
+			Operation:    request.Operation,
+			Policy:       p.name,
+			PolicySource: p.source,
+			Effect:       effectDeny.String(),
+			Explanation:  fmt.Sprintf("no binding applies to principal %v", principalLabel(principal, present)),
+		}
+	}
+	decision := p.effective(sets).Decide(ctx, request)
+	decision.Policy = p.name
+	decision.PolicySource = p.source
+	if decision.Rule != "" {
+		labels := map[string]struct{}{}
+		for _, rule := range strings.Split(decision.Rule, ", ") {
+			setName, _, _ := strings.Cut(rule, "/")
+			for _, label := range attribution[setName] {
+				labels[label] = struct{}{}
+			}
+		}
+		decision.Explanation += " via " + strings.Join(sortedKeys(labels), ", ")
+	}
+	return decision
+}
+
+func (p *PrincipalPolicySet) Authorize(ctx context.Context, request Request) error {
+	decision := p.Decide(ctx, request)
+	if decision.Allowed {
+		return nil
+	}
+	return &DeniedError{Decision: decision}
+}
+
+// boundSets returns the sorted, de-duplicated rule-set names bound to the
+// principal and, per set, the binding labels that pulled it in.
+func (p *PrincipalPolicySet) boundSets(principal Principal, present bool) ([]string, map[string][]string) {
+	attribution := map[string][]string{}
+	add := func(label string, sets []string) {
+		for _, setName := range sets {
+			attribution[setName] = append(attribution[setName], label)
+		}
+	}
+	add("everyone", p.bindings.Everyone)
+	if present {
+		if principal.ID != nil {
+			add("user:"+fmt.Sprint(principal.ID), p.bindings.Users[fmt.Sprint(principal.ID)])
+		}
+		for _, role := range principal.Roles {
+			add("role:"+role, p.bindings.Roles[role])
+		}
+		for _, group := range principal.Groups {
+			add("group:"+group, p.bindings.Groups[group])
+		}
+	}
+	for setName := range attribution {
+		sort.Strings(attribution[setName])
+	}
+	return sortedKeys(attribution), attribution
+}
+
+// effective returns the compiled union of the given rule sets, cached by the
+// set combination so repeated requests by the same kind of principal reuse it.
+func (p *PrincipalPolicySet) effective(sets []string) *AccessPolicy {
+	key := strings.Join(sets, "\x00")
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if policy, ok := p.cache[key]; ok {
+		return policy
+	}
+	var rules []Rule
+	for _, setName := range sets {
+		rules = append(rules, prefixRuleNames(setName, p.ruleSets[setName])...)
+	}
+	// Every rule set compiled alone at construction and names are prefixed
+	// per set, so the union compiles.
+	policy := MustPolicy(p.name, rules...)
+	p.cache[key] = policy
+	return policy
+}
+
+// prefixRuleNames returns a copy of rules whose directive names are prefixed
+// with the rule-set name ("content-write/read"), giving every rule a unique,
+// attributable identity across the union. Unnamed directives are numbered.
+func prefixRuleNames(setName string, rules []Rule) []Rule {
+	counter := 0
+	var walk func(rules []Rule) []Rule
+	walk = func(rules []Rule) []Rule {
+		out := make([]Rule, len(rules))
+		for i, rule := range rules {
+			out[i] = rule
+			switch rule.kind {
+			case directiveRule:
+				name := rule.name
+				if name == "" {
+					counter++
+					name = fmt.Sprintf("rule-%d", counter)
+				}
+				out[i].name = setName + "/" + name
+			default:
+				out[i].children = walk(rule.children)
+			}
+		}
+		return out
+	}
+	return walk(rules)
+}
+
+func principalLabel(principal Principal, present bool) string {
+	if !present {
+		return "<none>"
+	}
+	return fmt.Sprintf("%q", fmt.Sprint(principal.ID))
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+var _ Policy = (*PrincipalPolicySet)(nil)

--- a/access/principal_test.go
+++ b/access/principal_test.go
@@ -1,0 +1,319 @@
+package access
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/record"
+)
+
+func docsRuleSets() map[string][]Rule {
+	return map[string][]Rule{
+		"read-docs":     {Scope("docs", AnyID, Allow(Read, "read"))},
+		"write-docs":    {Scope("docs", AnyID, Allow(Insert|Set|Update, "write"))},
+		"content-write": {Scope("docs", AnyID, Allow(Write, "publish"))},
+		"suspend":       {Scope("docs", AnyID, Deny(Write, "no-writes"))},
+		"own-docs":      {Scope("docs", AnyID, Allow(Update, "own").Where(dal.WhereField("ownerID", dal.Equal, dal.NewParam("currentUser"))))},
+		"by-role":       {Scope("docs", AnyID, Allow(Get).Where(dal.WhereField("audience", dal.In, dal.NewParam("principal.roles"))))},
+		"public":        {Scope("public", AnyID, Allow(Read, "anyone"))},
+	}
+}
+
+func docsBindings() Bindings {
+	return Bindings{
+		Roles:    map[string][]string{"reader": {"read-docs"}, "writer": {"write-docs"}, "editor": {"content-write"}, "admin": {"content-write", "read-docs"}, "member": {"own-docs", "by-role"}},
+		Groups:   map[string][]string{"suspended": {"suspend"}},
+		Users:    map[string][]string{"u9": {"write-docs"}},
+		Everyone: []string{"public"},
+	}
+}
+
+func TestPrincipalContext(t *testing.T) {
+	if _, ok := PrincipalFrom(context.Background()); ok {
+		t.Error("no principal expected")
+	}
+	var nilContext context.Context
+	if _, ok := PrincipalFrom(nilContext); ok {
+		t.Error("nil context has no principal")
+	}
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Error("WithPrincipal(nil) must panic")
+			}
+		}()
+		WithPrincipal(nilContext, Principal{})
+	}()
+	ctx := WithPrincipal(context.Background(), Principal{ID: "u1", Roles: []string{"member"}, Groups: []string{"staff"}})
+	variables := variablesFromContext(ctx)
+	if variables["currentUser"] != "u1" || len(variables["principal.roles"].([]string)) != 1 || len(variables["principal.groups"].([]string)) != 1 {
+		t.Errorf("principal-derived variables = %v", variables)
+	}
+	// Explicit variables take precedence over the principal.
+	variables = variablesFromContext(WithVariables(ctx, map[string]any{"currentUser": "impersonated", "principal.roles": []string{"x"}, "principal.groups": []string{}}))
+	if variables["currentUser"] != "impersonated" || variables["principal.roles"].([]string)[0] != "x" {
+		t.Errorf("explicit variables must win: %v", variables)
+	}
+}
+
+func TestPrincipalPolicySetConstruction(t *testing.T) {
+	for name, tc := range map[string]struct {
+		name     string
+		sets     map[string][]Rule
+		bindings Bindings
+	}{
+		"empty name":       {"", docsRuleSets(), docsBindings()},
+		"no rule sets":     {"p", nil, docsBindings()},
+		"bad set name":     {"p", map[string][]Rule{"a/b": {Root(Allow(Get))}}, Bindings{}},
+		"set fails":        {"p", map[string][]Rule{"bad": {Root(Deny(Get, "d").Where(dal.WhereField("a", dal.Equal, dal.Constant{Value: 1})))}}, Bindings{}},
+		"unknown role set": {"p", docsRuleSets(), Bindings{Roles: map[string][]string{"x": {"nope"}}}},
+		"unknown group":    {"p", docsRuleSets(), Bindings{Groups: map[string][]string{"x": {"nope"}}}},
+		"unknown user":     {"p", docsRuleSets(), Bindings{Users: map[string][]string{"x": {"nope"}}}},
+		"unknown everyone": {"p", docsRuleSets(), Bindings{Everyone: []string{"nope"}}},
+	} {
+		if _, err := NewPrincipalPolicySet(tc.name, tc.sets, tc.bindings); err == nil {
+			t.Errorf("%s: expected an error", name)
+		}
+	}
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Error("MustPrincipalPolicySet must panic on an invalid set")
+			}
+		}()
+		MustPrincipalPolicySet("", nil, Bindings{})
+	}()
+	set := MustPrincipalPolicySet("docs", docsRuleSets(), docsBindings())
+	if set.Name() != "docs" || set.Source() != "" {
+		t.Errorf("name/source = %q/%q", set.Name(), set.Source())
+	}
+}
+
+func TestPrincipalPolicySetDecisions(t *testing.T) {
+	set := MustPrincipalPolicySet("docs", docsRuleSets(), docsBindings())
+	doc := RecordResourceForKey(record.NewKeyWithID("docs", "d1"))
+	get := Request{Operation: Get, Resources: []Resource{doc}}
+	insert := Request{Operation: Insert, Resources: []Resource{doc}}
+	as := func(id string, roles ...string) context.Context {
+		return WithPrincipal(context.Background(), Principal{ID: id, Roles: roles})
+	}
+	// roles-union: reader + writer together read and insert.
+	both := as("u1", "reader", "writer")
+	mustDecideAllowed(t, set.Decide(both, get))
+	mustDecideAllowed(t, set.Decide(both, insert))
+	if decision := set.Decide(as("u1", "reader"), insert); decision.Allowed {
+		t.Errorf("reader alone must not insert: %+v", decision)
+	}
+	// shared-rule-set: editor and admin share content-write, same rule id.
+	editor, admin := set.Decide(as("u2", "editor"), insert), set.Decide(as("u3", "admin"), insert)
+	mustDecideAllowed(t, editor)
+	mustDecideAllowed(t, admin)
+	if editor.Rule != "content-write/publish" || admin.Rule != editor.Rule {
+		t.Errorf("shared rule ids = %q / %q", editor.Rule, admin.Rule)
+	}
+	if !strings.Contains(editor.Explanation, "via role:editor") || !strings.Contains(admin.Explanation, "via role:admin") {
+		t.Errorf("explanations must name the binding: %q / %q", editor.Explanation, admin.Explanation)
+	}
+	// specific-deny-across-bindings: a suspended writer cannot write.
+	suspended := WithPrincipal(context.Background(), Principal{ID: "u4", Roles: []string{"writer"}, Groups: []string{"suspended"}})
+	if decision := set.Decide(suspended, insert); decision.Allowed || !strings.Contains(decision.Explanation, "group:suspended") {
+		t.Errorf("suspended writer = %+v", decision)
+	}
+	// users binding and everyone.
+	mustDecideAllowed(t, set.Decide(as("u9"), insert))
+	public := Request{Operation: Get, Resources: []Resource{RecordResourceForKey(record.NewKeyWithID("public", "p1"))}}
+	anonymous := set.Decide(context.Background(), public)
+	mustDecideAllowed(t, anonymous)
+	if !strings.Contains(anonymous.Explanation, "via everyone") {
+		t.Errorf("everyone attribution: %q", anonymous.Explanation)
+	}
+	// unbound-principal-denied.
+	// everyone applies (public set), so a docs read by an unknown role is denied by "no matching allow rule".
+	if decision := set.Decide(as("nobody", "unknown-role"), get); decision.Allowed || !strings.Contains(decision.Explanation, "no matching allow rule") {
+		t.Errorf("unknown role must not read docs: %+v", decision)
+	}
+	none := MustPrincipalPolicySet("strict", map[string][]Rule{"r": {Root(Allow(Get, "g"))}}, Bindings{Roles: map[string][]string{"reader": {"r"}}})
+	if decision := none.Decide(as("nobody"), get); decision.Allowed || !strings.Contains(decision.Explanation, `no binding applies to principal "nobody"`) {
+		t.Errorf("no binding = %+v", decision)
+	}
+	if decision := none.Decide(context.Background(), get); decision.Allowed || !strings.Contains(decision.Explanation, "<none>") {
+		t.Errorf("absent principal = %+v", decision)
+	}
+	if err := none.Authorize(as("nobody"), get); !errors.Is(err, ErrAccessDenied) {
+		t.Errorf("Authorize = %v", err)
+	}
+	if err := none.Authorize(as("x", "reader"), get); err != nil {
+		t.Errorf("Authorize allowed = %v", err)
+	}
+	// Row conditions resolve $currentUser and $principal.roles from the principal.
+	member := WithPrincipal(context.Background(), Principal{ID: "u5", Roles: []string{"member", "vip"}})
+	decision := set.Decide(member, Request{Operation: Update, Resources: []Resource{doc}})
+	mustDecideAllowed(t, decision)
+	if decision.Residuals[0].String() != "ownerID = 'u5'" {
+		t.Errorf("principal-resolved residual = %q", decision.Residuals[0])
+	}
+	decision = set.Decide(member, get)
+	mustDecideAllowed(t, decision)
+	if got := decision.Residuals[0].String(); got != "audience In ('member','vip')" {
+		t.Errorf("roles residual = %q", got)
+	}
+	// The compiled union is cached per binding combination.
+	first := set.effective([]string{"read-docs", "write-docs"})
+	if second := set.effective([]string{"read-docs", "write-docs"}); second != first {
+		t.Error("same combination must reuse the compiled policy")
+	}
+	if other := set.effective([]string{"read-docs"}); other == first {
+		t.Error("different combination must compile separately")
+	}
+}
+
+func TestPrincipalPolicySetIntersection(t *testing.T) {
+	set := MustPrincipalPolicySet("docs", map[string][]Rule{"admin": {Root(Allow(ReadWrite, "all"))}}, Bindings{Roles: map[string][]string{"admin": {"admin"}}})
+	database := MustPolicy("db", Root(Allow(ReadWrite, "all"), Scope("audit", AnyID, Deny(Delete, "keep-audit"))))
+	session := SecureReadwriteSession(&stubReadwriteSession{rows: map[string]map[string]any{}}, database, set)
+	admin := WithPrincipal(context.Background(), Principal{ID: "root", Roles: []string{"admin"}})
+	if err := session.Delete(admin, record.NewKeyWithID("audit", "a1")); !errors.Is(err, ErrAccessDenied) {
+		t.Errorf("binding must not widen a database denial: %v", err)
+	}
+	if err := session.Delete(admin, record.NewKeyWithID("docs", "d1")); err != nil {
+		t.Errorf("admin delete = %v", err)
+	}
+	if err := session.Delete(context.Background(), record.NewKeyWithID("docs", "d1")); !errors.Is(err, ErrAccessDenied) {
+		t.Errorf("unbound principal must be denied: %v", err)
+	}
+}
+
+const principalPolicyYAML = `apiVersion: dalgo.io/access/v1
+kind: AccessPolicy
+metadata:
+  name: docs
+default: deny
+ruleSets:
+  read-docs:
+    - path: /docs/*
+      rules:
+        - id: read
+          effect: allow
+          operations: [read]
+  own-docs:
+    - path: /docs/*
+      rules:
+        - id: own
+          effect: allow
+          operations: [update]
+          where:
+            op: "=="
+            left: { field: ownerID }
+            right: { param: currentUser }
+bindings:
+  roles:
+    reader: [read-docs]
+    member: [own-docs, read-docs]
+  groups:
+    staff: [read-docs]
+  users:
+    u1: [own-docs]
+  everyone: [read-docs]
+`
+
+func TestPrincipalPolicySetDocuments(t *testing.T) {
+	set, err := UnmarshalPrincipalPolicySetYAML([]byte(principalPolicyYAML), WithSource("policies/docs.yaml"))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if set.Source() != "policies/docs.yaml" {
+		t.Errorf("source = %q", set.Source())
+	}
+	doc := RecordResourceForKey(record.NewKeyWithID("docs", "d1"))
+	member := WithPrincipal(context.Background(), Principal{ID: "u7", Roles: []string{"member"}})
+	decision := set.Decide(member, Request{Operation: Update, Resources: []Resource{doc}})
+	mustDecideAllowed(t, decision)
+	if decision.Residuals[0].String() != "ownerID = 'u7'" || decision.PolicySource != "policies/docs.yaml" {
+		t.Errorf("decoded decision = %+v", decision)
+	}
+	for name, marshal := range map[string]func(*PrincipalPolicySet) ([]byte, error){"yaml": MarshalPrincipalPolicySetYAML, "json": MarshalPrincipalPolicySetJSON} {
+		encoded, err := marshal(set)
+		if err != nil || !strings.Contains(string(encoded), "bindings") || !strings.Contains(string(encoded), "own-docs") {
+			t.Fatalf("%s encode: err=%v\n%s", name, err, encoded)
+		}
+		var again *PrincipalPolicySet
+		if name == "yaml" {
+			again, err = UnmarshalPrincipalPolicySetYAML(encoded)
+		} else {
+			again, err = UnmarshalPrincipalPolicySetJSON(encoded)
+		}
+		if err != nil {
+			t.Fatalf("%s decode again: %v", name, err)
+		}
+		second := again.Decide(member, Request{Operation: Update, Resources: []Resource{doc}})
+		if second.Allowed != decision.Allowed || second.Rule != decision.Rule || second.Condition != decision.Condition {
+			t.Errorf("%s round trip differs: %+v vs %+v", name, decision, second)
+		}
+	}
+	// DecodePolicy routes by shape.
+	if policy, err := DecodePolicy(strings.NewReader(principalPolicyYAML), YAMLCodec{}); err != nil {
+		t.Errorf("DecodePolicy(bindings) = %v", err)
+	} else if _, ok := policy.(*PrincipalPolicySet); !ok {
+		t.Errorf("DecodePolicy(bindings) = %T", policy)
+	}
+	if policy, err := DecodePolicy(strings.NewReader(conditionalPolicyYAML), YAMLCodec{}); err != nil {
+		t.Errorf("DecodePolicy(scopes) = %v", err)
+	} else if _, ok := policy.(*AccessPolicy); !ok {
+		t.Errorf("DecodePolicy(scopes) = %T", policy)
+	}
+	if _, err := DecodePolicy(strings.NewReader("x"), failingCodec{decode: errors.New("decode")}); err == nil {
+		t.Error("DecodePolicy must propagate decode errors")
+	}
+	// Error paths.
+	if _, err := UnmarshalAccessPolicyYAML([]byte(principalPolicyYAML)); err == nil || !strings.Contains(err.Error(), "principal policy set") {
+		t.Errorf("AccessPolicy decode of a bindings document = %v", err)
+	}
+	if _, err := DecodePrincipalPolicySet(strings.NewReader("x"), failingCodec{decode: errors.New("decode")}); err == nil {
+		t.Error("DecodePrincipalPolicySet must propagate decode errors")
+	}
+	base := func() Document {
+		return Document{APIVersion: DocumentAPIVersion, Kind: AccessPolicyKind, Metadata: DocumentMetadata{Name: "x"}, Default: "deny",
+			RuleSets: map[string][]DocumentScope{"r": {{Path: "/x/*", Rules: []DocumentRule{{ID: "g", Effect: "allow", Operations: []string{"get"}}}}}},
+			Bindings: &DocumentBindings{Everyone: []string{"r"}}}
+	}
+	for name, mutate := range map[string]func(*Document){
+		"wrong kind":    func(d *Document) { d.Kind = AuditPolicyKind },
+		"wrong default": func(d *Document) { d.Default = "allow" },
+		"no bindings":   func(d *Document) { d.Bindings = nil },
+		"top-level scopes": func(d *Document) {
+			d.Scopes = []DocumentScope{{Path: "/y/*", Rules: []DocumentRule{{ID: "y", Effect: "allow", Operations: []string{"get"}}}}}
+		},
+		"bad rule in set":        func(d *Document) { d.RuleSets["r"][0].Rules[0].Operations = []string{"bogus"} },
+		"unknown set referenced": func(d *Document) { d.Bindings.Everyone = []string{"nope"} },
+	} {
+		document := base()
+		mutate(&document)
+		if _, err := DecodePrincipalPolicySet(strings.NewReader(""), staticCodec{d: document}); err == nil {
+			t.Errorf("%s: expected an error", name)
+		}
+	}
+	empty := Document{APIVersion: DocumentAPIVersion, Kind: AccessPolicyKind, Metadata: DocumentMetadata{Name: "x"}, Default: "deny"}
+	if _, err := DecodePrincipalPolicySet(strings.NewReader(""), staticCodec{d: empty}); err == nil {
+		t.Error("a document with neither scopes nor bindings must fail")
+	}
+	// Encoding requires named rules and a non-nil set.
+	if err := EncodePrincipalPolicySet(nil, YAMLCodec{}, nil); err == nil {
+		t.Error("nil set must fail")
+	}
+	unnamed := MustPrincipalPolicySet("u", map[string][]Rule{"r": {Root(Allow(Get))}}, Bindings{Everyone: []string{"r"}})
+	if _, err := MarshalPrincipalPolicySetYAML(unnamed); !errors.Is(err, ErrNotSerializable) {
+		t.Errorf("unnamed rule encode = %v", err)
+	}
+	if _, err := MarshalPrincipalPolicySetJSON(unnamed); !errors.Is(err, ErrNotSerializable) {
+		t.Errorf("unnamed rule JSON encode = %v", err)
+	}
+	// Unnamed rules still get unique attributable ids inside the union.
+	decision = unnamed.Decide(context.Background(), Request{Operation: Get, Resources: []Resource{doc}})
+	mustDecideAllowed(t, decision)
+	if decision.Rule != "r/rule-1" {
+		t.Errorf("generated rule id = %q", decision.Rule)
+	}
+}

--- a/spec/features/access-policies/principal-bindings/README.md
+++ b/spec/features/access-policies/principal-bindings/README.md
@@ -1,12 +1,12 @@
 ---
 format: https://specscore.md/feature-specification
-status: Draft
+status: Implementing
 ---
 
 # Feature: Principal bindings — policies per user, group and role
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/principal-bindings?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/principal-bindings?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/principal-bindings?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/principal-bindings?op=request-change) |
-**Status:** Draft
+**Status:** Implementing
 **Date:** 2026-09-02
 **Owner:** alex
 **Source Ideas:** row-level-access-conditions

--- a/spec/plans/principal-bindings.md
+++ b/spec/plans/principal-bindings.md
@@ -1,0 +1,81 @@
+---
+format: https://specscore.md/plan-specification
+status: Implemented
+---
+# Plan: Implement principal bindings
+
+**Status:** Implemented
+**Source Feature:** access-policies/principal-bindings
+**Date:** 2026-09-03
+**Owner:** alex
+**Supersedes:** —
+
+## Summary
+
+Implement `access-policies/principal-bindings`: a principal on the context, a
+`PrincipalPolicySet` that unions the rule sets bound to the principal's ID,
+roles and groups (plus `everyone`) into one compiled policy, layer intersection
+through the existing guard, binding attribution in explanations, and portable
+documents with `ruleSets` and `bindings`.
+
+## Approach
+
+Bindings are a `Policy` implementation, not a change to the evaluator: the
+union of a principal's rule sets is compiled as an ordinary `AccessPolicy`
+(rule names prefixed per set so they stay unique and attributable), cached per
+binding combination, and evaluated by the existing precedence walk. The
+secured wrapper sees one more policy in its intersection, so no widening is
+possible. `$currentUser`, `$principal.roles` and `$principal.groups` default
+from the principal unless explicit variables override them.
+
+## Tasks
+
+### Task 1: Principal on the context and principal-derived variables
+
+**Id:** task-1
+**Verifies:** access-policies/principal-bindings#ac:principal-drives-current-user
+**Depends-On:** —
+**Status:** complete
+
+`Principal{ID, Roles, Groups}`, `WithPrincipal`, `PrincipalFrom`; the variable
+resolver defaults `$currentUser`, `$principal.roles` and `$principal.groups`
+from the principal, explicit variables winning.
+
+### Task 2: Rule sets, bindings and the effective policy
+
+**Id:** task-2
+**Verifies:** access-policies/principal-bindings#ac:shared-rule-set, access-policies/principal-bindings#ac:roles-union, access-policies/principal-bindings#ac:binding-in-explanation
+**Depends-On:** 1
+**Status:** complete
+
+`NewPrincipalPolicySet` validates names and references; `Decide` unions bound
+rule sets (sorted, de-duplicated), compiles and caches the union, delegates,
+and appends `via role:…, group:…, user:…, everyone` to explanations.
+
+### Task 3: Layer intersection and denials
+
+**Id:** task-3
+**Verifies:** access-policies/principal-bindings#ac:binding-cannot-widen
+**Depends-On:** 2
+**Status:** complete
+
+The set is one more `Policy` in the guard's intersection; an unbound principal
+(or an absent one with no `everyone`) is denied with an explanation naming it.
+
+### Task 4: Portable documents
+
+**Id:** task-4
+**Verifies:** access-policies/principal-bindings#ac:shared-rule-set
+**Depends-On:** 2
+**Status:** complete
+
+`ruleSets` and `bindings` on the document; `DecodePrincipalPolicySet`,
+`EncodePrincipalPolicySet`, YAML/JSON helpers, and `DecodePolicy` routing by
+shape; an `AccessPolicy` decode of a bindings document is refused.
+
+## Open Questions
+
+None at this time.
+
+---
+*This document follows the https://specscore.md/plan-specification*


### PR DESCRIPTION
Implements `access-policies/principal-bindings` (tracks #133; plan `spec/plans/principal-bindings.md`).

- `Principal{ID, Roles, Groups}` on the context; `$currentUser`, `$principal.roles`, `$principal.groups` default from it.
- `PrincipalPolicySet` unions the rule sets bound to the principal's ID, roles and groups (plus `everyone`), compiles the union as one `AccessPolicy` — rule names prefixed per set (`content-write/publish`), cached per binding combination — so the parent feature's precedence (most specific wins, deny on tie) resolves overlaps between bindings. Explanations end with `via role:admin, group:staff`. An unbound principal is denied naming it.
- The set is one more policy in the guard's intersection: a binding can never widen a database-level denial.
- Documents gain `ruleSets` and `bindings`; `DecodePrincipalPolicySet`, `EncodePrincipalPolicySet`, YAML/JSON helpers, and `DecodePolicy` routing by shape.

100% coverage in `access`; `go test ./...` green; golangci 0; spec lint 0. Feature moved Approved → Implementing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEVhqasFJJ3iAcARe7Wts6