### PR TITLE
feat(access): field patterns — fields allow-lists with projection, redaction and write checks

### DIFF
--- a/access/condition.go
+++ b/access/condition.go
@@ -51,14 +51,93 @@ func matchResiduals(operation Operations, data map[string]any, residuals []resid
 	return nil
 }
 
-// checkRecord enforces the residuals of a point read on a record the adapter
-// has just loaded. A record that does not exist needs no check. On denial the
-// record's data is cleared and its error set, so the caller receives nothing
-// but the denial.
-func checkRecord(operation Operations, rec record.Record, residuals []residual) error {
-	if len(residuals) == 0 || !rec.Exists() {
+// enforceRead applies row conditions and field redaction to a record the
+// adapter has just loaded: the residuals must hold, and the deciding
+// alternative's fields (per policy) bound what the caller receives.
+func enforceRead(operation Operations, rec record.Record, residuals []residual, writes []writeResidual) error {
+	if !rec.Exists() {
 		return nil
 	}
+	data, err := condeval.ToMap(rec.Data())
+	if err != nil {
+		if len(residuals) > 0 {
+			denied := residuals[0].deny(operation, fmt.Sprintf("row condition could not be evaluated: %v", err))
+			clearRecord(rec, denied)
+			return denied
+		}
+		if len(writes) > 0 {
+			denied := writes[0].deny(operation, "", "", fmt.Sprintf("record fields could not be evaluated: %v", err))
+			clearRecord(rec, denied)
+			return denied
+		}
+		return nil
+	}
+	if err := matchResiduals(operation, data, residuals); err != nil {
+		clearRecord(rec, err)
+		return err
+	}
+	sets, err := decidingFields(operation, data, writes)
+	if err != nil {
+		clearRecord(rec, err)
+		return err
+	}
+	if err := sets.redactRecord(rec); err != nil {
+		denied := writes[0].deny(operation, "", "", fmt.Sprintf("record could not be redacted: %v", err))
+		clearRecord(rec, denied)
+		return denied
+	}
+	return nil
+}
+
+// decidingFields returns, per policy, the allow-list of the alternative that
+// decides the loaded record: the first whose Where holds, else the terminal.
+func decidingFields(operation Operations, data map[string]any, writes []writeResidual) (fieldSets, error) {
+	var sets fieldSets
+	for _, w := range writes {
+		var deciding *WriteAlternative
+		for i := range w.residual.Alternatives {
+			alternative := &w.residual.Alternatives[i]
+			ok, err := condeval.Match(data, alternative.Where)
+			if err != nil {
+				return nil, w.deny(operation, alternative.Rule, alternative.WhereText, fmt.Sprintf("row condition could not be evaluated for rule %q: %v", alternative.Rule, err))
+			}
+			if ok {
+				deciding = alternative
+				break
+			}
+		}
+		if deciding == nil {
+			deciding = w.residual.Terminal
+		}
+		if deciding != nil && deciding.fields != nil {
+			sets = append(sets, deciding.fields)
+		}
+	}
+	return sets, nil
+}
+
+// queryFields collects every allow-list that could bound a row of a query:
+// all alternatives and the terminal of every policy. A row may come through
+// any of them, so the intersection is what is safe to return.
+func queryFields(writes []writeResidual) fieldSets {
+	var sets fieldSets
+	for _, w := range writes {
+		for i := range w.residual.Alternatives {
+			if fields := w.residual.Alternatives[i].fields; fields != nil {
+				sets = append(sets, fields)
+			}
+		}
+		if terminal := w.residual.Terminal; terminal != nil && terminal.fields != nil {
+			sets = append(sets, terminal.fields)
+		}
+	}
+	return sets
+}
+
+// checkRecord enforces the residuals of an existence check on the shadow
+// record just loaded for it. On denial the record's data is cleared and its
+// error set, so the caller receives nothing but the denial.
+func checkRecord(operation Operations, rec record.Record, residuals []residual) error {
 	data, err := condeval.ToMap(rec.Data())
 	if err != nil {
 		denied := residuals[0].deny(operation, fmt.Sprintf("row condition could not be evaluated: %v", err))
@@ -145,21 +224,4 @@ func existsThroughRead(ctx context.Context, session dal.ReadSession, key *record
 		return false, err
 	}
 	return true, nil
-}
-
-// checkRecords enforces residuals on a multi-record read. Any denial clears
-// every record, so a batch never returns a partial result.
-func checkRecords(operation Operations, records []record.Record, residuals [][]residual) error {
-	if len(residuals) == 0 {
-		return nil
-	}
-	for i, rec := range records {
-		if err := checkRecord(operation, rec, residuals[i]); err != nil {
-			for _, other := range records {
-				clearRecord(other, err)
-			}
-			return err
-		}
-	}
-	return nil
 }

--- a/access/conditions_test.go
+++ b/access/conditions_test.go
@@ -484,9 +484,6 @@ func TestCheckRecordEdges(t *testing.T) {
 	nilData := record.NewRecordWithData(key, (*customer)(nil))
 	nilData.SetError(nil)
 	clearRecord(nilData, errors.New("x"))
-	if err := checkRecords(Get, nil, nil); err != nil {
-		t.Errorf("no residuals = %v", err)
-	}
 }
 
 type fakeCond struct{}

--- a/access/document.go
+++ b/access/document.go
@@ -67,6 +67,8 @@ type DocumentRule struct {
 	// Check is an optional post-image condition on an allow rule: what a row
 	// written under the rule must satisfy afterwards. Defaults to Where.
 	Check *DocumentCondition `json:"check,omitempty" yaml:"check,omitempty"`
+	// Fields is an optional allow-list of field patterns on an allow rule.
+	Fields []string `json:"fields,omitempty" yaml:"fields,omitempty"`
 }
 
 // Codec decouples policy loading from both its syntax and its storage. A
@@ -509,6 +511,9 @@ func ruleFromDocumentRule(documentRule DocumentRule, allowedEffects map[effect]b
 		}
 		rule = rule.Check(condition)
 	}
+	if documentRule.Fields != nil {
+		rule = rule.Fields(documentRule.Fields...)
+	}
 	return rule, nil
 }
 
@@ -646,6 +651,9 @@ func documentRuleFromRule(rule Rule) (DocumentRule, error) {
 			return DocumentRule{}, fmt.Errorf("%w: rule %q: %v", ErrNotSerializable, rule.name, err)
 		}
 		documentRule.Check = check
+	}
+	if rule.fields != nil {
+		documentRule.Fields = append([]string(nil), rule.fields...)
 	}
 	return documentRule, nil
 }

--- a/access/fields.go
+++ b/access/fields.go
@@ -1,0 +1,331 @@
+package access
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/dal-go/dalgo/condeval"
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/record"
+	"github.com/dal-go/record/update"
+)
+
+// fieldPattern is one parsed entry of a rule's fields allow-list: dotted
+// segments, each a literal, a lone "*" (any one segment) or a glob with one
+// "*" at the start or end ("public_*", "*_id"); a trailing ".*" matches the
+// whole subtree below the preceding path.
+type fieldPattern struct {
+	source   string
+	segments []string
+	subtree  bool
+}
+
+// fieldSet is a rule's allow-list. A nil *fieldSet means every field.
+type fieldSet struct {
+	patterns []fieldPattern
+	sources  []string
+}
+
+func parseFieldPatterns(sources []string) (*fieldSet, error) {
+	if len(sources) == 0 {
+		return nil, fmt.Errorf("access: a fields list must name at least one pattern")
+	}
+	set := &fieldSet{}
+	for _, source := range sources {
+		text := strings.TrimSpace(source)
+		if text == "" {
+			return nil, fmt.Errorf("access: fields contains an empty pattern")
+		}
+		pattern := fieldPattern{source: text}
+		if strings.HasSuffix(text, ".*") {
+			pattern.subtree = true
+			text = strings.TrimSuffix(text, ".*")
+		}
+		for _, segment := range strings.Split(text, ".") {
+			if segment == "" {
+				return nil, fmt.Errorf("access: fields pattern %q has an empty segment", source)
+			}
+			if stars := strings.Count(segment, "*"); stars > 1 || (stars == 1 && segment != "*" && !strings.HasPrefix(segment, "*") && !strings.HasSuffix(segment, "*")) {
+				return nil, fmt.Errorf("access: fields pattern %q: a segment may be *, a prefix* or a *suffix", source)
+			}
+			pattern.segments = append(pattern.segments, segment)
+		}
+		set.patterns = append(set.patterns, pattern)
+		set.sources = append(set.sources, pattern.source)
+	}
+	return set, nil
+}
+
+func segmentMatches(pattern, segment string) bool {
+	switch {
+	case pattern == "*":
+		return true
+	case strings.HasPrefix(pattern, "*"):
+		return strings.HasSuffix(segment, pattern[1:])
+	case strings.HasSuffix(pattern, "*"):
+		return strings.HasPrefix(segment, pattern[:len(pattern)-1])
+	default:
+		return pattern == segment
+	}
+}
+
+// allows reports whether a dotted field path is readable or writable under
+// the set: a pattern matches the path exactly, matches a prefix of it (an
+// allowed parent covers its children), or is a subtree pattern over a prefix.
+func (s *fieldSet) allows(path string) bool {
+	if s == nil {
+		return true
+	}
+	segments := strings.Split(path, ".")
+	for _, pattern := range s.patterns {
+		if len(pattern.segments) > len(segments) {
+			continue
+		}
+		matched := true
+		for i, want := range pattern.segments {
+			if !segmentMatches(want, segments[i]) {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
+}
+
+// enumerable reports the top-level field names the set can be projected to
+// when no pattern uses a wildcard in its first segment; otherwise ok is false
+// and callers must fall back to redaction.
+func (s *fieldSet) enumerable() (names []string, ok bool) {
+	if s == nil {
+		return nil, false
+	}
+	seen := map[string]struct{}{}
+	for _, pattern := range s.patterns {
+		first := pattern.segments[0]
+		if strings.Contains(first, "*") {
+			return nil, false
+		}
+		seen[first] = struct{}{}
+	}
+	names = make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, true
+}
+
+// fieldSets is the intersection of the allow-lists every applicable policy
+// imposes on one resource; a field is allowed only when every set allows it.
+type fieldSets []*fieldSet
+
+func (sets fieldSets) allows(path string) bool {
+	for _, set := range sets {
+		if !set.allows(path) {
+			return false
+		}
+	}
+	return true
+}
+
+func (sets fieldSets) restrictive() bool {
+	for _, set := range sets {
+		if set != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (sets fieldSets) sources() string {
+	var all []string
+	for _, set := range sets {
+		if set != nil {
+			all = append(all, "["+strings.Join(set.sources, ", ")+"]")
+		}
+	}
+	return strings.Join(all, " ∩ ")
+}
+
+// enumerable intersects the projectable top-level names of every set; ok is
+// false when any restrictive set cannot be enumerated.
+func (sets fieldSets) enumerable() ([]string, bool) {
+	var names []string
+	first := true
+	for _, set := range sets {
+		if set == nil {
+			continue
+		}
+		own, ok := set.enumerable()
+		if !ok {
+			return nil, false
+		}
+		if first {
+			names, first = own, false
+			continue
+		}
+		keep := names[:0]
+		for _, name := range names {
+			for _, candidate := range own {
+				if name == candidate {
+					keep = append(keep, name)
+					break
+				}
+			}
+		}
+		names = keep
+	}
+	return names, !first
+}
+
+// disallowedPaths lists the leaf paths of JSON-shaped data the sets refuse.
+func (sets fieldSets) disallowedPaths(data map[string]any) []string {
+	var refused []string
+	var walk func(prefix string, value any)
+	walk = func(prefix string, value any) {
+		if nested, ok := value.(map[string]any); ok && len(nested) > 0 {
+			for key, child := range nested {
+				path := key
+				if prefix != "" {
+					path = prefix + "." + key
+				}
+				walk(path, child)
+			}
+			return
+		}
+		if !sets.allows(prefix) {
+			refused = append(refused, prefix)
+		}
+	}
+	for key, value := range data {
+		walk(key, value)
+	}
+	sort.Strings(refused)
+	return refused
+}
+
+// disallowedUpdates lists the update paths the sets refuse.
+func (sets fieldSets) disallowedUpdates(updates []update.Update) []string {
+	var refused []string
+	for _, item := range updates {
+		path := item.FieldName()
+		if fieldPath := item.FieldPath(); len(fieldPath) > 0 {
+			path = strings.Join(fieldPath, ".")
+		}
+		if !sets.allows(path) {
+			refused = append(refused, path)
+		}
+	}
+	sort.Strings(refused)
+	return refused
+}
+
+// redactMap removes every leaf the sets refuse, in place.
+func (sets fieldSets) redactMap(prefix string, data map[string]any) {
+	for key, value := range data {
+		path := key
+		if prefix != "" {
+			path = prefix + "." + key
+		}
+		if nested, ok := value.(map[string]any); ok && len(nested) > 0 {
+			sets.redactMap(path, nested)
+			if len(nested) == 0 {
+				delete(data, key)
+			}
+			continue
+		}
+		if !sets.allows(path) {
+			delete(data, key)
+		}
+	}
+}
+
+// redactRecord removes the refused fields from a loaded record: map data is
+// pruned in place; pointer data is round-tripped through JSON so nested
+// refusals apply, then written back into the zeroed target.
+func (sets fieldSets) redactRecord(rec record.Record) error {
+	if !sets.restrictive() || !rec.Exists() {
+		return nil
+	}
+	value := reflect.ValueOf(rec.Data())
+	switch {
+	case value.Kind() == reflect.Map:
+		if data, ok := rec.Data().(map[string]any); ok {
+			sets.redactMap("", data)
+			return nil
+		}
+		return fmt.Errorf("access: cannot redact map data of type %T", rec.Data())
+	case value.Kind() == reflect.Pointer && !value.IsNil():
+		if data, ok := rec.Data().(*map[string]any); ok {
+			sets.redactMap("", *data)
+			return nil
+		}
+		data, err := condeval.ToMap(rec.Data())
+		if err != nil {
+			return err
+		}
+		sets.redactMap("", data)
+		encoded, _ := json.Marshal(data) // JSON-shaped data always marshals
+		value.Elem().Set(reflect.Zero(value.Elem().Type()))
+		return json.Unmarshal(encoded, rec.Data())
+	default:
+		return nil
+	}
+}
+
+// redactingReader applies field redaction to every record a query returns.
+type redactingReader struct {
+	dal.RecordsReader
+	sets fieldSets
+}
+
+func (r redactingReader) Next() (record.Record, error) {
+	rec, err := r.RecordsReader.Next()
+	if err != nil || rec == nil {
+		return rec, err
+	}
+	if err := r.sets.redactRecord(rec); err != nil {
+		return nil, err
+	}
+	return rec, nil
+}
+
+// projectQuery narrows a structured query's columns to the enumerable
+// intersection of the allowed fields, keeping any columns the caller already
+// selected that are allowed. It returns ok=false when the sets are
+// restrictive but cannot be enumerated, so the caller must redact instead.
+func projectQuery(query dal.StructuredQuery, sets fieldSets) (dal.StructuredQuery, bool) {
+	if !sets.restrictive() {
+		return query, true
+	}
+	allowed, ok := sets.enumerable()
+	if !ok {
+		return query, false
+	}
+	var columns []dal.Column
+	if selected := query.Columns(); len(selected) > 0 {
+		for _, column := range selected {
+			field, isField := column.Expression.(dal.FieldRef)
+			if !isField {
+				return query, false
+			}
+			if sets.allows(field.Name()) {
+				columns = append(columns, column)
+			}
+		}
+	} else {
+		for _, name := range allowed {
+			columns = append(columns, dal.Column{Expression: dal.Field(name)})
+		}
+	}
+	return dal.WithColumns(query, columns), true
+}
+
+var _ = context.Background

--- a/access/fields_test.go
+++ b/access/fields_test.go
@@ -1,0 +1,446 @@
+package access
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/dal-go/dalgo/adapters/dalgo2memory"
+	"github.com/dal-go/dalgo/dal"
+	"github.com/dal-go/record"
+	"github.com/dal-go/record/update"
+)
+
+func TestFieldPatternMatching(t *testing.T) {
+	set, err := parseFieldPatterns([]string{"name", "address.*", "public_*", "*_id", "meta.*.value", "tags"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for path, want := range map[string]bool{
+		"name": true, "address": true, "address.city": true, "address.geo.lat": true,
+		"public_bio": true, "public_": true, "user_id": true, "meta.a.value": true, "meta.a.other": false,
+		"tags": true, "tags.0": true, "email": false, "nam": false, "namex": false, "passwordHash": false,
+	} {
+		if got := set.allows(path); got != want {
+			t.Errorf("allows(%q) = %v, want %v", path, got, want)
+		}
+	}
+	if names, ok := set.enumerable(); ok {
+		t.Errorf("wildcard first segments must not be enumerable: %v", names)
+	}
+	literal, _ := parseFieldPatterns([]string{"id", "name", "address.*", "id"})
+	if names, ok := literal.enumerable(); !ok || !reflect.DeepEqual(names, []string{"address", "id", "name"}) {
+		t.Errorf("enumerable = %v, %v", names, ok)
+	}
+	for name, patterns := range map[string][]string{
+		"empty list":    {},
+		"empty pattern": {" "},
+		"empty segment": {"a..b"},
+		"middle star":   {"a*b"},
+		"two stars":     {"*a*"},
+	} {
+		if _, err := parseFieldPatterns(patterns); err == nil {
+			t.Errorf("%s: expected an error", name)
+		}
+	}
+	var none *fieldSet
+	if !none.allows("anything") || (fieldSets{none}).restrictive() {
+		t.Error("a nil set allows everything and is not restrictive")
+	}
+	if _, ok := none.enumerable(); ok {
+		t.Error("a nil set is not enumerable")
+	}
+	// Intersection across sets.
+	a, _ := parseFieldPatterns([]string{"id", "name", "email"})
+	b, _ := parseFieldPatterns([]string{"name", "phone"})
+	sets := fieldSets{a, nil, b}
+	if !sets.allows("name") || sets.allows("email") || sets.allows("phone") {
+		t.Error("intersection must allow only name")
+	}
+	if names, ok := sets.enumerable(); !ok || !reflect.DeepEqual(names, []string{"name"}) {
+		t.Errorf("intersection enumerable = %v, %v", names, ok)
+	}
+	if !strings.Contains(sets.sources(), "[id, name, email]") || !strings.Contains(sets.sources(), " ∩ ") {
+		t.Errorf("sources = %q", sets.sources())
+	}
+	wild, _ := parseFieldPatterns([]string{"*_id"})
+	if _, ok := (fieldSets{a, wild}).enumerable(); ok {
+		t.Error("a wildcard set in the intersection is not enumerable")
+	}
+	if _, ok := (fieldSets{nil}).enumerable(); ok {
+		t.Error("no restrictive set means nothing to enumerate")
+	}
+}
+
+func TestFieldRedaction(t *testing.T) {
+	set, _ := parseFieldPatterns([]string{"name", "address.city"})
+	sets := fieldSets{set}
+	data := map[string]any{"name": "Ann", "email": "a@x", "address": map[string]any{"city": "Cork", "zip": "T12"}, "meta": map[string]any{"secret": 1}}
+	sets.redactMap("", data)
+	if !reflect.DeepEqual(data, map[string]any{"name": "Ann", "address": map[string]any{"city": "Cork"}}) {
+		t.Errorf("redacted map = %v", data)
+	}
+	if refused := sets.disallowedPaths(map[string]any{"name": "x", "email": "y", "address": map[string]any{"zip": "z"}, "empty": map[string]any{}}); !reflect.DeepEqual(refused, []string{"address.zip", "email", "empty"}) {
+		t.Errorf("disallowedPaths = %v", refused)
+	}
+	if refused := sets.disallowedUpdates([]update.Update{update.ByFieldName("name", "x"), update.ByFieldPath(update.FieldPath{"address", "zip"}, "z"), update.DeleteByFieldName("email")}); !reflect.DeepEqual(refused, []string{"address.zip", "email"}) {
+		t.Errorf("disallowedUpdates = %v", refused)
+	}
+	type user struct {
+		Name         string `json:"name"`
+		Email        string `json:"email"`
+		PasswordHash string `json:"passwordHash"`
+	}
+	rec := record.NewRecordWithData(record.NewKeyWithID("users", "u1"), &user{Name: "Ann", Email: "a@x", PasswordHash: "h"})
+	rec.SetError(nil)
+	if err := sets.redactRecord(rec); err != nil || *rec.Data().(*user) != (user{Name: "Ann"}) {
+		t.Errorf("struct redaction: err=%v data=%+v", err, rec.Data())
+	}
+	m := map[string]any{"name": "Ann", "email": "a@x"}
+	mapRec := record.NewRecordWithData(record.NewKeyWithID("users", "u2"), m)
+	mapRec.SetError(nil)
+	if err := sets.redactRecord(mapRec); err != nil || len(m) != 1 {
+		t.Errorf("map redaction: err=%v data=%v", err, m)
+	}
+	pm := map[string]any{"name": "Ann", "email": "a@x"}
+	pointerRec := record.NewRecordWithData(record.NewKeyWithID("users", "u3"), &pm)
+	pointerRec.SetError(nil)
+	if err := sets.redactRecord(pointerRec); err != nil || len(pm) != 1 {
+		t.Errorf("*map redaction: err=%v data=%v", err, pm)
+	}
+	missing := record.NewRecordWithData(record.NewKeyWithID("users", "u4"), &user{})
+	missing.SetError(record.ErrRecordNotFound)
+	if err := sets.redactRecord(missing); err != nil {
+		t.Errorf("missing record: %v", err)
+	}
+	if err := (fieldSets{nil}).redactRecord(rec); err != nil {
+		t.Errorf("non-restrictive: %v", err)
+	}
+	other := record.NewRecordWithData(record.NewKeyWithID("users", "u5"), map[int]any{1: "x"})
+	other.SetError(nil)
+	if err := sets.redactRecord(other); err == nil {
+		t.Error("a non-string-keyed map cannot be redacted")
+	}
+	chanRec := record.NewRecordWithData(record.NewKeyWithID("users", "u6"), &struct{ C chan int }{C: make(chan int)})
+	chanRec.SetError(nil)
+	if err := sets.redactRecord(chanRec); err == nil {
+		t.Error("unserialisable data must fail redaction")
+	}
+	scalar := record.NewRecordWithData(record.NewKeyWithID("users", "u7"), 42)
+	scalar.SetError(nil)
+	if err := sets.redactRecord(scalar); err != nil {
+		t.Errorf("scalar data is left alone: %v", err)
+	}
+}
+
+func TestFieldRuleCompilation(t *testing.T) {
+	for name, rules := range map[string][]Rule{
+		"fields on deny":   {Root(Deny(Get, "d").Fields("name"))},
+		"fields on scope":  {Under(Path("x"), Allow(Get)).Fields("name")},
+		"fields on opaque": {OpaqueQueryScope(Allow(Query, "q").Fields("name"))},
+		"bad pattern":      {Root(Allow(Get, "g").Fields("a..b"))},
+	} {
+		if _, err := NewPolicy("p", rules...); err == nil {
+			t.Errorf("%s: expected a compile error", name)
+		}
+	}
+	policy := MustPolicy("p", Scope("users", AnyID, Allow(Read).Fields("id", "name")))
+	decision := policy.Decide(context.Background(), Request{Operation: Get, Resources: []Resource{RecordResourceForKey(record.NewKeyWithID("users", "u1"))}})
+	mustDecideAllowed(t, decision)
+	if !strings.Contains(decision.Rule, "fields [id, name]") || decision.Residuals != nil || decision.Writes == nil || decision.Writes[0].Terminal == nil || !reflect.DeepEqual(decision.Writes[0].Terminal.Fields, []string{"id", "name"}) {
+		t.Errorf("fields-only decision = %+v", decision)
+	}
+}
+
+func TestFieldsThroughStub(t *testing.T) {
+	ctx := WithCurrentUser(context.Background(), "u1")
+	stub := &stubReadwriteSession{rows: map[string]map[string]any{
+		"u1": {"id": "u1", "name": "Ann", "email": "a@x", "passwordHash": "h1", "ownerID": "u1"},
+		"u2": {"id": "u2", "name": "Bob", "email": "b@x", "passwordHash": "h2", "ownerID": "u2"},
+	}}
+	stub.load = nil
+	// List users without passwordHash; see own row fully.
+	policy := MustPolicy("users", Scope("users", AnyID,
+		Allow(Get, "own-full").Where(dal.WhereField("ownerID", dal.Equal, dal.NewParam("currentUser"))),
+		Allow(Read, "public").Fields("id", "name"),
+	), Collection("users", Allow(Query, "list").Fields("id", "name")))
+	session := SecureReadwriteSession(stub, policy)
+	key := func(id string) *record.Key { return record.NewKeyWithID("users", id) }
+	own := map[string]any{}
+	if err := session.Get(ctx, record.NewRecordWithData(key("u1"), &own)); err != nil || own["passwordHash"] != "h1" {
+		t.Errorf("own row must be complete: err=%v data=%v", err, own)
+	}
+	other := map[string]any{}
+	if err := session.Get(ctx, record.NewRecordWithData(key("u2"), &other)); err != nil || !reflect.DeepEqual(other, map[string]any{"id": "u2", "name": "Bob"}) {
+		t.Errorf("other row must be redacted: err=%v data=%v", err, other)
+	}
+	batch := []record.Record{record.NewRecordWithData(key("u1"), &map[string]any{}), record.NewRecordWithData(key("u2"), &map[string]any{})}
+	if err := session.GetMulti(ctx, batch); err != nil {
+		t.Fatalf("GetMulti: %v", err)
+	}
+	if second := *batch[1].Data().(*map[string]any); second["passwordHash"] != nil || second["name"] != "Bob" {
+		t.Errorf("batch redaction: %v", second)
+	}
+	// Queries are projected and their records redacted.
+	stub.queries = nil
+	query := dal.NewQueryBuilder(dal.From(dal.NewRootCollectionRef("users", ""))).SelectIntoRecord(func() record.Record {
+		return record.NewRecordWithData(record.NewKeyWithID("users", ""), &map[string]any{})
+	})
+	if _, err := session.ExecuteQueryToRecordsReader(ctx, query); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	columns := stub.queries[0].(dal.StructuredQuery).Columns()
+	if len(columns) != 2 || columns[0].Expression.(dal.FieldRef).Name() != "id" || columns[1].Expression.(dal.FieldRef).Name() != "name" {
+		t.Errorf("projected columns = %v", columns)
+	}
+	// Caller columns are intersected with the allow-list.
+	stub.queries = nil
+	selected := dal.NewQueryBuilder(dal.From(dal.NewRootCollectionRef("users", ""))).SelectColumns(dal.Column{Expression: dal.Field("name")}, dal.Column{Expression: dal.Field("passwordHash")})
+	if _, err := session.ExecuteQueryToRecordsetReader(ctx, selected); err != nil {
+		t.Fatalf("selected query: %v", err)
+	}
+	if columns := stub.queries[0].(dal.StructuredQuery).Columns(); len(columns) != 1 || columns[0].Expression.(dal.FieldRef).Name() != "name" {
+		t.Errorf("intersected columns = %v", columns)
+	}
+	// A wildcard allow-list cannot be projected: records are redacted, recordsets refused.
+	wild := SecureReadwriteSession(stub, MustPolicy("wild", Collection("users", Allow(Query, "list").Fields("public_*", "name"))))
+	stub.queries = nil
+	if _, err := wild.ExecuteQueryToRecordsReader(ctx, query); err != nil || len(stub.queries[0].(dal.StructuredQuery).Columns()) != 0 {
+		t.Errorf("wildcard records query: err=%v columns=%v", err, stub.queries[0].(dal.StructuredQuery).Columns())
+	}
+	if _, err := wild.ExecuteQueryToRecordsetReader(ctx, query); !errors.Is(err, ErrAccessDenied) || !strings.Contains(err.Error(), "cannot be projected") {
+		t.Errorf("wildcard recordset query = %v", err)
+	}
+	// A non-field column selection cannot be projected either.
+	computed := dal.NewQueryBuilder(dal.From(dal.NewRootCollectionRef("users", ""))).SelectColumns(dal.Column{Expression: dal.Constant{Value: 1}, Alias: "one"})
+	if _, err := session.ExecuteQueryToRecordsetReader(ctx, computed); !errors.Is(err, ErrAccessDenied) {
+		t.Errorf("computed column recordset = %v", err)
+	}
+	// Field rules on a joined source are refused.
+	joined := MustPolicy("join", Collection("orders", Allow(Query, "all")), Collection("users", Allow(Query, "list").Fields("id")))
+	joinQuery := dal.NewQueryBuilder(dal.From(dal.NewRootCollectionRef("orders", "o")).Join(dal.NewJoinedSource(dal.NewRootCollectionRef("users", "u"), dal.JoinInner))).SelectKeysOnly(reflect.String)
+	if _, err := SecureReadwriteSession(stub, joined).ExecuteQueryToRecordsReader(ctx, joinQuery); !errors.Is(err, ErrAccessDenied) || !strings.Contains(err.Error(), "joined source") {
+		t.Errorf("joined fields = %v", err)
+	}
+	// Field rules never authorise an opaque query, so a redacting path with a
+	// non-structured query is unreachable through policies; the guard itself is covered by rewriteQuery.
+	// Adapter errors propagate through the redacting path.
+	stub.queryErr = errors.New("boom")
+	if _, err := session.ExecuteQueryToRecordsReader(ctx, query); err == nil || err.Error() != "boom" {
+		t.Errorf("adapter error = %v", err)
+	}
+	stub.queryErr = nil
+
+	// Writes: only allowed fields may be set or touched.
+	writer := SecureReadwriteSession(stub, MustPolicy("edit", Scope("users", AnyID, Allow(Write, "profile").Fields("name", "phones.*"))))
+	if err := writer.Update(ctx, key("u1"), []update.Update{update.ByFieldName("name", "Ann B"), update.ByFieldPath(update.FieldPath{"phones", "home"}, "1")}); err != nil {
+		t.Errorf("allowed update: %v", err)
+	}
+	if err := writer.Update(ctx, key("u1"), []update.Update{update.ByFieldName("ownerID", "u2")}); !errors.Is(err, ErrAccessDenied) || !strings.Contains(err.Error(), `"ownerID"`) {
+		t.Errorf("update outside fields = %v", err)
+	}
+	if err := writer.Insert(ctx, record.NewRecordWithData(key("u3"), map[string]any{"name": "Cy", "email": "c@x"})); !errors.Is(err, ErrAccessDenied) || !strings.Contains(err.Error(), `"email"`) {
+		t.Errorf("insert outside fields = %v", err)
+	}
+	if err := writer.Set(ctx, record.NewRecordWithData(key("u1"), map[string]any{"name": "Ann"})); err != nil {
+		t.Errorf("allowed set: %v", err)
+	}
+	// A conditional alternative with fields checks them too; the terminal's fields apply otherwise.
+	mixed := SecureReadwriteSession(stub, MustPolicy("mixed", Root(Allow(Write, "any").Fields("name")), Scope("users", AnyID,
+		Allow(Write, "own").Where(dal.WhereField("ownerID", dal.Equal, dal.NewParam("currentUser"))).Fields("name", "email", "ownerID"))))
+	if err := mixed.Update(ctx, key("u1"), []update.Update{update.ByFieldName("email", "new@x")}); err != nil {
+		t.Errorf("own alternative allows email: %v", err)
+	}
+	if err := mixed.Update(ctx, key("u2"), []update.Update{update.ByFieldName("email", "new@x")}); !errors.Is(err, ErrAccessDenied) {
+		t.Errorf("terminal fields must refuse email on another's row: %v", err)
+	}
+	if err := mixed.Insert(ctx, record.NewRecordWithData(key("u9"), map[string]any{"ownerID": "u1", "email": "e"})); err != nil {
+		t.Errorf("new own row via alternative check: %v", err)
+	}
+	if err := mixed.Insert(ctx, record.NewRecordWithData(key("u9"), map[string]any{"ownerID": "u2", "email": "e"})); !errors.Is(err, ErrAccessDenied) {
+		t.Errorf("new other's row falls to terminal fields: %v", err)
+	}
+}
+
+func TestFieldDocuments(t *testing.T) {
+	source := `apiVersion: dalgo.io/access/v1
+kind: AccessPolicy
+metadata:
+  name: users
+default: deny
+scopes:
+  - path: /users/*
+    rules:
+      - id: public
+        effect: allow
+        operations: [read]
+        fields: [id, name, address.*]
+`
+	policy, err := UnmarshalAccessPolicyYAML([]byte(source))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	decision := policy.Decide(context.Background(), Request{Operation: Get, Resources: []Resource{RecordResourceForKey(record.NewKeyWithID("users", "u1"))}})
+	mustDecideAllowed(t, decision)
+	if !reflect.DeepEqual(decision.Writes[0].Terminal.Fields, []string{"id", "name", "address.*"}) {
+		t.Errorf("decoded fields = %v", decision.Writes[0].Terminal.Fields)
+	}
+	for name, marshal := range map[string]func(*AccessPolicy) ([]byte, error){"yaml": MarshalAccessPolicyYAML, "json": MarshalAccessPolicyJSON} {
+		encoded, err := marshal(policy)
+		if err != nil || !strings.Contains(string(encoded), "address.*") {
+			t.Errorf("%s: err=%v encoded=%s", name, err, encoded)
+		}
+	}
+	bad := Document{APIVersion: DocumentAPIVersion, Kind: AccessPolicyKind, Metadata: DocumentMetadata{Name: "x"}, Default: "deny",
+		Scopes: []DocumentScope{{Path: "/x/*", Rules: []DocumentRule{{ID: "r", Effect: "allow", Operations: []string{"get"}, Fields: []string{"a..b"}}}}}}
+	if _, err := DecodeAccessPolicy(strings.NewReader(""), staticCodec{d: bad}); err == nil {
+		t.Error("invalid fields pattern must fail")
+	}
+}
+
+func TestFieldsOnMemoryDB(t *testing.T) {
+	ctx := context.Background()
+	raw := dalgo2memory.New(dalgo2memory.FirestoreProfile())
+	type user struct {
+		Name         string `json:"name"`
+		Email        string `json:"email"`
+		PasswordHash string `json:"passwordHash"`
+	}
+	if err := raw.RunReadwriteTransaction(ctx, func(ctx context.Context, tx dal.ReadwriteTransaction) error {
+		for id, u := range map[string]user{"u1": {"Ann", "a@x", "h1"}, "u2": {"Bob", "b@x", "h2"}} {
+			u := u
+			if err := tx.Set(ctx, record.NewRecordWithData(record.NewKeyWithID("users", id), &u)); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	db := MustSecureDB(raw, WithDatabasePolicies(MustPolicy("users",
+		Scope("users", AnyID, Allow(Get, "profile").Fields("name", "email")),
+		Collection("users", Allow(Query, "list").Fields("name")),
+	)))
+	got := &user{}
+	if err := db.Get(ctx, record.NewRecordWithData(record.NewKeyWithID("users", "u1"), got)); err != nil || got.PasswordHash != "" || got.Name != "Ann" || got.Email != "a@x" {
+		t.Errorf("get: err=%v data=%+v", err, *got)
+	}
+	query := dal.NewQueryBuilder(dal.From(dal.NewRootCollectionRef("users", ""))).SelectIntoRecord(func() record.Record {
+		return record.NewRecordWithData(record.NewKeyWithID("users", ""), &user{})
+	})
+	records, err := dal.ExecuteQueryAndReadAllToRecords(ctx, query, db)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("rows = %d", len(records))
+	}
+	for _, rec := range records {
+		switch data := rec.Data().(type) {
+		case *user:
+			if data.PasswordHash != "" || data.Email != "" || data.Name == "" {
+				t.Errorf("row not limited to name: %+v", *data)
+			}
+		case map[string]any:
+			if _, leaked := data["passwordHash"]; leaked || data["name"] == nil {
+				t.Errorf("projected row not limited to name: %v", data)
+			}
+		default:
+			t.Errorf("unexpected row data %T", data)
+		}
+	}
+}
+
+type fakeRecordsReader struct {
+	dal.RecordsReader
+	records []record.Record
+}
+
+func (r *fakeRecordsReader) Next() (record.Record, error) {
+	if len(r.records) == 0 {
+		return nil, dal.ErrNoMoreRecords
+	}
+	rec := r.records[0]
+	r.records = r.records[1:]
+	return rec, nil
+}
+
+func TestFieldEdgeBranches(t *testing.T) {
+	ctx := WithCurrentUser(context.Background(), "u1")
+	set, _ := parseFieldPatterns([]string{"name"})
+	key := record.NewKeyWithID("users", "u1")
+	// The redacting reader surfaces redaction errors and end-of-stream.
+	odd := record.NewRecordWithData(key, map[int]any{1: "x"})
+	odd.SetError(nil)
+	fine := record.NewRecordWithData(key, map[string]any{"name": "Ann", "email": "e"})
+	fine.SetError(nil)
+	reader := redactingReader{RecordsReader: &fakeRecordsReader{records: []record.Record{fine, odd}}, sets: fieldSets{set}}
+	if rec, err := reader.Next(); err != nil || len(rec.Data().(map[string]any)) != 1 {
+		t.Errorf("redacted record: err=%v data=%v", err, rec)
+	}
+	if _, err := reader.Next(); err == nil {
+		t.Error("unredactable record must fail")
+	}
+	if _, err := reader.Next(); !errors.Is(err, dal.ErrNoMoreRecords) {
+		t.Errorf("end of stream = %v", err)
+	}
+	// projectQuery leaves unrestricted queries alone.
+	bare := dal.NewQueryBuilder(dal.From(dal.NewRootCollectionRef("users", ""))).SelectKeysOnly(reflect.String)
+	if q, ok := projectQuery(bare, fieldSets{nil}); !ok || len(q.Columns()) != 0 {
+		t.Errorf("unrestricted projection = %v, %v", q, ok)
+	}
+	// decidingFields reports an unevaluable alternative.
+	bad := writeResidual{policy: "p", resource: RecordResourceForKey(key), residual: &WriteResidual{Alternatives: []WriteAlternative{{Rule: "bad", Where: fakeCond{}}}}}
+	if _, err := decidingFields(Get, map[string]any{}, []writeResidual{bad}); !errors.Is(err, ErrAccessDenied) {
+		t.Errorf("unevaluable alternative = %v", err)
+	}
+	loaded := record.NewRecordWithData(key, map[string]any{"name": "Ann"})
+	loaded.SetError(nil)
+	if err := enforceRead(Get, loaded, nil, []writeResidual{bad}); !errors.Is(err, ErrAccessDenied) || !errors.Is(loaded.Error(), ErrAccessDenied) {
+		t.Errorf("unevaluable alternative on read = %v (record %v)", err, loaded.Error())
+	}
+	// A conditional alternative with fields bounds a query too.
+	stub := &stubReadwriteSession{rows: map[string]map[string]any{}}
+	session := SecureReadwriteSession(stub, MustPolicy("q", Collection("users", Allow(Query, "own").Where(dal.WhereField("ownerID", dal.Equal, dal.NewParam("currentUser"))).Fields("id"))))
+	query := dal.NewQueryBuilder(dal.From(dal.NewRootCollectionRef("users", ""))).SelectKeysOnly(reflect.String)
+	if _, err := session.ExecuteQueryToRecordsReader(ctx, query); err != nil {
+		t.Fatalf("conditional fields query: %v", err)
+	}
+	if columns := stub.queries[0].(dal.StructuredQuery).Columns(); len(columns) != 1 {
+		t.Errorf("conditional alternative fields must project: %v", columns)
+	}
+	// A joined source under a conditional rule is refused by the rewrite.
+	joined := MustPolicy("join", Collection("orders", Allow(Query, "all")), Collection("users", Allow(Query, "own").Where(dal.WhereField("ownerID", dal.Equal, dal.NewParam("currentUser")))))
+	joinQuery := dal.NewQueryBuilder(dal.From(dal.NewRootCollectionRef("orders", "o")).Join(dal.NewJoinedSource(dal.NewRootCollectionRef("users", "u"), dal.JoinInner))).SelectKeysOnly(reflect.String)
+	if _, err := SecureReadwriteSession(stub, joined).ExecuteQueryToRecordsReader(ctx, joinQuery); !errors.Is(err, ErrAccessDenied) || !strings.Contains(err.Error(), "conditional rules on joins") {
+		t.Errorf("joined conditional = %v", err)
+	}
+	// Point reads: data that cannot be evaluated is refused under row rules and under field rules alike;
+	// data that can be evaluated but not redacted is refused too.
+	stubs := &stubReadSession{exists: true}
+	rowRule := SecureReadSession(stubs, MustPolicy("rows", Scope("users", AnyID, Allow(Get, "own").Where(dal.WhereField("ownerID", dal.Equal, dal.NewParam("currentUser"))))))
+	if err := rowRule.Get(ctx, record.NewRecordWithData(key, &struct{ C chan int }{C: make(chan int)})); !errors.Is(err, ErrAccessDenied) || !strings.Contains(err.Error(), "could not be evaluated") {
+		t.Errorf("unserialisable under row rule = %v", err)
+	}
+	fieldRule := SecureReadSession(stubs, MustPolicy("fields", Scope("users", AnyID, Allow(Get, "public").Fields("name"))))
+	if err := fieldRule.Get(ctx, record.NewRecordWithData(key, &struct{ C chan int }{C: make(chan int)})); !errors.Is(err, ErrAccessDenied) || !strings.Contains(err.Error(), "fields could not be evaluated") {
+		t.Errorf("unserialisable under field rule = %v", err)
+	}
+	if err := fieldRule.Get(ctx, record.NewRecordWithData(key, map[int]any{1: "x"})); !errors.Is(err, ErrAccessDenied) || !strings.Contains(err.Error(), "could not be redacted") {
+		t.Errorf("unredactable under field rule = %v", err)
+	}
+	// A batch mixing an unconditional record whose data cannot be evaluated with a conditional one.
+	mixed := SecureReadwriteSession(&stubReadwriteSession{rows: map[string]map[string]any{"u1": {"ownerID": "u1"}, "shared": {"x": 1}}},
+		MustPolicy("mixed", Scope("users", "shared", Allow(Get, "shared")), Scope("users", AnyID, Allow(Get, "own").Where(dal.WhereField("ownerID", dal.Equal, dal.NewParam("currentUser"))))))
+	if err := mixed.GetMulti(ctx, []record.Record{record.NewRecordWithData(record.NewKeyWithID("users", "shared"), &struct{ C chan int }{C: make(chan int)}), record.NewRecordWithData(key, &map[string]any{})}); err != nil {
+		t.Errorf("unconditional record needs no evaluation: %v", err)
+	}
+	// A conditional alternative refuses a field outside its list on update.
+	own := SecureReadwriteSession(&stubReadwriteSession{rows: map[string]map[string]any{"u1": {"ownerID": "u1"}}},
+		MustPolicy("own", Scope("users", AnyID, Allow(Write, "own").Where(dal.WhereField("ownerID", dal.Equal, dal.NewParam("currentUser"))).Fields("name", "ownerID"))))
+	if err := own.Update(ctx, key, []update.Update{update.ByFieldName("passwordHash", "x")}); !errors.Is(err, ErrAccessDenied) || !strings.Contains(err.Error(), `"passwordHash"`) {
+		t.Errorf("alternative field refusal = %v", err)
+	}
+}

--- a/access/policy.go
+++ b/access/policy.go
@@ -65,6 +65,9 @@ type WriteAlternative struct {
 	Check     dal.Condition
 	WhereText string
 	CheckText string
+	// Fields is the rule's allow-list of field patterns; nil means every field.
+	Fields []string
+	fields *fieldSet
 }
 
 // WriteResidual is what the secured wrapper enforces on a write: the
@@ -213,7 +216,7 @@ func (p *AccessPolicy) decideResource(resolver variableResolver, operation Opera
 		}
 		conditional = append(conditional, matching[i])
 	}
-	if len(conditional) == 0 && (terminal.effect != effectAllow || terminal.check == nil) {
+	if len(conditional) == 0 && (terminal.effect != effectAllow || (terminal.check == nil && terminal.fields == nil)) {
 		allowed := terminal.effect == effectAllow
 		return Decision{
 			Allowed:      allowed,
@@ -252,10 +255,14 @@ func (p *AccessPolicy) decideResource(resolver variableResolver, operation Opera
 		Writes:       []*WriteResidual{write},
 	}
 	if len(conditional) == 0 {
-		// A terminal allow with only a post-image check: reads are unconditional.
+		// A terminal allow with only a post-image check or a fields list:
+		// reads are unconditional on rows.
 		decision.Rule = terminal.name
-		decision.Condition = terminal.check.String()
-		decision.Explanation = fmt.Sprintf("matched rule %q (allow; check: %s)", terminal.name, decision.Condition)
+		decision.Explanation = fmt.Sprintf("matched rule %q (allow)", terminal.name)
+		if terminal.check != nil {
+			decision.Condition = terminal.check.String()
+			decision.Explanation = fmt.Sprintf("matched rule %q (allow; check: %s)", terminal.name, decision.Condition)
+		}
 		return decision
 	}
 	names := make([]string, 0, len(conditional))
@@ -285,7 +292,10 @@ func (p *AccessPolicy) decideResource(resolver variableResolver, operation Opera
 }
 
 func (p *AccessPolicy) resolveAlternative(resolver variableResolver, rule compiledRule) (WriteAlternative, error) {
-	alternative := WriteAlternative{Rule: rule.name}
+	alternative := WriteAlternative{Rule: rule.name, fields: rule.fields}
+	if rule.fields != nil {
+		alternative.Fields = append([]string(nil), rule.fields.sources...)
+	}
 	if rule.where != nil {
 		resolved, err := condeval.Substitute(rule.where, resolver.resolve)
 		if err != nil {

--- a/access/rule.go
+++ b/access/rule.go
@@ -55,6 +55,18 @@ type Rule struct {
 	children   []Rule
 	where      dal.Condition
 	check      dal.Condition
+	fields     []string
+}
+
+// Fields attaches an allow-list of field patterns to an allow rule: reads
+// return only matching fields (a query is projected and its records
+// redacted) and writes may only set or touch matching fields. Patterns are
+// dotted paths whose segments are literal names, `*`, `prefix*` or `*suffix`;
+// a trailing `.*` covers a whole subtree; an allowed parent covers its
+// children. A rule without Fields means every field.
+func (r Rule) Fields(patterns ...string) Rule {
+	r.fields = append([]string(nil), patterns...)
+	return r
 }
 
 // Where attaches a row condition to an allow rule: the rule applies only to
@@ -154,6 +166,7 @@ type compiledRule struct {
 	literals   int
 	where      dal.Condition
 	check      dal.Condition
+	fields     *fieldSet
 	params     []string
 }
 
@@ -182,8 +195,8 @@ func compileRule(
 	allowedEffects map[effect]bool,
 	compiled *[]compiledRule,
 ) error {
-	if (rule.where != nil || rule.check != nil) && rule.kind != directiveRule {
-		return fmt.Errorf("access: conditions are only valid on allow rules, not on scopes")
+	if (rule.where != nil || rule.check != nil || rule.fields != nil) && rule.kind != directiveRule {
+		return fmt.Errorf("access: conditions and fields are only valid on allow rules, not on scopes")
 	}
 	switch rule.kind {
 	case directiveRule:
@@ -195,6 +208,20 @@ func compileRule(
 		}
 		operations := rule.operations
 		var params []string
+		var fields *fieldSet
+		if rule.fields != nil {
+			if rule.effect != effectAllow {
+				return fmt.Errorf("access: rule %q: fields apply to allow rules only", rule.name)
+			}
+			if resourceKind != PathResource {
+				return fmt.Errorf("access: rule %q: fields are not valid on %s rules", rule.name, resourceKind)
+			}
+			parsed, err := parseFieldPatterns(rule.fields)
+			if err != nil {
+				return fmt.Errorf("access: rule %q: %w", rule.name, err)
+			}
+			fields = parsed
+		}
 		if rule.where != nil || rule.check != nil {
 			if rule.effect != effectAllow {
 				return fmt.Errorf("access: rule %q: conditional %s rules are not supported; conditions apply to allow rules only", rule.name, rule.effect)
@@ -244,6 +271,9 @@ func compileRule(
 			if rule.check != nil {
 				name += " check " + rule.check.String()
 			}
+			if fields != nil {
+				name += " fields [" + strings.Join(fields.sources, ", ") + "]"
+			}
 		}
 		*compiled = append(*compiled, compiledRule{
 			kind:       resourceKind,
@@ -256,6 +286,7 @@ func compileRule(
 			literals:   literalCount(prefix),
 			where:      rule.where,
 			check:      rule.check,
+			fields:     fields,
 			params:     params,
 		})
 		return nil

--- a/access/session.go
+++ b/access/session.go
@@ -27,57 +27,110 @@ func (s securedReadSession) Exists(ctx context.Context, key *record.Key) (bool, 
 }
 
 func (s securedReadSession) Get(ctx context.Context, record record.Record) error {
-	residuals, _, err := s.guard.authorizeRequest(ctx, Request{Operation: Get, Resources: []Resource{RecordResourceForKey(record.Key())}})
+	residuals, writes, err := s.guard.authorizeRequest(ctx, Request{Operation: Get, Resources: []Resource{RecordResourceForKey(record.Key())}})
 	if err != nil {
 		return err
 	}
 	if err := s.session.Get(ctx, record); err != nil {
 		return err
 	}
-	if len(residuals) == 0 {
+	if len(residuals) == 0 && len(writes) == 0 {
 		return nil
 	}
-	return checkRecord(Get, record, residuals[0])
+	return enforceRead(Get, record, first(residuals), first(writes))
+}
+
+func first[T any](perResource [][]T) []T {
+	if len(perResource) == 0 {
+		return nil
+	}
+	return perResource[0]
 }
 
 func (s securedReadSession) GetMulti(ctx context.Context, records []record.Record) error {
 	resources := resourcesForRecords(records)
-	residuals, _, err := s.guard.authorizeRequest(ctx, Request{Operation: Get, Resources: resources})
+	residuals, writes, err := s.guard.authorizeRequest(ctx, Request{Operation: Get, Resources: resources})
 	if err != nil {
 		return err
 	}
 	if err := s.session.GetMulti(ctx, records); err != nil {
 		return err
 	}
-	return checkRecords(Get, records, residuals)
+	if len(residuals) == 0 && len(writes) == 0 {
+		return nil
+	}
+	for i, rec := range records {
+		var perRecordResiduals []residual
+		if len(residuals) > 0 {
+			perRecordResiduals = residuals[i]
+		}
+		var perRecordWrites []writeResidual
+		if len(writes) > 0 {
+			perRecordWrites = writes[i]
+		}
+		if err := enforceRead(Get, rec, perRecordResiduals, perRecordWrites); err != nil {
+			for _, other := range records {
+				clearRecord(other, err)
+			}
+			return err
+		}
+	}
+	return nil
 }
 
 func (s securedReadSession) ExecuteQueryToRecordsReader(ctx context.Context, query dal.Query) (dal.RecordsReader, error) {
-	query, err := s.authorizeQuery(ctx, query)
+	query, sets, err := s.authorizeQuery(ctx, query)
 	if err != nil {
 		return nil, err
 	}
-	return s.session.ExecuteQueryToRecordsReader(ctx, query)
+	if structured, ok := query.(dal.StructuredQuery); ok && sets.restrictive() {
+		if projected, ok := projectQuery(structured, sets); ok {
+			query = projected
+		}
+	}
+	reader, err := s.session.ExecuteQueryToRecordsReader(ctx, query)
+	if err != nil || !sets.restrictive() {
+		return reader, err
+	}
+	return redactingReader{RecordsReader: reader, sets: sets}, nil
 }
 
 func (s securedReadSession) ExecuteQueryToRecordsetReader(ctx context.Context, query dal.Query, options ...recordset.Option) (dal.RecordsetReader, error) {
-	query, err := s.authorizeQuery(ctx, query)
+	query, sets, err := s.authorizeQuery(ctx, query)
 	if err != nil {
 		return nil, err
+	}
+	if sets.restrictive() {
+		structured, _ := query.(dal.StructuredQuery)
+		projected, ok := projectQuery(structured, sets)
+		if !ok {
+			return nil, &DeniedError{Decision: Decision{Operation: Query, Resource: resourcesForQuery(query)[0], Policy: "fields", Effect: effectDeny.String(), Explanation: fmt.Sprintf("the allowed fields (%s) cannot be projected onto a recordset; select explicit columns or read records", sets.sources())}}
+		}
+		query = projected
 	}
 	return s.session.ExecuteQueryToRecordsetReader(ctx, query, options...)
 }
 
 // authorizeQuery authorizes every source of a query and returns the query to
-// execute: the caller's own when no residual applies, otherwise a copy whose
-// Where carries the residual row condition.
-func (s securedReadSession) authorizeQuery(ctx context.Context, query dal.Query) (dal.Query, error) {
+// execute — the caller's own when no residual applies, otherwise a copy whose
+// Where carries the residual row condition — and the field allow-lists that
+// bound its rows.
+func (s securedReadSession) authorizeQuery(ctx context.Context, query dal.Query) (dal.Query, fieldSets, error) {
 	resources := resourcesForQuery(query)
-	residuals, _, err := s.guard.authorizeRequest(ctx, Request{Operation: Query, Resources: resources, Query: query})
+	residuals, writes, err := s.guard.authorizeRequest(ctx, Request{Operation: Query, Resources: resources, Query: query})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return rewriteQuery(query, residuals)
+	rewritten, err := rewriteQuery(query, residuals)
+	if err != nil {
+		return nil, nil, err
+	}
+	for i := 1; i < len(writes); i++ {
+		for _, w := range writes[i] {
+			return nil, nil, w.deny(Query, "", "", "field rules on a joined source are not supported in this version")
+		}
+	}
+	return rewritten, queryFields(first(writes)), nil
 }
 
 type securedWriteSession struct {

--- a/access/write.go
+++ b/access/write.go
@@ -43,9 +43,10 @@ type writeTarget struct {
 // writeImages holds what a write residual is evaluated against: whether the
 // row exists, its pre-image, and its post-image (nil for a Delete).
 type writeImages struct {
-	exists bool
-	pre    map[string]any
-	post   map[string]any
+	exists  bool
+	pre     map[string]any
+	post    map[string]any
+	updates []update.Update
 }
 
 // enforceWrites evaluates every policy's write residual for every target
@@ -91,6 +92,7 @@ func (s securedWriteSession) writeImages(ctx context.Context, operation Operatio
 			images.pre = *shadow.Data().(*map[string]any)
 		}
 	}
+	images.updates = target.updates
 	switch operation {
 	case Insert, Set:
 		post, err := condeval.ToMap(target.data)
@@ -125,7 +127,7 @@ func evaluateWrite(operation Operations, images writeImages, w writeResidual) er
 				return w.deny(operation, alternative.Rule, checkText, fmt.Sprintf("post-image check could not be evaluated for rule %q: %v", alternative.Rule, err))
 			}
 			if ok {
-				return nil
+				return checkFields(operation, images, w, alternative)
 			}
 		}
 		return terminalAdmits(operation, images, w, "no rule admits the new row")
@@ -148,6 +150,9 @@ func evaluateWrite(operation Operations, images writeImages, w writeResidual) er
 		}
 		if operation == Delete {
 			return nil
+		}
+		if err := checkFields(operation, images, w, alternative); err != nil {
+			return err
 		}
 		check, checkText := alternativeCheck(alternative)
 		ok, err = condeval.Match(images.post, check)
@@ -179,7 +184,13 @@ func terminalAdmits(operation Operations, images writeImages, w writeResidual, f
 	if terminal == nil {
 		return w.deny(operation, alternativeNames(w.residual), alternativeTexts(w.residual), failure)
 	}
-	if operation == Delete || terminal.Check == nil {
+	if operation == Delete {
+		return nil
+	}
+	if err := checkFields(operation, images, w, *terminal); err != nil {
+		return err
+	}
+	if terminal.Check == nil {
 		return nil
 	}
 	ok, err := condeval.Match(images.post, terminal.Check)
@@ -190,6 +201,25 @@ func terminalAdmits(operation Operations, images writeImages, w writeResidual, f
 		return w.deny(operation, terminal.Rule, terminal.CheckText, fmt.Sprintf("post-image check not satisfied for rule %q (check: %s)", terminal.Rule, terminal.CheckText))
 	}
 	return nil
+}
+
+// checkFields refuses a write that sets (Insert, Set) or touches (Update) a
+// field outside the deciding alternative's allow-list.
+func checkFields(operation Operations, images writeImages, w writeResidual, alternative WriteAlternative) error {
+	if alternative.fields == nil {
+		return nil
+	}
+	sets := fieldSets{alternative.fields}
+	var refused []string
+	if operation == Update {
+		refused = sets.disallowedUpdates(images.updates)
+	} else {
+		refused = sets.disallowedPaths(images.post)
+	}
+	if len(refused) == 0 {
+		return nil
+	}
+	return w.deny(operation, alternative.Rule, sets.sources(), fmt.Sprintf("field %q is outside the fields of rule %q (%s)", refused[0], alternative.Rule, sets.sources()))
 }
 
 func alternativeNames(r *WriteResidual) string {

--- a/access/writes_test.go
+++ b/access/writes_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/dal-go/dalgo/adapters/dalgo2memory"
+	"github.com/dal-go/dalgo/condeval"
 	"github.com/dal-go/dalgo/dal"
 	"github.com/dal-go/record"
 	"github.com/dal-go/record/update"
@@ -31,9 +32,18 @@ func (s *stubReadwriteSession) Get(_ context.Context, rec record.Record) error {
 		return nil
 	}
 	if target, ok := rec.Data().(*map[string]any); ok {
-		*target = row
+		*target = condeval.CloneMap(row)
 	}
 	rec.SetError(nil)
+	return nil
+}
+
+func (s *stubReadwriteSession) GetMulti(ctx context.Context, records []record.Record) error {
+	for _, rec := range records {
+		if err := s.Get(ctx, rec); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/dal/query_struct.go
+++ b/dal/query_struct.go
@@ -214,26 +214,58 @@ func WithWhere(q StructuredQuery, condition Condition) StructuredQuery {
 		clone.where = condition
 		return clone
 	default:
-		return whereOverride{StructuredQuery: q, where: condition}
+		return queryOverride{StructuredQuery: q, where: condition, hasWhere: true}
 	}
 }
 
-// whereOverride wraps a foreign StructuredQuery implementation with a
-// replaced Where. It hands itself, not the wrapped query, to executors.
-type whereOverride struct {
-	StructuredQuery
-	where Condition
+// WithColumns returns a query identical to q except that it selects columns.
+// Like WithWhere it copies a builder query and wraps any other implementation.
+func WithColumns(q StructuredQuery, columns []Column) StructuredQuery {
+	switch native := q.(type) {
+	case structuredQuery:
+		native.columns = columns
+		return native
+	case *structuredQuery:
+		clone := *native
+		clone.columns = columns
+		return clone
+	default:
+		return queryOverride{StructuredQuery: q, columns: columns, hasColumns: true}
+	}
 }
 
-func (w whereOverride) Where() Condition { return w.where }
+// queryOverride wraps a foreign StructuredQuery implementation with a
+// replaced Where and/or Columns. It hands itself, not the wrapped query, to
+// executors.
+type queryOverride struct {
+	StructuredQuery
+	where      Condition
+	hasWhere   bool
+	columns    []Column
+	hasColumns bool
+}
 
-func (w whereOverride) String() string { return QueryString(w) }
+func (w queryOverride) Where() Condition {
+	if w.hasWhere {
+		return w.where
+	}
+	return w.StructuredQuery.Where()
+}
 
-func (w whereOverride) GetRecordsReader(ctx context.Context, qe QueryExecutor) (RecordsReader, error) {
+func (w queryOverride) Columns() []Column {
+	if w.hasColumns {
+		return w.columns
+	}
+	return w.StructuredQuery.Columns()
+}
+
+func (w queryOverride) String() string { return QueryString(w) }
+
+func (w queryOverride) GetRecordsReader(ctx context.Context, qe QueryExecutor) (RecordsReader, error) {
 	return qe.ExecuteQueryToRecordsReader(ctx, w)
 }
 
-func (w whereOverride) GetRecordsetReader(ctx context.Context, qe QueryExecutor) (RecordsetReader, error) {
+func (w queryOverride) GetRecordsetReader(ctx context.Context, qe QueryExecutor) (RecordsetReader, error) {
 	return qe.ExecuteQueryToRecordsetReader(ctx, w)
 }
 

--- a/dal/with_where_test.go
+++ b/dal/with_where_test.go
@@ -58,7 +58,7 @@ func TestWithWhereForeignQuery(t *testing.T) {
 	inner := NewQueryBuilder(From(NewRootCollectionRef("orders", ""))).Limit(3).SelectKeysOnly(reflect.String)
 	foreign := &foreignQuery{StructuredQuery: inner}
 	wrapped := WithWhere(foreign, WhereField("tenantID", Equal, "t1"))
-	if _, ok := wrapped.(whereOverride); !ok {
+	if _, ok := wrapped.(queryOverride); !ok {
 		t.Fatalf("expected a wrapper, got %T", wrapped)
 	}
 	if wrapped.Where().String() != "tenantID = 't1'" || wrapped.Limit() != 3 {
@@ -75,7 +75,7 @@ func TestWithWhereForeignQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i, q := range executor.seen {
-		if _, ok := q.(whereOverride); !ok {
+		if _, ok := q.(queryOverride); !ok {
 			t.Errorf("executor call %d received %T, want the wrapper", i, q)
 		}
 	}
@@ -90,5 +90,30 @@ func TestQuoteEscaping(t *testing.T) {
 	}
 	if got := (Array{Value: []any{"x'y", 2}}).String(); got != "('x''y',2)" {
 		t.Errorf("Array.String() []any = %q", got)
+	}
+}
+
+func TestWithColumns(t *testing.T) {
+	base := NewQueryBuilder(From(NewRootCollectionRef("users", ""))).WhereField("status", Equal, "active").SelectKeysOnly(reflect.String)
+	projected := WithColumns(base, []Column{{Expression: Field("id")}, {Expression: Field("name")}})
+	if len(projected.Columns()) != 2 || projected.Where().String() != "status = 'active'" || len(base.Columns()) != 0 {
+		t.Errorf("native projection: %+v", projected)
+	}
+	if !strings.Contains(projected.String(), "id") || !strings.Contains(projected.String(), "name") {
+		t.Errorf("String() = %q", projected.String())
+	}
+	pointer := base.(structuredQuery)
+	if got := WithColumns(&pointer, []Column{{Expression: Field("x")}}); len(got.Columns()) != 1 || len(pointer.columns) != 0 {
+		t.Errorf("pointer clone: %v / %v", got.Columns(), pointer.columns)
+	}
+	foreign := &foreignQuery{StructuredQuery: base}
+	wrapped := WithColumns(foreign, []Column{{Expression: Field("id")}})
+	if len(wrapped.Columns()) != 1 || wrapped.Where().String() != "status = 'active'" {
+		t.Errorf("foreign projection: columns=%v where=%q", wrapped.Columns(), wrapped.Where())
+	}
+	// A where override on a foreign query keeps the foreign columns.
+	narrowed := WithWhere(foreign, WhereField("a", Equal, 1))
+	if len(narrowed.Columns()) != 0 {
+		t.Errorf("where override must not touch columns: %v", narrowed.Columns())
 	}
 }

--- a/spec/features/access-policies/field-patterns/README.md
+++ b/spec/features/access-policies/field-patterns/README.md
@@ -1,12 +1,12 @@
 ---
 format: https://specscore.md/feature-specification
-status: Draft
+status: Implementing
 ---
 
 # Feature: Field patterns — wildcard field allow-lists on rules
 
 > [SpecScore.**Studio**](https://specscore.studio): | [Explore](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/field-patterns?op=explore) | [Edit](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/field-patterns?op=edit) | [Ask question](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/field-patterns?op=ask) | [Request change](https://specscore.studio/app/github.com/dal-go/dalgo/spec/features/access-policies/field-patterns?op=request-change) |
-**Status:** Draft
+**Status:** Implementing
 **Date:** 2026-09-02
 **Owner:** alex
 **Source Ideas:** row-level-access-conditions
@@ -133,11 +133,23 @@ allowed set MUST be the intersection of every applicable rule's allowed fields.
 **When** the caller queries `users` selecting all columns
 **Then** the adapter observes a query selecting `id` and `name` only.
 
+### AC: get-redacted (verifies REQ:read-projection)
+
+**Given** the same rule
+**When** the caller gets `/users/u1`
+**Then** the returned data contains `id` and `name` and no other field.
+
 ### AC: update-outside-fields (verifies REQ:write-field-check)
 
 **Given** a rule allowing `Update` on `/contacts/*` with `fields: [name, phones.*]`
 **When** the caller updates `ownerID`
 **Then** the update is denied naming `ownerID`.
+
+### AC: condition-may-read-hidden-field (verifies REQ:write-field-check)
+
+**Given** a rule with `fields: [name]` and `where: ownerID == $currentUser`
+**When** the caller gets their own record
+**Then** the read is allowed and the returned data contains `name` only.
 
 ### AC: intersection-across-policies (verifies REQ:precedence-and-composition)
 
@@ -147,13 +159,16 @@ allowed set MUST be the intersection of every applicable rule's allowed fields.
 
 ## Architecture
 
-- `access.Rule` gains `Fields []FieldPattern`; compiled rules hold a matcher.
+- `access.Rule` gains the `Fields(patterns ...string)` builder (documents:
+  `fields:`); compiled rules hold a parsed matcher. `fields` is accepted on
+  allow rules only and applies to every operation the rule names.
 - The secured query executor rewrites `Columns` using the existing
   [column projection](../../query-column-projection/README.md) support; when an
   adapter reports it cannot project, the wrapper redacts in the reader.
-- Point-read redaction operates on map data directly and on struct data through
-  the same field access the query model uses, producing a map when a struct
-  cannot be partially populated.
+- Point-read redaction removes keys from map data in place; a struct target is
+  zeroed and re-populated with the allowed fields only, so hidden fields are at
+  their zero value (a struct cannot express absence). Callers that need to
+  tell "absent" from "zero" read into a map.
 - Write checks inspect record data (maps or structs via field access) and the
   `update` operations' field paths.
 - Codecs extend the versioned document model with `fields`.
@@ -184,5 +199,12 @@ No adapter is modified.
 
 ## Open Questions
 
-- Should redaction on struct data return a map, or a zeroed struct with a "redacted fields" side channel? Recommendation: map, so absence is unambiguous.
-- Should a rule be able to allow `fields` for reads and a different list for writes in one rule, or must that be two rules? Recommendation: two rules; simpler precedence.
+None at this time.
+
+Resolved during implementation:
+
+- Redaction on struct data keeps the caller's type: the struct is zeroed and
+  re-populated with the allowed fields (see Architecture). A map is not
+  substituted because the caller chose the target type.
+- One rule carries one `fields` list for every operation it names; different
+  read and write lists are two rules, so precedence stays per rule.

--- a/spec/plans/field-patterns.md
+++ b/spec/plans/field-patterns.md
@@ -1,0 +1,83 @@
+---
+format: https://specscore.md/plan-specification
+status: Implemented
+---
+# Plan: Implement field patterns
+
+**Status:** Implemented
+**Source Feature:** access-policies/field-patterns
+**Date:** 2026-09-03
+**Owner:** alex
+**Supersedes:** —
+
+## Summary
+
+Implement `access-policies/field-patterns`: `fields` allow-lists on allow
+rules, validated at construction; column projection (or reader redaction) on
+queries; record redaction on point reads; touched-field checks on writes;
+intersection of the lists every applicable policy imposes; portable documents
+carrying `fields`.
+
+## Approach
+
+A rule's list compiles to a matcher (`fieldSet`); the decision surfaces it on
+the deciding alternative or terminal of each policy's `WriteResidual`, which
+the read and write paths already receive. Reads take the intersection of the
+lists of the alternatives that decide the loaded record (per policy); queries
+take the intersection of every list a row could come through, projecting the
+query's columns when the lists enumerate top-level names and wrapping the
+reader in a redactor otherwise. Writes refuse before delegation when any
+touched field falls outside the intersection. No adapter changes.
+
+## Tasks
+
+### Task 1: Pattern vocabulary and rule builder
+
+**Id:** task-1
+**Verifies:** access-policies/field-patterns#ac:pattern-forms
+**Depends-On:** —
+**Status:** complete
+
+`parseFieldPatterns` (literal, `*` segment, `prefix*`/`*suffix`, trailing
+`.*` subtree), `Rule.Fields(...)` on allow rules only, document codec `fields`,
+rule names suffixed with the list in explanations.
+
+### Task 2: Read projection and redaction
+
+**Id:** task-2
+**Verifies:** access-policies/field-patterns#ac:query-projected, access-policies/field-patterns#ac:get-redacted, access-policies/field-patterns#ac:condition-may-read-hidden-field
+**Depends-On:** 1
+**Status:** complete
+
+`projectQuery` narrows `Columns` through `dal.WithColumns`; `redactingReader`
+prunes rows an adapter returns unprojected; `enforceRead` evaluates row
+conditions on the full record first, then redacts to the deciding
+alternative's list; a recordset query that cannot be projected is denied.
+
+### Task 3: Write field checks
+
+**Id:** task-3
+**Verifies:** access-policies/field-patterns#ac:update-outside-fields
+**Depends-On:** 1
+**Status:** complete
+
+Insert and Set data paths, Update paths (`FieldName`/`FieldPath`) checked
+against the deciding alternative's or terminal's list; a violation denies the
+whole batch naming the field.
+
+### Task 4: Intersection across policies and joins
+
+**Id:** task-4
+**Verifies:** access-policies/field-patterns#ac:intersection-across-policies
+**Depends-On:** 2, 3
+**Status:** complete
+
+`fieldSets` intersects the lists of every applicable policy for reads, queries
+and writes; field rules on a joined source are refused in this version.
+
+## Open Questions
+
+None at this time.
+
+---
+*This document follows the https://specscore.md/plan-specification*


### PR DESCRIPTION
## Summary

Implements `access-policies/field-patterns` (the last slice of the declarative policies series after row-level conditions and principal bindings).

- **Rules** accept `Fields(...)` / document `fields:` — dotted patterns with `*` segments, `prefix*` / `*suffix` globs and `.*` subtrees; allow rules only, validated at construction.
- **Queries** are projected to the enumerable intersection of every list a row could come through (`dal.WithColumns`); when lists cannot be enumerated the records reader is wrapped in a redactor; recordset queries that cannot be projected are denied.
- **Point reads** evaluate row conditions on the full record first, then redact to the deciding alternative's list (maps pruned in place; struct targets zeroed and re-populated with allowed fields only).
- **Writes**: Insert/Set data paths and Update field paths must fall inside the deciding list; a violation denies the whole batch naming the field.
- **Intersection** across database and context policies; field rules on joined sources are refused in this version.

Spec: feature Draft → Implementing (two Behavior ACs added to its Acceptance Criteria section, open questions resolved), plan `spec/plans/field-patterns.md` (Implemented).

## Verification

- `go test -cover ./...` — `access` 100.0%, all packages green (`dalgotest` 99.2% is pre-existing on main).
- `golangci-lint run ./...` — 0 issues.
- `specscore spec lint` — 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEVhqasFJJ3iAcARe7Wts6
